### PR TITLE
fix(auth): skip NextAuth provider picker; jump straight to Keycloak (#136)

### DIFF
--- a/apps/portal-web/src/app/public-landing.tsx
+++ b/apps/portal-web/src/app/public-landing.tsx
@@ -90,7 +90,7 @@ export function PublicLanding({ data }: Props) {
                 portal account, sign in to see content shared with you.
               </p>
               <Link
-                href="/api/auth/signin"
+                href="/signin"
                 className="mt-4 inline-flex h-9 items-center gap-1.5 rounded-md bg-accent px-3 text-sm font-medium text-accent-foreground shadow-card hover:opacity-90"
               >
                 <LogIn className="h-4 w-4" />
@@ -110,7 +110,7 @@ export function PublicLanding({ data }: Props) {
         // the page has something the user can actually do.
         <section className="flex flex-1 items-center justify-center px-6 py-12">
           <Link
-            href="/api/auth/signin"
+            href="/signin"
             className="inline-flex h-11 items-center gap-2 rounded-md bg-accent px-5 text-base font-medium text-accent-foreground shadow-card hover:opacity-90"
           >
             <LogIn className="h-5 w-5" />
@@ -136,7 +136,7 @@ function TopBar({ orgName }: { orgName: string }) {
         </span>
       </div>
       <Link
-        href="/api/auth/signin"
+        href="/signin"
         className="inline-flex h-9 items-center gap-1.5 rounded-md bg-accent px-3 text-sm font-medium text-accent-foreground hover:opacity-90"
       >
         <LogIn className="h-4 w-4" />

--- a/apps/portal-web/src/app/signin/page.tsx
+++ b/apps/portal-web/src/app/signin/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { signIn } from 'next-auth/react';
+
+/**
+ * Custom sign-in page wired to NextAuth via authOptions.pages.signIn.
+ *
+ * When NextAuth has only one provider, the default /api/auth/signin
+ * shows a one-button "Sign in with Keycloak" picker -- a useless extra
+ * click since there's nothing to pick. We override pages.signIn so
+ * NextAuth routes its sign-in flow through this page instead, and we
+ * call signIn('keycloak', { callbackUrl }) on mount to drop the user
+ * straight into Keycloak's hosted login.
+ *
+ * The visible "Continue to Keycloak" link is the noscript / late-JS
+ * fallback. In the normal case the useEffect fires before the user
+ * sees it, so they only ever land on Keycloak's own login.
+ */
+export default function SignInPage() {
+  const params = useSearchParams();
+  // NextAuth normally appends ?callbackUrl=... so the user lands back
+  // where they were trying to go after auth. Honor it; default to / so
+  // a direct visit to /signin still works.
+  const callbackUrl = params.get('callbackUrl') ?? '/';
+
+  useEffect(() => {
+    void signIn('keycloak', { callbackUrl });
+  }, [callbackUrl]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-surface-0 p-4">
+      <div className="rounded-md border border-border bg-surface-1 px-6 py-5 text-center shadow-card">
+        <p className="text-sm text-ink-1">Redirecting to sign in...</p>
+        <p className="mt-2 text-xs text-muted">
+          If nothing happens,{' '}
+          <a
+            href={`/api/auth/signin/keycloak?callbackUrl=${encodeURIComponent(
+              callbackUrl,
+            )}`}
+            className="underline hover:text-ink-0"
+          >
+            continue to Keycloak
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/portal-web/src/components/app-shell.tsx
+++ b/apps/portal-web/src/components/app-shell.tsx
@@ -144,7 +144,7 @@ export async function AppShell({ children }: { children: ReactNode }) {
               />
             ) : (
               <Link
-                href="/api/auth/signin"
+                href="/signin"
                 className="inline-flex h-9 items-center rounded-md bg-accent px-3 text-sm font-medium text-accent-foreground hover:opacity-90"
               >
                 Sign in

--- a/apps/portal-web/src/lib/api.ts
+++ b/apps/portal-web/src/lib/api.ts
@@ -25,7 +25,9 @@ export async function apiFetch<T>(path: string, init: RequestInit = {}): Promise
   const session = (await getServerSession(authOptions)) as SessionWithToken | null;
   const tSession = trace ? Date.now() : 0;
   if (!session?.accessToken) {
-    redirect('/api/auth/signin');
+    // Redirect via the custom /signin so the user skips the
+    // default provider picker (we have only one provider).
+    redirect('/signin');
   }
   const res = await fetch(`${API_BASE}${path}`, {
     ...init,

--- a/apps/portal-web/src/lib/auth.ts
+++ b/apps/portal-web/src/lib/auth.ts
@@ -131,6 +131,11 @@ export const authOptions: NextAuthOptions = {
     },
   },
   session: { strategy: 'jwt' },
+  // We have only one provider (Keycloak). Override the default
+  // /api/auth/signin picker page with a custom /signin that
+  // immediately redirects to Keycloak; saves the user a useless
+  // "Sign in with Keycloak" click. See app/signin/page.tsx.
+  pages: { signIn: '/signin' },
 };
 
 export type SessionWithToken = import('next-auth').Session & {

--- a/apps/portal-web/src/middleware.ts
+++ b/apps/portal-web/src/middleware.ts
@@ -10,7 +10,11 @@ import { withAuth } from 'next-auth/middleware';
 
 export default withAuth({
   pages: {
-    signIn: '/api/auth/signin',
+    // Mirror authOptions.pages.signIn so middleware redirects skip
+    // the default provider picker and go straight to /signin, which
+    // immediately calls signIn('keycloak'). One provider == one less
+    // click for the user.
+    signIn: '/signin',
   },
 });
 


### PR DESCRIPTION
The default `/api/auth/signin` page shows a "Sign in with Keycloak"
button -- a useless extra click since Keycloak is the only configured
provider.

## What changes

Override `pages.signIn` (in both `authOptions` and the `withAuth`
middleware) to point at a new custom `/signin` route that immediately
calls `signIn('keycloak', { callbackUrl })` on mount, dropping the
user straight onto Keycloak's hosted login.

The new page renders a minimal "Redirecting to sign in..." card with
a `continue to Keycloak` link as the no-script / late-JS fallback.

Existing href references (`/api/auth/signin` in `app-shell`,
`public-landing`, `lib/api` redirect) are repointed at `/signin` so
the picker is unreachable through normal flows.

## Future-proofing

When we add a second IdP (SAML, separate OIDC, Google Workspace, etc),
revert `pages.signIn` to the default and the picker is back. One
line per location.

## Quality gate

- `pnpm typecheck` passes
- `pnpm lint` passes (existing import-type warnings only)
- `pnpm test` passes

Closes #136.
