### PR TITLE
feat(notifications): Phase 2b user preferences UI (#129)

### DIFF
--- a/apps/portal-api/src/notifications/notification-types.ts
+++ b/apps/portal-api/src/notifications/notification-types.ts
@@ -1,0 +1,117 @@
+import { NotificationChannel, NotificationType } from '@prisma/client';
+
+/**
+ * Catalog of notification types the user can opt in / out of, with
+ * human-readable labels + descriptions and a category for grouping
+ * the preferences UI. The catalog is server-driven (rather than
+ * hard-coded in the web app) so adding a new NotificationType is a
+ * one-place edit: append an entry here, the settings page picks it
+ * up automatically.
+ *
+ * Defaults live alongside the catalog. `defaultEnabled` records
+ * whether the type fires for a user with no `notification_preference`
+ * row stored. The matching default in NotificationsService.notify()
+ * reads this same value so the UI and the worker agree on the
+ * "what fires when no row exists" answer.
+ *
+ * Categories are intentionally a small fixed set:
+ *   - sharing: events about items shared with the user
+ *   - account: events about the user's own account lifecycle
+ *   - editor:  events about features collected via editor items
+ *
+ * Channels are also fixed today (email only). The shape is per-type
+ * + per-channel because Phase 3 will add webhooks / in-app and a
+ * user might want share_created over email but not over webhook.
+ */
+export type NotificationCategory = 'sharing' | 'account' | 'editor';
+
+export interface NotificationTypeMeta {
+  type: NotificationType;
+  category: NotificationCategory;
+  label: string;
+  description: string;
+  /** Channels this type can deliver through. Driven by which
+   *  templates.ts has a renderer for AND which channels the platform
+   *  supports today. Phase 1 / 2a: email only. */
+  channels: NotificationChannel[];
+  /** Default enabled state per channel when no preference row exists.
+   *  Currently every type defaults to enabled across every channel;
+   *  we keep the per-channel shape so a future "default off" type
+   *  (e.g. very chatty editor activity) can land without a schema
+   *  migration. */
+  defaultByChannel: Record<NotificationChannel, boolean>;
+}
+
+const ALL_CHANNELS: NotificationChannel[] = ['email'];
+const ALL_DEFAULT_ON: Record<NotificationChannel, boolean> = { email: true };
+
+/**
+ * Authoritative list, ordered the way the settings UI should render
+ * them top-to-bottom. Same order also applies to the rendering of
+ * the cron sweep -- not load-bearing, just pleasant.
+ */
+export const NOTIFICATION_TYPES: NotificationTypeMeta[] = [
+  // Sharing
+  {
+    type: 'share_created',
+    category: 'sharing',
+    label: 'Item shared with you',
+    description:
+      'Someone shares an item directly or via a group you belong to.',
+    channels: ALL_CHANNELS,
+    defaultByChannel: ALL_DEFAULT_ON,
+  },
+  {
+    type: 'share_expiring',
+    category: 'sharing',
+    label: 'Share about to expire',
+    description: 'Your access to a shared item is within the warning window.',
+    channels: ALL_CHANNELS,
+    defaultByChannel: ALL_DEFAULT_ON,
+  },
+  {
+    type: 'share_expired',
+    category: 'sharing',
+    label: 'Share has expired',
+    description: 'Your access to a shared item has lapsed.',
+    channels: ALL_CHANNELS,
+    defaultByChannel: ALL_DEFAULT_ON,
+  },
+
+  // Account
+  {
+    type: 'user_auto_disable_warning',
+    category: 'account',
+    label: 'Account disable warning',
+    description:
+      'Your account is scheduled to be disabled for inactivity within the warning window.',
+    channels: ALL_CHANNELS,
+    defaultByChannel: ALL_DEFAULT_ON,
+  },
+  {
+    type: 'user_disabled',
+    category: 'account',
+    label: 'Account disabled',
+    description: 'Your account was disabled.',
+    channels: ALL_CHANNELS,
+    defaultByChannel: ALL_DEFAULT_ON,
+  },
+
+  // Editor
+  {
+    type: 'editor_feature_created',
+    category: 'editor',
+    label: 'New submission on your editor',
+    description:
+      'Someone created a feature through an editor you own. Useful for "send me an email per response" data-collection workflows.',
+    channels: ALL_CHANNELS,
+    defaultByChannel: ALL_DEFAULT_ON,
+  },
+];
+
+/** Lookup by NotificationType. */
+export function getTypeMeta(
+  type: NotificationType,
+): NotificationTypeMeta | undefined {
+  return NOTIFICATION_TYPES.find((t) => t.type === type);
+}

--- a/apps/portal-api/src/notifications/notifications.module.ts
+++ b/apps/portal-api/src/notifications/notifications.module.ts
@@ -6,6 +6,7 @@ import { EmailTransport } from './email-transport.js';
 import { NotificationsService } from './notifications.service.js';
 import { NotificationsWorker } from './notifications.worker.js';
 import { NotificationsCron } from './notifications-cron.service.js';
+import { NotificationPreferencesController } from './preferences.controller.js';
 
 /**
  * Cross-cutting notifications platform (#127). Other modules import
@@ -21,6 +22,7 @@ import { NotificationsCron } from './notifications-cron.service.js';
  */
 @Module({
   imports: [PrismaModule, ScheduleModule.forRoot()],
+  controllers: [NotificationPreferencesController],
   providers: [
     NotificationsService,
     NotificationsWorker,

--- a/apps/portal-api/src/notifications/preferences.controller.ts
+++ b/apps/portal-api/src/notifications/preferences.controller.ts
@@ -1,0 +1,169 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Put,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { IsBoolean, IsEnum } from 'class-validator';
+import { NotificationChannel, NotificationType } from '@prisma/client';
+
+import { CurrentUser } from '../auth/current-user.decorator.js';
+import type { AuthUser } from '../auth/auth-sync.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+import {
+  NOTIFICATION_TYPES,
+  getTypeMeta,
+} from './notification-types.js';
+
+class UpsertPreferenceDto {
+  @IsEnum(NotificationType)
+  type!: NotificationType;
+  @IsEnum(NotificationChannel)
+  channel!: NotificationChannel;
+  @IsBoolean()
+  enabled!: boolean;
+}
+
+interface PreferenceState {
+  enabled: boolean;
+  /** True when no row exists in notification_preference and the
+   *  default from notification-types.ts is being applied. The UI
+   *  uses this to render a "default" tag next to defaulted rows so
+   *  users see at a glance which rows are theirs vs derived. */
+  isDefault: boolean;
+}
+
+interface PreferencesPayload {
+  channels: NotificationChannel[];
+  types: Array<{
+    type: NotificationType;
+    category: string;
+    label: string;
+    description: string;
+    channels: NotificationChannel[];
+    preferences: Record<NotificationChannel, PreferenceState>;
+  }>;
+}
+
+/**
+ * Per-current-user notification preferences. Mounted under /users/me
+ * so it lives next to the existing /users/me identity endpoint. The
+ * settings UI hits these two endpoints to render the preferences
+ * page.
+ *
+ * Storage rule: the `notification_preference` table only stores
+ * divergences from the default. A user who hasn't touched the
+ * settings page has zero rows. PUT-ing `enabled === default` deletes
+ * any existing row so the table stays sparse over time -- a v3
+ * default flip would then naturally affect every user who hadn't
+ * explicitly opted out.
+ *
+ * Auth: every endpoint runs through the global JwtAuthGuard via
+ * @CurrentUser; users only ever read / write their own preferences.
+ * No admin endpoint here -- admins managing other users' preferences
+ * is a Phase 3 idea, low priority.
+ */
+@ApiTags('users')
+@ApiBearerAuth()
+@Controller('users/me/notification-preferences')
+export class NotificationPreferencesController {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Materialized per-(type, channel) state, ready for the UI to
+   *  render. Combines the catalog from notification-types.ts with
+   *  any rows the user has stored. Channels they haven't touched
+   *  fall through to the default + isDefault: true. */
+  @Get()
+  async list(@CurrentUser() user: AuthUser): Promise<PreferencesPayload> {
+    const rows = await this.prisma.notificationPreference.findMany({
+      where: { userId: user.id },
+      select: { type: true, channel: true, enabled: true },
+    });
+    // Build a (type, channel) -> stored row index for O(1) merge below.
+    const byKey = new Map<string, boolean>();
+    for (const r of rows) {
+      byKey.set(`${r.type}|${r.channel}`, r.enabled);
+    }
+    const channels: NotificationChannel[] = ['email'];
+    return {
+      channels,
+      types: NOTIFICATION_TYPES.map((meta) => {
+        const preferences = {} as Record<NotificationChannel, PreferenceState>;
+        for (const channel of meta.channels) {
+          const key = `${meta.type}|${channel}`;
+          if (byKey.has(key)) {
+            preferences[channel] = {
+              enabled: byKey.get(key)!,
+              isDefault: false,
+            };
+          } else {
+            preferences[channel] = {
+              enabled: meta.defaultByChannel[channel],
+              isDefault: true,
+            };
+          }
+        }
+        return {
+          type: meta.type,
+          category: meta.category,
+          label: meta.label,
+          description: meta.description,
+          channels: meta.channels,
+          preferences,
+        };
+      }),
+    };
+  }
+
+  /**
+   * Upsert a single (type, channel) preference. When the supplied
+   * `enabled` matches the default, we DELETE any existing row to
+   * keep the table sparse. Otherwise upsert. Returns 204 with the
+   * fresh state for that one (type, channel) so the UI can confirm
+   * its optimistic update.
+   */
+  @Put()
+  async upsert(
+    @CurrentUser() user: AuthUser,
+    @Body() body: UpsertPreferenceDto,
+  ): Promise<PreferenceState> {
+    const meta = getTypeMeta(body.type);
+    if (!meta || !meta.channels.includes(body.channel)) {
+      // Unknown type or channel-not-supported-for-type. Treat as a
+      // no-op rather than throwing so a stale UI from before a
+      // catalog change doesn't 400 the user.
+      return { enabled: true, isDefault: true };
+    }
+    const defaultEnabled = meta.defaultByChannel[body.channel];
+    if (body.enabled === defaultEnabled) {
+      // Match default -> remove the row so this (user, type, channel)
+      // tracks the default if it ever changes.
+      await this.prisma.notificationPreference.deleteMany({
+        where: {
+          userId: user.id,
+          type: body.type,
+          channel: body.channel,
+        },
+      });
+      return { enabled: defaultEnabled, isDefault: true };
+    }
+    await this.prisma.notificationPreference.upsert({
+      where: {
+        userId_type_channel: {
+          userId: user.id,
+          type: body.type,
+          channel: body.channel,
+        },
+      },
+      create: {
+        userId: user.id,
+        type: body.type,
+        channel: body.channel,
+        enabled: body.enabled,
+      },
+      update: { enabled: body.enabled },
+    });
+    return { enabled: body.enabled, isDefault: false };
+  }
+}

--- a/apps/portal-web/src/app/profile/page.tsx
+++ b/apps/portal-web/src/app/profile/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { LogOut } from 'lucide-react';
+import { Bell, LogOut } from 'lucide-react';
 import { apiFetch } from '@/lib/api';
 import { AvatarEditor } from './avatar-editor';
 import { ProfileIdentityForm } from './profile-identity-form';
@@ -69,7 +69,14 @@ export default async function ProfilePage() {
         <Field label="Role" value={me.orgRole} />
       </section>
 
-      <section className="mt-8">
+      <section className="mt-8 flex flex-wrap items-center gap-2">
+        <Link
+          href="/settings/notifications"
+          className="inline-flex h-9 items-center gap-1.5 rounded-md border border-border bg-surface-1 px-3 text-sm font-medium text-ink-1 shadow-card hover:bg-surface-2"
+        >
+          <Bell className="h-4 w-4" />
+          Notification preferences
+        </Link>
         <Link
           href="/api/auth/federated-logout"
           className="inline-flex h-9 items-center gap-1.5 rounded-md border border-border bg-surface-1 px-3 text-sm font-medium text-ink-1 shadow-card hover:bg-surface-2"

--- a/apps/portal-web/src/app/settings/notifications/notification-preferences-form.tsx
+++ b/apps/portal-web/src/app/settings/notifications/notification-preferences-form.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Mail, Loader2 } from 'lucide-react';
+
+interface PreferenceState {
+  enabled: boolean;
+  isDefault: boolean;
+}
+
+interface NotificationTypeView {
+  type: string;
+  category: string;
+  label: string;
+  description: string;
+  channels: ('email')[];
+  preferences: Record<'email', PreferenceState>;
+}
+
+interface PreferencesPayload {
+  channels: ('email')[];
+  types: NotificationTypeView[];
+}
+
+interface Props {
+  initial: PreferencesPayload;
+}
+
+const CATEGORY_LABEL: Record<string, string> = {
+  sharing: 'Sharing',
+  account: 'Account',
+  editor: 'Editor activity',
+};
+
+/**
+ * Per-(type, channel) toggles the user can flip. Each toggle does
+ * an optimistic local update and PUTs the change. On error we
+ * revert and surface the message inline.
+ *
+ * We display a small "default" tag next to defaulted rows so users
+ * understand a freshly-flipped preference is now an explicit
+ * override -- and a row that returns to its default value drops
+ * the override at the server (the backend deletes the row when
+ * `enabled === default`).
+ */
+export function NotificationPreferencesForm({ initial }: Props) {
+  const [types, setTypes] = useState(initial.types);
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+  const [errorByKey, setErrorByKey] = useState<Record<string, string>>({});
+
+  // Group the catalog by category so we can render section headers
+  // without the UI hard-coding the category list. Order within each
+  // group preserves the server's catalog order (which is curated).
+  const grouped = useMemo(() => {
+    const groups = new Map<string, NotificationTypeView[]>();
+    for (const t of types) {
+      const list = groups.get(t.category) ?? [];
+      list.push(t);
+      groups.set(t.category, list);
+    }
+    return groups;
+  }, [types]);
+
+  async function toggle(
+    type: string,
+    channel: 'email',
+    nextEnabled: boolean,
+  ) {
+    const key = `${type}|${channel}`;
+    // Optimistic local update so the toggle feels instant.
+    const prevTypes = types;
+    setTypes((cur) =>
+      cur.map((t) =>
+        t.type === type
+          ? {
+              ...t,
+              preferences: {
+                ...t.preferences,
+                [channel]: {
+                  enabled: nextEnabled,
+                  // We don't yet know if the new value matches the
+                  // server-side default; assume not until the response
+                  // comes back. That's a benign assumption: if it does
+                  // match the default, the response replaces the state
+                  // with isDefault: true on the next render.
+                  isDefault: false,
+                },
+              },
+            }
+          : t,
+      ),
+    );
+    setSavingKey(key);
+    setErrorByKey((prev) => {
+      if (!(key in prev)) return prev;
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+    try {
+      const res = await fetch(
+        '/api/portal/users/me/notification-preferences',
+        {
+          method: 'PUT',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ type, channel, enabled: nextEnabled }),
+        },
+      );
+      if (!res.ok) {
+        throw new Error(`${res.status} ${await res.text()}`);
+      }
+      const body = (await res.json()) as PreferenceState;
+      // Replace with server-confirmed state (which may flip
+      // isDefault back to true if the new value matched the default
+      // and the row was deleted).
+      setTypes((cur) =>
+        cur.map((t) =>
+          t.type === type
+            ? {
+                ...t,
+                preferences: { ...t.preferences, [channel]: body },
+              }
+            : t,
+        ),
+      );
+    } catch (err) {
+      // Revert on failure so the UI matches reality.
+      setTypes(prevTypes);
+      setErrorByKey((prev) => ({
+        ...prev,
+        [key]:
+          err instanceof Error ? err.message : 'Could not save change.',
+      }));
+    } finally {
+      setSavingKey(null);
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      {[...grouped.entries()].map(([category, items]) => (
+        <section key={category}>
+          <h2 className="mb-3 text-xs font-medium uppercase tracking-wide text-muted">
+            {CATEGORY_LABEL[category] ?? category}
+          </h2>
+          <ul className="space-y-1.5">
+            {items.map((t) => (
+              <li
+                key={t.type}
+                className="rounded-md border border-border bg-surface-1 p-4"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0 flex-1">
+                    <p className="text-sm font-medium text-ink-0">
+                      {t.label}
+                    </p>
+                    <p className="mt-1 text-xs text-muted">
+                      {t.description}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 flex-col items-end gap-1.5">
+                    {t.channels.map((channel) => {
+                      const pref = t.preferences[channel];
+                      const key = `${t.type}|${channel}`;
+                      const saving = savingKey === key;
+                      const error = errorByKey[key];
+                      return (
+                        <div
+                          key={channel}
+                          className="flex items-center gap-2"
+                        >
+                          <Mail className="h-3.5 w-3.5 text-muted" />
+                          <span className="text-xs text-muted">
+                            {channel}
+                          </span>
+                          {pref.isDefault ? (
+                            <span className="rounded-full bg-surface-2 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted">
+                              default
+                            </span>
+                          ) : null}
+                          <button
+                            type="button"
+                            role="switch"
+                            aria-checked={pref.enabled}
+                            disabled={saving}
+                            onClick={() =>
+                              void toggle(t.type, channel, !pref.enabled)
+                            }
+                            className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors disabled:opacity-50 ${
+                              pref.enabled
+                                ? 'bg-accent'
+                                : 'bg-surface-2 ring-1 ring-inset ring-border'
+                            }`}
+                          >
+                            <span
+                              className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow transition-transform ${
+                                pref.enabled
+                                  ? 'translate-x-5'
+                                  : 'translate-x-1'
+                              }`}
+                            />
+                            {saving ? (
+                              <Loader2 className="absolute inset-0 m-auto h-3 w-3 animate-spin text-white" />
+                            ) : null}
+                          </button>
+                        </div>
+                      );
+                    })}
+                    {Object.entries(errorByKey).find(([k]) =>
+                      k.startsWith(`${t.type}|`),
+                    ) ? (
+                      <p
+                        className="text-[11px] text-danger"
+                        role="alert"
+                      >
+                        {Object.entries(errorByKey).find(([k]) =>
+                          k.startsWith(`${t.type}|`),
+                        )?.[1]}
+                      </p>
+                    ) : null}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/portal-web/src/app/settings/notifications/page.tsx
+++ b/apps/portal-web/src/app/settings/notifications/page.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+
+import { apiFetch } from '@/lib/api';
+import { NotificationPreferencesForm } from './notification-preferences-form';
+
+interface PreferencesPayload {
+  channels: ('email')[];
+  types: Array<{
+    type: string;
+    category: string;
+    label: string;
+    description: string;
+    channels: ('email')[];
+    preferences: Record<
+      'email',
+      { enabled: boolean; isDefault: boolean }
+    >;
+  }>;
+}
+
+export const metadata = { title: 'Notification preferences' };
+
+/**
+ * /settings/notifications: per-user opt-in / opt-out for every
+ * notification type the platform fires. Server fetches the current
+ * state through the BFF; the form below is a client component that
+ * PUTs each toggle independently and reflects optimistic state so a
+ * slow round-trip doesn't make the toggle feel laggy.
+ */
+export default async function NotificationsSettingsPage() {
+  const data = await apiFetch<PreferencesPayload>(
+    '/api/portal/users/me/notification-preferences',
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-3xl px-6 py-10">
+      <header className="mb-8">
+        <Link
+          href="/profile"
+          className="inline-flex items-center gap-1 text-xs text-muted hover:text-ink-0"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          Back to profile
+        </Link>
+        <h1 className="mt-2 text-3xl font-semibold tracking-tight">
+          Notification preferences
+        </h1>
+        <p className="mt-2 max-w-2xl text-sm text-muted">
+          Choose which events email you. The portal admin must enable
+          email delivery at the platform level (NOTIFICATIONS_ENABLED)
+          for any of these to actually fire.
+        </p>
+      </header>
+
+      <NotificationPreferencesForm initial={data} />
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Phase 2b of the notifications platform: per-user opt-in / opt-out for every notification type the platform fires. Adds a `/settings/notifications` page plus the supporting endpoints and a server-driven catalog so adding a new `NotificationType` is a one-place edit.

## Sequencing note

Independent of #2 (Phase 2a backend triggers) — this PR only reads/writes the existing `notification_preference` table from Phase 1. CI passes on its own; clean merge expected after #2 lands.

## Changes

**API**

- `apps/portal-api/src/notifications/notification-types.ts` — server-side catalog of every type with category / label / description / channels / per-channel default.
- `preferences.controller.ts` — mounts at `/users/me/notification-preferences`. GET joins the catalog with the user's rows, missing rows fall through to default (`isDefault: true`). PUT upserts and DELETEs the row when the new value matches the default, keeping the table sparse so a future default flip naturally affects users who hadn't explicitly opted out.
- `NotificationsModule` registers the controller alongside the existing service / worker.

**UI**

- New `/settings/notifications` page (server component fetches state through BFF).
- `NotificationPreferencesForm` client component with per-(type, channel) toggle, optimistic update + PUT, revert + inline error on failure. "default" tag next to defaulted rows.
- Profile page grew a **Notification preferences** link button next to Sign out.

## Test plan

1. Open `/profile`, click **Notification preferences** → lands on `/settings/notifications`.
2. Every type renders grouped by category (Sharing / Account / Editor activity), with the "default" tag visible (no rows yet).
3. Toggle one off → "default" tag disappears, request fires, toggle stays.
4. Reload — state persists.
5. Toggle it back on (matches default) → "default" tag re-appears, server-side row deleted.
6. As Bob (admin), check the `notification_preference` table after each toggle to confirm sparse-storage behaviour.
7. With `NOTIFICATIONS_ENABLED=true` and SMTP wired, do a share and confirm the disabled type doesn't fire.

## Quality gate

`pnpm format && pnpm lint && pnpm test && pnpm typecheck && pnpm build` all green locally.

## Out of scope

- **Phase 2c**: admin notifications status page (queue depth / failures / retry).
- Webhooks / in-app channels (the catalog has the per-channel shape but only `email` exists today).
- Bulk "turn off all notifications" / "reset to defaults" buttons. Easy to add later if useful.
