### PR TITLE
feat(notifications): Phase 2a backend triggers (#128)

### DIFF
--- a/apps/portal-api/src/admin/admin.module.ts
+++ b/apps/portal-api/src/admin/admin.module.ts
@@ -11,6 +11,7 @@ import { HousekeepingCronService } from './housekeeping-cron.service.js';
 import { KeycloakAdminService } from './keycloak-admin.service.js';
 import { V3TablesModule } from '../features-v3/v3-tables.module.js';
 import { ItemsModule } from '../items/items.module.js';
+import { NotificationsModule } from '../notifications/notifications.module.js';
 
 /**
  * Wires the admin surfaces: Keycloak integration (users +
@@ -25,7 +26,7 @@ import { ItemsModule } from '../items/items.module.js';
  * management yet.
  */
 @Module({
-  imports: [V3TablesModule, ItemsModule],
+  imports: [V3TablesModule, ItemsModule, NotificationsModule],
   controllers: [
     AdminUsersController,
     AdminBrandingController,

--- a/apps/portal-api/src/admin/housekeeping-schedule.service.ts
+++ b/apps/portal-api/src/admin/housekeeping-schedule.service.ts
@@ -9,6 +9,7 @@ import {
   type V3LayerShape,
 } from '../features-v3/v3-tables.service.js';
 import { HousekeepingService } from './housekeeping.service.js';
+import { NotificationsService } from '../notifications/notifications.service.js';
 
 export type HousekeepingScheduleMode = 'off' | 'daily' | 'weekly';
 
@@ -76,6 +77,7 @@ export class HousekeepingScheduleService {
     private readonly keycloak: KeycloakAdminService,
     private readonly v3Tables: V3TablesService,
     private readonly housekeeping: HousekeepingService,
+    private readonly notifications: NotificationsService,
   ) {}
 
   // ---------------------------------------------------------------
@@ -384,13 +386,25 @@ export class HousekeepingScheduleService {
         orgRole: { not: 'admin' },
         autoDisableAt: { not: null, lte: new Date() },
       },
-      select: { id: true, username: true },
+      select: { id: true, username: true, autoDisableAt: true },
     });
     let count = 0;
     for (const u of candidates) {
       try {
         await this.keycloak.updateUser(u.id, { enabled: false });
         count += 1;
+        // Fire user_disabled notification (#128). The cron's
+        // sweep-once-per-tick contract means we only get here when
+        // the row freshly crossed the threshold or the previous
+        // tick failed; the notify() path is idempotent on
+        // (userId, type, autoDisableAt) so a flap doesn't double-
+        // email. Fire-and-forget: a notify failure shouldn't
+        // unflip the Keycloak disable.
+        if (u.autoDisableAt) {
+          void this.notifications.notify(u.id, 'user_disabled', {
+            autoDisableAt: u.autoDisableAt.toISOString(),
+          });
+        }
       } catch (err) {
         this.log.warn(
           `auto-disable (expired): could not disable ${u.username} (${u.id}): ${
@@ -431,10 +445,20 @@ export class HousekeepingScheduleService {
       select: { id: true, username: true },
     });
     let count = 0;
+    const now = new Date();
     for (const u of candidates) {
       try {
         await this.keycloak.updateUser(u.id, { enabled: false });
         count += 1;
+        // Quiet-user disable doesn't have a stored autoDisableAt
+        // (the heuristic is the disable trigger). Use `now` as
+        // the synthetic timestamp so the user sees a real "your
+        // account was disabled on <today>" message; the
+        // notification's idempotency key falls back to user_id +
+        // type if the autoDisableAt timestamp matches.
+        void this.notifications.notify(u.id, 'user_disabled', {
+          autoDisableAt: now.toISOString(),
+        });
       } catch (err) {
         this.log.warn(
           `auto-disable: could not disable ${u.username} (${u.id}): ${

--- a/apps/portal-api/src/features-v3/v3-features.controller.ts
+++ b/apps/portal-api/src/features-v3/v3-features.controller.ts
@@ -30,6 +30,7 @@ import { SharingService } from '../items/sharing.service.js';
 import { EditorPolicyService } from '../items/editor-policy.service.js';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { V3FeaturesService } from './v3-features.service.js';
+import { NotificationsService } from '../notifications/notifications.service.js';
 
 class AppendFeatureDto {
   @IsOptional() @IsString() globalId?: string;
@@ -70,6 +71,7 @@ export class V3FeaturesController {
     private readonly v3: V3FeaturesService,
     private readonly prisma: PrismaService,
     private readonly editorPolicy: EditorPolicyService,
+    private readonly notifications: NotificationsService,
   ) {}
 
   @Get('features')
@@ -180,7 +182,94 @@ export class V3FeaturesController {
         op: 'create',
       });
     }
-    return this.v3.insertFeatures(itemId, layerId, body.features, user);
+    const result = await this.v3.insertFeatures(
+      itemId,
+      layerId,
+      body.features,
+      user,
+    );
+    // Fire editor_feature_created when this insert came through an
+    // editor (#128). Notifies the editor item's owner so authors who
+    // build a data-collection editor get told when submissions land,
+    // matching the Survey123 "send me an email per response" gap.
+    // Per-target configurable recipient lists land in a follow-up;
+    // for v1 the editor owner is the only recipient. Fire-and-forget
+    // so a notify error never rolls back the user's POST.
+    if (editorId && result.inserted > 0) {
+      void this.notifyEditorFeatureCreated({
+        editorId,
+        dataLayerId: itemId,
+        layerKey: layerId,
+        features: body.features,
+        creator: user,
+      });
+    }
+    return result;
+  }
+
+  /**
+   * Helper for the editor_feature_created notification fan-out.
+   * Resolves the editor item, the data_layer title, and a best-
+   * effort summary string from the first non-empty user-field value
+   * of the (first) submitted feature. Notifies the editor's owner.
+   */
+  private async notifyEditorFeatureCreated(args: {
+    editorId: string;
+    dataLayerId: string;
+    layerKey: string;
+    features: AppendFeatureDto[];
+    creator: AuthUser;
+  }): Promise<void> {
+    try {
+      const editor = await this.prisma.item.findUnique({
+        where: { id: args.editorId },
+        select: { id: true, title: true, ownerId: true, type: true },
+      });
+      if (!editor || editor.type !== 'editor') return;
+      const dataLayer = await this.prisma.item.findUnique({
+        where: { id: args.dataLayerId },
+        select: { title: true },
+      });
+      const dataLayerTitle = dataLayer?.title ?? args.layerKey;
+      const creatorRow = await this.prisma.user.findUnique({
+        where: { id: args.creator.id },
+        select: { fullName: true, username: true },
+      });
+      const createdByName =
+        creatorRow?.fullName || creatorRow?.username || 'Someone';
+      // For v1 we notify per inserted feature; the typical editor
+      // submission is one feature at a time. Bulk inserts (e.g. a
+      // future import-via-editor flow) would multiply emails which
+      // is fine for now -- the recipient list is just the owner.
+      for (const f of args.features) {
+        const summary = pickFeatureSummary(f.properties);
+        const featureId = typeof f.globalId === 'string' ? f.globalId : '';
+        await this.notifications.notify(
+          editor.ownerId,
+          'editor_feature_created',
+          {
+            editorId: editor.id,
+            editorTitle: editor.title,
+            dataLayerId: args.dataLayerId,
+            dataLayerTitle,
+            layerKey: args.layerKey,
+            featureId,
+            createdByName,
+            summary,
+          },
+        );
+      }
+    } catch (err) {
+      // Notify errors are non-fatal -- the feature already landed.
+      // Pinned to debug because a misconfigured editor would
+      // otherwise spam the api logs on every collection.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `editor_feature_created notify failed: ${
+          err instanceof Error ? err.message : err
+        }`,
+      );
+    }
   }
 
   @Patch('features/:fid')
@@ -318,4 +407,24 @@ export class V3FeaturesController {
     );
     return { geoLimit, rowScope };
   }
+}
+
+/**
+ * Best-effort summary string for an editor-feature-created
+ * notification. Picks the first non-empty user-field value so the
+ * email subject reads "New submission: <something useful>" rather
+ * than a uuid. Underscore-prefixed keys (system metadata) are
+ * skipped. Falls back to a short literal when nothing's available.
+ */
+function pickFeatureSummary(
+  properties: Record<string, unknown> | undefined,
+): string {
+  if (!properties) return '(no attributes)';
+  for (const [k, v] of Object.entries(properties)) {
+    if (k.startsWith('_')) continue;
+    if (v === null || v === undefined || v === '') continue;
+    const s = String(v);
+    return s.length > 80 ? `${s.slice(0, 77)}...` : s;
+  }
+  return '(no attributes)';
 }

--- a/apps/portal-api/src/features-v3/v3-features.module.ts
+++ b/apps/portal-api/src/features-v3/v3-features.module.ts
@@ -6,6 +6,7 @@ import { V3AttachmentsService } from './v3-attachments.service.js';
 import { V3AttachmentsController } from './v3-attachments.controller.js';
 import { ItemsModule } from '../items/items.module.js';
 import { StorageModule } from '../storage/storage.module.js';
+import { NotificationsModule } from '../notifications/notifications.module.js';
 
 /**
  * v3 feature CRUD + attachments. Depends on ItemsModule (auth / gate
@@ -15,7 +16,7 @@ import { StorageModule } from '../storage/storage.module.js';
  * metadata against whatever's already there.
  */
 @Module({
-  imports: [ItemsModule, StorageModule],
+  imports: [ItemsModule, StorageModule, NotificationsModule],
   providers: [V3FeaturesService, V3AttachmentsService],
   controllers: [V3FeaturesController, V3AttachmentsController],
   exports: [V3FeaturesService, V3AttachmentsService],

--- a/apps/portal-api/src/notifications/notifications-cron.service.ts
+++ b/apps/portal-api/src/notifications/notifications-cron.service.ts
@@ -1,0 +1,270 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { Prisma } from '@prisma/client';
+
+import { PrismaService } from '../prisma/prisma.service.js';
+import { NotificationsService } from './notifications.service.js';
+
+/**
+ * Periodic notification triggers that don't have a natural API
+ * call site. share_expiring + share_expired + user_auto_disable_warning
+ * all need a cron sweep because their condition is "time has elapsed
+ * past a stored timestamp"; nothing the user does directly fires
+ * them. user_disabled fires from the housekeeping auto-disable cron
+ * via NotificationsService.notify() at the call site (this service
+ * doesn't drive that one).
+ *
+ * Scheduling:
+ *
+ *   The sweep runs every 15 minutes. That's frequent enough that an
+ *   expiry-warning email lands within a quarter hour of the warning
+ *   window opening, infrequent enough that a busy org doesn't burn
+ *   cycles re-checking. Heavy lifting (the JSONB idempotency lookups)
+ *   only runs on the small candidate sets the time-window query
+ *   produces, not the full share / user table.
+ *
+ * Idempotency:
+ *
+ *   We use the Notification table itself as the "have we already
+ *   notified about this" check rather than adding new columns to
+ *   item_share / user. For each candidate we query for an existing
+ *   Notification with the matching type, recipient, and identity
+ *   tuple captured in the payload (e.g. itemId + principalId +
+ *   expiresAt). A re-extension of the share moves expiresAt to a
+ *   new value, so the next sweep finds no prior notification with
+ *   the new timestamp and re-warns the recipient. Same shape works
+ *   for user_auto_disable_warning vs autoDisableAt.
+ *
+ *   Tradeoff: JSONB lookups aren't quite as fast as an indexed
+ *   boolean column. At our target scale (thousands of shares per
+ *   org, sweep runs in single-digit ms) the simplicity wins.
+ *
+ * Disable-the-feature switch:
+ *
+ *   NOTIFICATIONS_ENABLED governs the whole platform: when false,
+ *   notify() is a no-op so this cron is effectively a no-op too
+ *   (it still runs; the work is paid only when notify() does).
+ */
+@Injectable()
+export class NotificationsCron {
+  private readonly log = new Logger(NotificationsCron.name);
+  private readonly enabled: boolean;
+  private readonly expiryWarningDays: number;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly notifications: NotificationsService,
+    cfg: ConfigService,
+  ) {
+    this.enabled =
+      (cfg.get<string>('NOTIFICATIONS_ENABLED') ?? '').toLowerCase() === 'true';
+    // The warning-window-in-days for both share_expiring and
+    // user_auto_disable_warning. Same setting because the user's
+    // mental model is the same: "alert me a week before the thing
+    // happens." Configurable for orgs that want a longer lead time
+    // (e.g. 30 days for compliance contexts).
+    this.expiryWarningDays = Number(
+      cfg.get<string>('NOTIFICATIONS_EXPIRY_WARNING_DAYS') ?? '7',
+    );
+  }
+
+  @Cron(CronExpression.EVERY_30_MINUTES, {
+    name: 'notifications-trigger-sweep',
+  })
+  async tick() {
+    if (!this.enabled) return;
+    await this.sweepExpiringShares();
+    await this.sweepExpiredShares();
+    await this.sweepDisableWarnings();
+  }
+
+  /** Notify recipients of shares whose expiresAt is within the
+   *  warning window AND haven't already received an expiring
+   *  notification for this exact expiresAt value. */
+  private async sweepExpiringShares() {
+    const now = new Date();
+    const horizon = new Date(
+      Date.now() + this.expiryWarningDays * 24 * 60 * 60 * 1000,
+    );
+    // gt now (still active) AND lte horizon (within warning window).
+    const candidates = await this.prisma.itemShare.findMany({
+      where: {
+        expiresAt: { gt: now, lte: horizon },
+        item: { deletedAt: null },
+      },
+      include: {
+        item: { select: { id: true, title: true, type: true } },
+      },
+    });
+    for (const share of candidates) {
+      if (!share.expiresAt) continue;
+      const recipientIds = await this.resolveShareRecipients(
+        share.principalType,
+        share.principalId,
+      );
+      for (const userId of recipientIds) {
+        const expiresIso = share.expiresAt.toISOString();
+        if (
+          await this.alreadyNotified('share_expiring', userId, {
+            itemId: share.itemId,
+            principalId: share.principalId,
+            expiresAt: expiresIso,
+          })
+        ) {
+          continue;
+        }
+        await this.notifications.notify(userId, 'share_expiring', {
+          itemId: share.itemId,
+          itemTitle: share.item.title,
+          itemType: share.item.type,
+          expiresAt: expiresIso,
+          principalType: share.principalType,
+          principalId: share.principalId,
+        });
+      }
+    }
+  }
+
+  /** Notify recipients of shares that have just expired. The "just"
+   *  is enforced by the idempotency check: we only enqueue when the
+   *  Notification table has no existing share_expired row for this
+   *  (recipient, share, expiresAt) tuple. Shares that have been
+   *  expired for ages stop firing repeat emails because the row
+   *  from the first sweep stays in the table. */
+  private async sweepExpiredShares() {
+    const now = new Date();
+    // Expired anywhere within the last warning-window. Going back
+    // further is wasted work since the idempotency table holds
+    // older expiries already; going forward less risks missing the
+    // first sweep after a long downtime.
+    const lookback = new Date(
+      Date.now() - this.expiryWarningDays * 24 * 60 * 60 * 1000,
+    );
+    const candidates = await this.prisma.itemShare.findMany({
+      where: {
+        expiresAt: { gt: lookback, lt: now },
+        item: { deletedAt: null },
+      },
+      include: {
+        item: { select: { id: true, title: true, type: true } },
+      },
+    });
+    for (const share of candidates) {
+      if (!share.expiresAt) continue;
+      const recipientIds = await this.resolveShareRecipients(
+        share.principalType,
+        share.principalId,
+      );
+      for (const userId of recipientIds) {
+        const expiresIso = share.expiresAt.toISOString();
+        if (
+          await this.alreadyNotified('share_expired', userId, {
+            itemId: share.itemId,
+            principalId: share.principalId,
+            expiresAt: expiresIso,
+          })
+        ) {
+          continue;
+        }
+        await this.notifications.notify(userId, 'share_expired', {
+          itemId: share.itemId,
+          itemTitle: share.item.title,
+          itemType: share.item.type,
+          expiresAt: expiresIso,
+          principalType: share.principalType,
+          principalId: share.principalId,
+        });
+      }
+    }
+  }
+
+  /** Notify users whose autoDisableAt is within the warning window.
+   *  Idempotent on the autoDisableAt timestamp so an admin pushing
+   *  the date out triggers a fresh warning at the new date. The
+   *  matching user_disabled notification fires from the housekeeping
+   *  cron at the moment the row gets disabled, not from here. */
+  private async sweepDisableWarnings() {
+    const now = new Date();
+    const horizon = new Date(
+      Date.now() + this.expiryWarningDays * 24 * 60 * 60 * 1000,
+    );
+    const candidates = await this.prisma.user.findMany({
+      where: {
+        orgRole: { not: 'admin' },
+        autoDisableAt: { gt: now, lte: horizon },
+      },
+      select: { id: true, autoDisableAt: true },
+    });
+    for (const user of candidates) {
+      if (!user.autoDisableAt) continue;
+      const isoAt = user.autoDisableAt.toISOString();
+      if (
+        await this.alreadyNotified('user_auto_disable_warning', user.id, {
+          autoDisableAt: isoAt,
+        })
+      ) {
+        continue;
+      }
+      await this.notifications.notify(
+        user.id,
+        'user_auto_disable_warning',
+        { autoDisableAt: isoAt },
+      );
+    }
+  }
+
+  /** Resolve user-ids for a share's principal. User principals
+   *  return [principalId]; group principals fan out to current
+   *  membership. Mirrors the same logic in items.service.ts so a
+   *  group share fires the same set of recipients here as it did
+   *  for share_created. */
+  private async resolveShareRecipients(
+    principalType: 'user' | 'group',
+    principalId: string,
+  ): Promise<string[]> {
+    if (principalType === 'user') return [principalId];
+    const members = await this.prisma.groupMember.findMany({
+      where: { groupId: principalId },
+      select: { userId: true },
+    });
+    return members.map((m) => m.userId);
+  }
+
+  /**
+   * Check whether the Notification table already has an entry of
+   * the given type for this user with payload fields matching the
+   * supplied identity. A match in any non-failed status (queued /
+   * sending / sent / failed) prevents re-enqueue: failed rows are
+   * preserved as the audit signal that we already tried.
+   *
+   * Implementation uses Prisma's JSONB path query. We require ALL
+   * supplied fields to match; extra fields in the stored payload
+   * are ignored. Postgres jsonb_path_exists / @> would also work
+   * but the AND-of-equals shape below is what Prisma exposes
+   * cleanly and is plenty fast at our scale.
+   */
+  private async alreadyNotified(
+    type:
+      | 'share_expiring'
+      | 'share_expired'
+      | 'user_auto_disable_warning',
+    userId: string,
+    identity: Record<string, string>,
+  ): Promise<boolean> {
+    const conditions: Prisma.NotificationWhereInput[] = Object.entries(
+      identity,
+    ).map(([key, value]) => ({
+      payload: { path: [key], equals: value },
+    }));
+    const existing = await this.prisma.notification.findFirst({
+      where: {
+        type,
+        userId,
+        AND: conditions,
+      },
+      select: { id: true },
+    });
+    return existing !== null;
+  }
+}

--- a/apps/portal-api/src/notifications/notifications.module.ts
+++ b/apps/portal-api/src/notifications/notifications.module.ts
@@ -5,6 +5,7 @@ import { PrismaModule } from '../prisma/prisma.module.js';
 import { EmailTransport } from './email-transport.js';
 import { NotificationsService } from './notifications.service.js';
 import { NotificationsWorker } from './notifications.worker.js';
+import { NotificationsCron } from './notifications-cron.service.js';
 
 /**
  * Cross-cutting notifications platform (#127). Other modules import
@@ -20,7 +21,12 @@ import { NotificationsWorker } from './notifications.worker.js';
  */
 @Module({
   imports: [PrismaModule, ScheduleModule.forRoot()],
-  providers: [NotificationsService, NotificationsWorker, EmailTransport],
+  providers: [
+    NotificationsService,
+    NotificationsWorker,
+    NotificationsCron,
+    EmailTransport,
+  ],
   exports: [NotificationsService],
 })
 export class NotificationsModule {}

--- a/apps/portal-api/src/notifications/templates.ts
+++ b/apps/portal-api/src/notifications/templates.ts
@@ -49,6 +49,52 @@ export interface ShareCreatedPayload {
   expiresAt?: string;
 }
 
+/** Payload shape for share_expiring + share_expired. The cron carries
+ *  the share's identifying tuple (itemId + principalType + principalId)
+ *  so the idempotency lookup can find prior notifications, plus the
+ *  exact expiresAt so a re-extension of the share triggers a fresh
+ *  warning. */
+export interface ShareExpiryPayload {
+  itemId: string;
+  itemTitle: string;
+  itemType: string;
+  /** ISO timestamp at which (or after which) the share lapses. */
+  expiresAt: string;
+  /** The share's principal -- needed for idempotency and for the
+   *  human "you no longer have access" framing in the email body. */
+  principalType: 'user' | 'group';
+  principalId: string;
+}
+
+/** Payload shape for user_auto_disable_warning + user_disabled. */
+export interface UserDisablePayload {
+  /** ISO timestamp at which the auto-disable will fire (warning) or
+   *  fired (disabled). Used by the idempotency check + the email
+   *  body. */
+  autoDisableAt: string;
+}
+
+/** Payload shape for editor_feature_created. The editor's owner is
+ *  the immediate recipient; a richer per-target recipient list is a
+ *  Phase 2b extension. */
+export interface EditorFeatureCreatedPayload {
+  editorId: string;
+  editorTitle: string;
+  /** The data_layer the feature landed in. */
+  dataLayerId: string;
+  dataLayerTitle: string;
+  /** Layer key inside the data_layer. */
+  layerKey: string;
+  /** global_id of the new feature. */
+  featureId: string;
+  /** Display name of the author who created the feature. */
+  createdByName: string;
+  /** Best-effort summary string -- the first non-empty user field's
+   *  value, e.g. "Building #4127". Falls back to a truncated
+   *  featureId when nothing better is available. */
+  summary: string;
+}
+
 type Renderer<T> = (payload: T, ctx: RenderContext) => RenderedNotification;
 
 const renderers: { [K in NotificationType]?: Renderer<unknown> } = {
@@ -72,6 +118,85 @@ const renderers: { [K in NotificationType]?: Renderer<unknown> } = {
       `<li>Permission: ${escapeHtml(payload.permission)}${escapeHtml(expiryNote)}</li>` +
       `</ul>` +
       `<p><a href="${escapeAttr(itemUrl)}">Open the item</a></p>`;
+    return { subject, text, html };
+  }) as Renderer<unknown>,
+
+  share_expiring: ((payload: ShareExpiryPayload, ctx) => {
+    const itemUrl = `${ctx.baseUrl}/items/${payload.itemId}`;
+    const when = formatDate(payload.expiresAt);
+    const subject = `Your access to "${payload.itemTitle}" expires soon`;
+    const text =
+      `Your access to "${payload.itemTitle}" on ${ctx.orgLabel} expires on ${when}.\n\n` +
+      `If you still need this item, ask the owner to extend the share.\n\n` +
+      `Open it: ${itemUrl}\n`;
+    const html =
+      `<p>Your access to <strong>${escapeHtml(payload.itemTitle)}</strong> on ` +
+      `${escapeHtml(ctx.orgLabel)} expires on <strong>${escapeHtml(when)}</strong>.</p>` +
+      `<p>If you still need this item, ask the owner to extend the share.</p>` +
+      `<p><a href="${escapeAttr(itemUrl)}">Open the item</a></p>`;
+    return { subject, text, html };
+  }) as Renderer<unknown>,
+
+  share_expired: ((payload: ShareExpiryPayload, ctx) => {
+    const when = formatDate(payload.expiresAt);
+    const subject = `Your access to "${payload.itemTitle}" has expired`;
+    const text =
+      `Your access to "${payload.itemTitle}" on ${ctx.orgLabel} expired on ${when}.\n\n` +
+      `You can no longer open or query this item. If you need access, contact the owner.\n`;
+    const html =
+      `<p>Your access to <strong>${escapeHtml(payload.itemTitle)}</strong> on ` +
+      `${escapeHtml(ctx.orgLabel)} expired on <strong>${escapeHtml(when)}</strong>.</p>` +
+      `<p>You can no longer open or query this item. If you need access, contact the owner.</p>`;
+    return { subject, text, html };
+  }) as Renderer<unknown>,
+
+  user_auto_disable_warning: ((payload: UserDisablePayload, ctx) => {
+    const when = formatDate(payload.autoDisableAt);
+    const subject = `Your account on ${ctx.orgLabel} will be disabled on ${when}`;
+    const text =
+      `Your account on ${ctx.orgLabel} is scheduled to be disabled on ${when}.\n\n` +
+      `If you still need access, sign in once before that date or contact your org admin.\n\n` +
+      `${ctx.baseUrl}\n`;
+    const html =
+      `<p>Your account on <strong>${escapeHtml(ctx.orgLabel)}</strong> is scheduled to be ` +
+      `disabled on <strong>${escapeHtml(when)}</strong>.</p>` +
+      `<p>If you still need access, sign in once before that date or contact your org admin.</p>` +
+      `<p><a href="${escapeAttr(ctx.baseUrl)}">${escapeHtml(ctx.baseUrl)}</a></p>`;
+    return { subject, text, html };
+  }) as Renderer<unknown>,
+
+  user_disabled: ((payload: UserDisablePayload, ctx) => {
+    const when = formatDate(payload.autoDisableAt);
+    const subject = `Your account on ${ctx.orgLabel} has been disabled`;
+    const text =
+      `Your account on ${ctx.orgLabel} was disabled on ${when}.\n\n` +
+      `Contact your org admin if you believe this was in error.\n`;
+    const html =
+      `<p>Your account on <strong>${escapeHtml(ctx.orgLabel)}</strong> was disabled on ` +
+      `<strong>${escapeHtml(when)}</strong>.</p>` +
+      `<p>Contact your org admin if you believe this was in error.</p>`;
+    return { subject, text, html };
+  }) as Renderer<unknown>,
+
+  editor_feature_created: ((payload: EditorFeatureCreatedPayload, ctx) => {
+    const editorUrl = `${ctx.baseUrl}/items/${payload.editorId}`;
+    const dataLayerUrl = `${ctx.baseUrl}/items/${payload.dataLayerId}`;
+    const subject = `New submission on "${payload.editorTitle}": ${payload.summary}`;
+    const text =
+      `${payload.createdByName} added a feature through "${payload.editorTitle}".\n\n` +
+      `Layer: ${payload.dataLayerTitle}\n` +
+      `Summary: ${payload.summary}\n\n` +
+      `Editor: ${editorUrl}\n` +
+      `Data layer: ${dataLayerUrl}\n`;
+    const html =
+      `<p><strong>${escapeHtml(payload.createdByName)}</strong> added a feature ` +
+      `through <strong>${escapeHtml(payload.editorTitle)}</strong>.</p>` +
+      `<ul>` +
+      `<li>Layer: ${escapeHtml(payload.dataLayerTitle)}</li>` +
+      `<li>Summary: ${escapeHtml(payload.summary)}</li>` +
+      `</ul>` +
+      `<p><a href="${escapeAttr(editorUrl)}">Open the editor</a> · ` +
+      `<a href="${escapeAttr(dataLayerUrl)}">open the data layer</a></p>`;
     return { subject, text, html };
   }) as Renderer<unknown>,
 };


### PR DESCRIPTION
## What

Phase 2a of the notifications platform: wires the remaining backend triggers on top of the Phase 1 foundation. Five new automatic notification flows now fire without any user-visible UI work.

Builds on #1 (already merged).

## Triggers

- **`share_expiring`** — cron sweep finds shares with `expiresAt` within the warning window (configurable via `NOTIFICATIONS_EXPIRY_WARNING_DAYS`, default 7).
- **`share_expired`** — cron sweep finds shares whose `expiresAt` fell in the trailing window since last sweep.
- **`user_auto_disable_warning`** — cron sweep finds users with `autoDisableAt` within the warning window.
- **`user_disabled`** — housekeeping auto-disable cron fires this immediately after Keycloak flips `enabled=false`. Wired into both the expired-`autoDisableAt` path and the quiet-user heuristic.
- **`editor_feature_created`** — v3 features POST controller fires this when the request carries `x-editor-id`; notifies the editor item's owner with a best-effort summary string. (The original Survey123-gap motivation.)

## Idempotency strategy

The `Notification` table itself is the "have we already notified about this?" check rather than adding flag columns to `item_share` / `user`. Each cron sweep queries existing rows by `(type, userId, payload identity)` and skips re-enqueue when found. Re-extending an expiry timestamp moves the payload's `expiresAt` to a new value, so the next sweep treats it as a fresh trigger and warns again. No schema additions, no flag-column drift.

## Files

New:
- `apps/portal-api/src/notifications/notifications-cron.service.ts` — drains the three time-based triggers every 30 minutes. Honors `NOTIFICATIONS_ENABLED` + `NOTIFICATIONS_EXPIRY_WARNING_DAYS`.

Touched:
- `notifications.module.ts` — registers the cron service.
- `templates.ts` — adds renderers + payload type docs for the five new types.
- `admin/housekeeping-schedule.service.ts` — injects `NotificationsService`, fires `user_disabled` inline after each successful Keycloak disable in both paths.
- `admin/admin.module.ts` — imports `NotificationsModule`.
- `features-v3/v3-features.controller.ts` — injects `NotificationsService`, fan-outs `editor_feature_created` on a successful append when `x-editor-id` was present. Includes a `pickFeatureSummary()` helper for the email subject.
- `features-v3/v3-features.module.ts` — imports `NotificationsModule`.

## Test plan

1. Set up SMTP env (or MailHog).
2. **Share expiring**: create a share with `expiresAt = now + 5 days`. Wait for the cron to tick (or call the cron's exposed test hook if it exists). Confirm the recipient gets one `share_expiring` email; the next sweep does NOT re-fire.
3. **Share expired**: set `expiresAt = now - 1 hour`. Next sweep fires `share_expired` once.
4. **User auto-disable warning**: set a non-admin's `autoDisableAt = now + 5 days`. Next sweep fires.
5. **User disabled**: set `autoDisableAt = now - 1 hour`, run housekeeping. Recipient gets `user_disabled` after Keycloak flips them.
6. **Editor feature created**: in the editor runtime, create a feature. The editor's owner gets an email with the feature's summary string in the subject.
7. **Idempotency**: re-run each cron immediately. No duplicate notifications.
8. **Re-extension**: extend a share's `expiresAt` to a new value. Next sweep fires a fresh `share_expiring` notification (because the payload's `expiresAt` is now different).

## Quality gate

`pnpm format && pnpm lint && pnpm test && pnpm typecheck && pnpm build` all green locally.

## Out of scope (future PRs)

- **Phase 2b**: user preferences UI at `/settings/notifications`.
- **Phase 2c**: admin status page for queue depth / failures / retry.
- Per-target configurable recipient lists on editors (today the owner is the only recipient of `editor_feature_created`).
