### PR TITLE
feat(notifications): admin status page with retry (#130)

### DIFF
--- a/apps/portal-api/src/admin/admin.module.ts
+++ b/apps/portal-api/src/admin/admin.module.ts
@@ -12,6 +12,7 @@ import { KeycloakAdminService } from './keycloak-admin.service.js';
 import { V3TablesModule } from '../features-v3/v3-tables.module.js';
 import { ItemsModule } from '../items/items.module.js';
 import { NotificationsModule } from '../notifications/notifications.module.js';
+import { NotificationsAdminController } from '../notifications/admin.controller.js';
 
 /**
  * Wires the admin surfaces: Keycloak integration (users +
@@ -32,6 +33,7 @@ import { NotificationsModule } from '../notifications/notifications.module.js';
     AdminBrandingController,
     AdminCapabilitiesController,
     HousekeepingController,
+    NotificationsAdminController,
   ],
   providers: [
     KeycloakAdminService,

--- a/apps/portal-api/src/notifications/admin.controller.ts
+++ b/apps/portal-api/src/notifications/admin.controller.ts
@@ -1,0 +1,207 @@
+import { Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { NotificationStatus, NotificationType } from '@prisma/client';
+
+import { AdminGuard } from '../admin/admin.guard.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { NOTIFICATION_TYPES } from './notification-types.js';
+
+interface StatsPayload {
+  /** Total queued + sending rows. The "in-flight" backlog. */
+  queueDepth: number;
+  /** Rows whose status is `failed` after exhausting retries. Stay in
+   *  the table for admin inspection until manually retried or
+   *  pruned. */
+  failedTotal: number;
+  /** Sent successfully in the last 24h. */
+  sentLast24h: number;
+  /** Failed in the last 24h (terminal failures, not transient ones
+   *  that are still retrying). */
+  failedLast24h: number;
+  /** Average time from creation to delivery for rows sent in the
+   *  last 24h, in milliseconds. Null when no rows were sent. */
+  avgLatencyMs: number | null;
+  /** Per-type rollup so admins can spot a single trigger that's
+   *  flooding or failing. */
+  byType: Array<{
+    type: NotificationType;
+    label: string;
+    queued: number;
+    sent: number;
+    failed: number;
+  }>;
+}
+
+interface RecentRow {
+  id: string;
+  type: NotificationType;
+  status: NotificationStatus;
+  address: string;
+  attempts: number;
+  lastError: string | null;
+  scheduledAt: string;
+  sentAt: string | null;
+  createdAt: string;
+}
+
+/**
+ * Admin-only notifications status surface (#130). Reads counts +
+ * recent rows out of the `notification` table for the org admin's
+ * dashboard. Also offers a per-row Retry to push a `failed` row
+ * back into `queued` so the worker picks it up on its next tick
+ * (used after the underlying issue is fixed, e.g. SMTP creds
+ * corrected).
+ *
+ * Scope: this is org-wide today (no per-org filter on the query),
+ * matching the rest of the admin pages. When multi-org tenancy
+ * lands (#47), the queries grow an `orgId` filter and the page
+ * becomes per-admin's-org.
+ */
+@ApiTags('admin')
+@ApiBearerAuth()
+@UseGuards(AdminGuard)
+@Controller('admin/notifications')
+export class NotificationsAdminController {
+  constructor(private readonly prisma: PrismaService) {}
+
+  @Get('stats')
+  async stats(): Promise<StatsPayload> {
+    const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    // Three count queries that share roughly the same shape; doing
+    // them in parallel keeps the dashboard responsive even on a
+    // backlog that's larger than usual.
+    const [queueDepth, failedTotal, last24Sent, last24Failed] =
+      await Promise.all([
+        this.prisma.notification.count({
+          where: {
+            status: { in: ['queued', 'sending'] satisfies NotificationStatus[] },
+          },
+        }),
+        this.prisma.notification.count({ where: { status: 'failed' } }),
+        this.prisma.notification.findMany({
+          where: { status: 'sent', sentAt: { gte: since24h } },
+          select: { createdAt: true, sentAt: true },
+        }),
+        this.prisma.notification.count({
+          where: { status: 'failed', createdAt: { gte: since24h } },
+        }),
+      ]);
+
+    // Average latency over the sent slice. Filtering null sentAt
+    // upstream means every row in last24Sent has a real timestamp.
+    let avgLatencyMs: number | null = null;
+    if (last24Sent.length > 0) {
+      const total = last24Sent.reduce((acc, row) => {
+        if (!row.sentAt) return acc;
+        return acc + (row.sentAt.getTime() - row.createdAt.getTime());
+      }, 0);
+      avgLatencyMs = Math.round(total / last24Sent.length);
+    }
+
+    // Per-type rollup. groupBy is the cheapest path; we materialise
+    // every type from the catalog so an unused type still shows
+    // "0/0/0" rather than disappearing from the dashboard.
+    const grouped = await this.prisma.notification.groupBy({
+      by: ['type', 'status'],
+      _count: { _all: true },
+    });
+    const byTypeMap = new Map<
+      NotificationType,
+      { queued: number; sent: number; failed: number }
+    >();
+    for (const meta of NOTIFICATION_TYPES) {
+      byTypeMap.set(meta.type, { queued: 0, sent: 0, failed: 0 });
+    }
+    for (const g of grouped) {
+      const slot = byTypeMap.get(g.type);
+      if (!slot) continue;
+      const count = g._count._all;
+      // queued + sending fold into "in-flight" for the rollup;
+      // sent and failed each get their own column.
+      if (g.status === 'queued' || g.status === 'sending') {
+        slot.queued += count;
+      } else if (g.status === 'sent') {
+        slot.sent += count;
+      } else if (g.status === 'failed') {
+        slot.failed += count;
+      }
+    }
+    const byType = NOTIFICATION_TYPES.map((meta) => {
+      const counts = byTypeMap.get(meta.type)!;
+      return {
+        type: meta.type,
+        label: meta.label,
+        queued: counts.queued,
+        sent: counts.sent,
+        failed: counts.failed,
+      };
+    });
+
+    return {
+      queueDepth,
+      failedTotal,
+      sentLast24h: last24Sent.length,
+      failedLast24h: last24Failed,
+      avgLatencyMs,
+      byType,
+    };
+  }
+
+  /**
+   * Recent rows for the dashboard's "Recent activity" panel. Returns
+   * the latest 50 ordered by createdAt desc, mixing every status so
+   * an admin can spot a wave of failures next to the successes.
+   */
+  @Get('recent')
+  async recent(): Promise<RecentRow[]> {
+    const rows = await this.prisma.notification.findMany({
+      orderBy: { createdAt: 'desc' },
+      take: 50,
+      select: {
+        id: true,
+        type: true,
+        status: true,
+        address: true,
+        attempts: true,
+        lastError: true,
+        scheduledAt: true,
+        sentAt: true,
+        createdAt: true,
+      },
+    });
+    return rows.map((r) => ({
+      id: r.id,
+      type: r.type,
+      status: r.status,
+      address: r.address,
+      attempts: r.attempts,
+      lastError: r.lastError,
+      scheduledAt: r.scheduledAt.toISOString(),
+      sentAt: r.sentAt ? r.sentAt.toISOString() : null,
+      createdAt: r.createdAt.toISOString(),
+    }));
+  }
+
+  /**
+   * Push a failed row back into the queue. Resets attempts to 0 so
+   * the worker treats it as a fresh send (and the exponential
+   * backoff doesn't kick in immediately on a row that already burned
+   * its budget). scheduledAt becomes "now" so the next tick picks
+   * it up. No-op when the row is already in any non-failed state --
+   * keeps the action idempotent for double-clicks.
+   */
+  @Post(':id/retry')
+  async retry(@Param('id') id: string): Promise<{ retried: boolean }> {
+    const r = await this.prisma.notification.updateMany({
+      where: { id, status: 'failed' },
+      data: {
+        status: 'queued',
+        attempts: 0,
+        lastError: null,
+        scheduledAt: new Date(),
+      },
+    });
+    return { retried: r.count > 0 };
+  }
+}

--- a/apps/portal-web/src/app/admin/notifications/notifications-admin-view.tsx
+++ b/apps/portal-web/src/app/admin/notifications/notifications-admin-view.tsx
@@ -1,0 +1,372 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  Loader2,
+  RefreshCcw,
+  RotateCw,
+} from 'lucide-react';
+
+export interface Stats {
+  queueDepth: number;
+  failedTotal: number;
+  sentLast24h: number;
+  failedLast24h: number;
+  avgLatencyMs: number | null;
+  byType: Array<{
+    type: string;
+    label: string;
+    queued: number;
+    sent: number;
+    failed: number;
+  }>;
+}
+
+export interface RecentRow {
+  id: string;
+  type: string;
+  status: 'queued' | 'sending' | 'sent' | 'failed';
+  address: string;
+  attempts: number;
+  lastError: string | null;
+  scheduledAt: string;
+  sentAt: string | null;
+  createdAt: string;
+}
+
+interface Props {
+  initialStats: Stats;
+  initialRecent: RecentRow[];
+}
+
+/**
+ * Admin notifications dashboard view (#130). Shows the four
+ * top-line metrics, the per-type rollup, and the recent-activity
+ * list with per-row Retry on failed rows. The Refresh button at
+ * the top re-fetches both stats + recent in one round-trip-pair
+ * so the page stays current without a full reload.
+ *
+ * Optimistic Retry: clicking Retry flips the local row to "queued"
+ * with attempts: 0, then PUTs. On error we revert. The server-side
+ * retry is idempotent on already-non-failed rows so a double-click
+ * doesn't cause weird state.
+ */
+export function NotificationsAdminView({
+  initialStats,
+  initialRecent,
+}: Props) {
+  const [stats, setStats] = useState<Stats>(initialStats);
+  const [recent, setRecent] = useState<RecentRow[]>(initialRecent);
+  const [refreshing, setRefreshing] = useState(false);
+  const [retryingId, setRetryingId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function refresh() {
+    setRefreshing(true);
+    setError(null);
+    try {
+      const [s, r] = await Promise.all([
+        fetch('/api/portal/admin/notifications/stats').then(
+          (res) => res.json() as Promise<Stats>,
+        ),
+        fetch('/api/portal/admin/notifications/recent').then(
+          (res) => res.json() as Promise<RecentRow[]>,
+        ),
+      ]);
+      setStats(s);
+      setRecent(r);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Refresh failed; try again.',
+      );
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  async function retry(id: string) {
+    setRetryingId(id);
+    setError(null);
+    // Optimistic: flip the row to queued so the UI confirms instantly.
+    const prev = recent;
+    setRecent((cur) =>
+      cur.map((r) =>
+        r.id === id
+          ? { ...r, status: 'queued', attempts: 0, lastError: null }
+          : r,
+      ),
+    );
+    try {
+      const res = await fetch(
+        `/api/portal/admin/notifications/${id}/retry`,
+        { method: 'POST' },
+      );
+      if (!res.ok) {
+        throw new Error(`${res.status} ${await res.text()}`);
+      }
+      // Re-pull stats so the queueDepth / failedTotal counters
+      // reflect the change.
+      const s = (await fetch(
+        '/api/portal/admin/notifications/stats',
+      ).then((r) => r.json())) as Stats;
+      setStats(s);
+    } catch (err) {
+      setRecent(prev);
+      setError(
+        err instanceof Error ? err.message : 'Retry failed; try again.',
+      );
+    } finally {
+      setRetryingId(null);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-end gap-2">
+        {error ? (
+          <span
+            className="text-xs text-danger"
+            role="alert"
+          >
+            {error}
+          </span>
+        ) : null}
+        <button
+          type="button"
+          disabled={refreshing}
+          onClick={() => void refresh()}
+          className="inline-flex h-8 items-center gap-1 rounded-md border border-border bg-surface-1 px-2.5 text-xs font-medium text-ink-1 hover:bg-surface-2 disabled:opacity-50"
+        >
+          {refreshing ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <RefreshCcw className="h-3.5 w-3.5" />
+          )}
+          Refresh
+        </button>
+      </div>
+
+      {/* Top-line metrics. */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <Metric
+          icon={<Clock className="h-4 w-4" />}
+          label="Queue depth"
+          value={stats.queueDepth.toLocaleString()}
+          tone={stats.queueDepth > 100 ? 'warn' : 'normal'}
+          help="Queued + sending"
+        />
+        <Metric
+          icon={<CheckCircle2 className="h-4 w-4" />}
+          label="Sent (24h)"
+          value={stats.sentLast24h.toLocaleString()}
+          tone="normal"
+        />
+        <Metric
+          icon={<AlertTriangle className="h-4 w-4" />}
+          label="Failed (24h)"
+          value={stats.failedLast24h.toLocaleString()}
+          tone={stats.failedLast24h > 0 ? 'warn' : 'normal'}
+          help={
+            stats.failedTotal > stats.failedLast24h
+              ? `${stats.failedTotal} total since launch`
+              : undefined
+          }
+        />
+        <Metric
+          icon={<Clock className="h-4 w-4" />}
+          label="Avg latency"
+          value={
+            stats.avgLatencyMs === null
+              ? '-'
+              : formatLatency(stats.avgLatencyMs)
+          }
+          tone="normal"
+          help="Create -> sent (24h)"
+        />
+      </div>
+
+      {/* Per-type rollup. */}
+      <section className="rounded-lg border border-border bg-surface-1 p-4 shadow-card">
+        <h2 className="mb-3 text-xs font-medium uppercase tracking-wide text-muted">
+          By type
+        </h2>
+        <table className="min-w-full text-xs">
+          <thead className="text-muted">
+            <tr>
+              <th className="pb-1 text-left font-medium">Type</th>
+              <th className="pb-1 text-right font-medium">Queued</th>
+              <th className="pb-1 text-right font-medium">Sent</th>
+              <th className="pb-1 text-right font-medium">Failed</th>
+            </tr>
+          </thead>
+          <tbody>
+            {stats.byType.map((row) => (
+              <tr key={row.type} className="border-t border-border">
+                <td className="py-1.5 text-ink-1">{row.label}</td>
+                <td className="py-1.5 text-right tabular-nums">
+                  {row.queued.toLocaleString()}
+                </td>
+                <td className="py-1.5 text-right tabular-nums">
+                  {row.sent.toLocaleString()}
+                </td>
+                <td
+                  className={`py-1.5 text-right tabular-nums ${
+                    row.failed > 0 ? 'text-amber-700' : ''
+                  }`}
+                >
+                  {row.failed.toLocaleString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      {/* Recent activity. */}
+      <section className="rounded-lg border border-border bg-surface-1 p-4 shadow-card">
+        <h2 className="mb-3 text-xs font-medium uppercase tracking-wide text-muted">
+          Recent activity
+        </h2>
+        {recent.length === 0 ? (
+          <p className="text-sm text-muted">
+            No notifications yet. Once the platform fires a trigger,
+            rows will appear here.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-xs">
+              <thead className="text-muted">
+                <tr>
+                  <th className="pb-1 text-left font-medium">Type</th>
+                  <th className="pb-1 text-left font-medium">Address</th>
+                  <th className="pb-1 text-left font-medium">Status</th>
+                  <th className="pb-1 text-left font-medium">Created</th>
+                  <th className="pb-1 text-left font-medium">Sent</th>
+                  <th className="pb-1 text-left font-medium">Attempts</th>
+                  <th className="pb-1 text-right font-medium">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recent.map((row) => {
+                  const failed = row.status === 'failed';
+                  return (
+                    <tr key={row.id} className="border-t border-border">
+                      <td className="py-1.5 align-top text-ink-1">
+                        {row.type}
+                      </td>
+                      <td className="py-1.5 align-top">{row.address}</td>
+                      <td className="py-1.5 align-top">
+                        <StatusBadge status={row.status} />
+                        {failed && row.lastError ? (
+                          <p
+                            className="mt-0.5 max-w-xs truncate text-[11px] text-amber-800"
+                            title={row.lastError}
+                          >
+                            {row.lastError}
+                          </p>
+                        ) : null}
+                      </td>
+                      <td className="py-1.5 align-top tabular-nums">
+                        {formatRel(row.createdAt)}
+                      </td>
+                      <td className="py-1.5 align-top tabular-nums">
+                        {row.sentAt ? formatRel(row.sentAt) : '-'}
+                      </td>
+                      <td className="py-1.5 align-top tabular-nums">
+                        {row.attempts}
+                      </td>
+                      <td className="py-1.5 text-right align-top">
+                        {failed ? (
+                          <button
+                            type="button"
+                            disabled={retryingId === row.id}
+                            onClick={() => void retry(row.id)}
+                            className="inline-flex items-center gap-1 rounded border border-border bg-surface-1 px-1.5 py-0.5 text-[11px] font-medium text-ink-1 hover:bg-surface-2 disabled:opacity-50"
+                          >
+                            {retryingId === row.id ? (
+                              <Loader2 className="h-3 w-3 animate-spin" />
+                            ) : (
+                              <RotateCw className="h-3 w-3" />
+                            )}
+                            Retry
+                          </button>
+                        ) : null}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Metric({
+  icon,
+  label,
+  value,
+  tone,
+  help,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  tone: 'normal' | 'warn';
+  help?: string | undefined;
+}) {
+  return (
+    <div
+      className={`rounded-lg border bg-surface-1 p-4 shadow-card ${
+        tone === 'warn' ? 'border-amber-300' : 'border-border'
+      }`}
+    >
+      <div className="flex items-center gap-1.5 text-xs uppercase tracking-wide text-muted">
+        {icon}
+        {label}
+      </div>
+      <p className="mt-1.5 text-2xl font-semibold tabular-nums text-ink-0">
+        {value}
+      </p>
+      {help ? <p className="mt-0.5 text-[11px] text-muted">{help}</p> : null}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: RecentRow['status'] }) {
+  const tone =
+    status === 'sent'
+      ? 'bg-emerald-100 text-emerald-800'
+      : status === 'failed'
+        ? 'bg-amber-100 text-amber-900'
+        : status === 'sending'
+          ? 'bg-sky-100 text-sky-800'
+          : 'bg-surface-2 text-muted';
+  return (
+    <span
+      className={`inline-flex rounded-full px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${tone}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function formatLatency(ms: number): string {
+  if (ms < 1000) return `${ms} ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)} s`;
+  return `${(ms / 60_000).toFixed(1)} min`;
+}
+
+function formatRel(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 0) return new Date(iso).toLocaleString();
+  if (ms < 60_000) return `${Math.floor(ms / 1000)}s ago`;
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+  return new Date(iso).toLocaleDateString();
+}

--- a/apps/portal-web/src/app/admin/notifications/page.tsx
+++ b/apps/portal-web/src/app/admin/notifications/page.tsx
@@ -1,0 +1,77 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { ArrowLeft, Bell } from 'lucide-react';
+
+import { apiFetch } from '@/lib/api';
+import { NotificationsAdminView, type Stats, type RecentRow } from './notifications-admin-view';
+
+/**
+ * Admin-only notifications status surface (#130). Shows queue
+ * depth, last-24h sent / failed counts, average latency, a per-
+ * type rollup, and a recent-activity table with per-row Retry on
+ * failed entries. Pairs with the existing housekeeping dashboard
+ * shape so admins find the same affordances across pages.
+ */
+export default async function AdminNotificationsPage() {
+  let me: { orgRole: string };
+  try {
+    me = await apiFetch<{ orgRole: string }>('/api/users/me');
+  } catch {
+    redirect('/items');
+  }
+  if (me.orgRole !== 'admin') redirect('/items');
+
+  let stats: Stats | null = null;
+  let recent: RecentRow[] = [];
+  let error: string | null = null;
+  try {
+    [stats, recent] = await Promise.all([
+      apiFetch<Stats>('/api/admin/notifications/stats'),
+      apiFetch<RecentRow[]>('/api/admin/notifications/recent'),
+    ]);
+  } catch (err) {
+    error =
+      err instanceof Error
+        ? err.message
+        : 'Could not load notifications data.';
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-5xl px-6 py-10">
+      <Link
+        href="/items"
+        className="mb-3 inline-flex items-center gap-1 text-xs text-muted hover:text-ink-0"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        Back to portal
+      </Link>
+      <header className="mb-6 flex items-center gap-3">
+        <span className="flex h-10 w-10 items-center justify-center rounded-md bg-accent/10 text-accent">
+          <Bell className="h-5 w-5" />
+        </span>
+        <div>
+          <p className="text-xs text-muted">Admin</p>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Notifications
+          </h1>
+          <p className="mt-0.5 text-sm text-muted">
+            Email delivery health for the platform. Stuck rows can be
+            retried after fixing the underlying issue (typically SMTP
+            credentials).
+          </p>
+        </div>
+      </header>
+
+      {error ? (
+        <div className="mb-6 rounded-lg border border-danger/30 bg-danger/5 px-4 py-3 text-sm text-danger">
+          <p className="font-medium">Could not load notifications data</p>
+          <p className="mt-1 text-danger/90">{error}</p>
+        </div>
+      ) : null}
+
+      {stats ? (
+        <NotificationsAdminView initialStats={stats} initialRecent={recent} />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/portal-web/src/components/app-shell.tsx
+++ b/apps/portal-web/src/components/app-shell.tsx
@@ -112,6 +112,12 @@ export async function AppShell({ children }: { children: ReactNode }) {
               >
                 Housekeeping
               </NavLink>
+              <NavLink
+                href="/admin/notifications"
+                icon={<Bell className="h-4 w-4" />}
+              >
+                Notifications
+              </NavLink>
             </>
           ) : null}
         </nav>


### PR DESCRIPTION
Phase 2c of the notifications platform. Admin-only dashboard at
/admin/notifications that shows queue health and lets admins retry
failed rows after fixing the underlying issue (typically SMTP
credentials).

## What

Top-line metrics:
- **Queue depth** (queued + sending). Yellow border above 100.
- **Sent (24h)**.
- **Failed (24h)**, with a "since launch" total in the helper line.
- **Avg latency** from create to sent in the last 24h.

**Per-type rollup** materialised from the catalog so unused types
stay visible at 0/0/0 instead of disappearing.

**Recent activity** table (50 most recent rows) with status, address,
attempts, last-error tooltip, and a per-row **Retry** button on
failed rows. Retry is optimistic with revert-on-error; server-side
retry is idempotent (only flips rows still in `failed`).

## Where

Backend: `apps/portal-api/src/notifications/admin.controller.ts`
under `@UseGuards(AdminGuard)`. Registered in **AdminModule** (not
NotificationsModule) to avoid a circular import.

Frontend: `apps/portal-web/src/app/admin/notifications/{page,notifications-admin-view}.tsx`.
Linked from the Admin section of the left rail.

## Quality gate

- `pnpm typecheck` passes
- `pnpm lint` passes (existing import-type warnings only)
- `pnpm test` passes

Closes #130.
