### PR TITLE
feat(notifications): admin SMTP / org defaults / template preview (#137)

### DIFF
--- a/apps/portal-api/prisma/migrations/20260428040000_admin_notifications_config/migration.sql
+++ b/apps/portal-api/prisma/migrations/20260428040000_admin_notifications_config/migration.sql
@@ -1,0 +1,40 @@
+-- Admin notifications config (#137).
+--
+-- Two new tables: a singleton-ish key/value bag for SMTP and other
+-- platform settings the admin should be able to edit from the UI
+-- (no env file editing), and a per-(type, channel) override table
+-- for org-wide defaults that beat the code defaults in
+-- notification-types.ts.
+--
+-- system_setting:
+--   key             primary key, free string ('smtp', etc.)
+--   value           JSON for non-secret fields
+--   encrypted_secret + encrypted_secret_iv: AES-256-GCM payload from
+--                   credential-cipher.ts. Used today for the SMTP
+--                   password; null for keys with no secret.
+--   updated_*       last write timestamp + actor (Keycloak sub) so an
+--                   admin can see when SMTP was last changed and by
+--                   whom.
+--
+-- notification_type_default:
+--   (type, channel) primary key. Presence of a row overrides the
+--   code default in notification-types.ts at the org-wide level.
+--   When a user's notification_preference also exists, that still
+--   wins. Sparse: an admin keeping the code default has no row.
+
+CREATE TABLE "system_setting" (
+    "key"                 TEXT     NOT NULL PRIMARY KEY,
+    "value"               JSONB    NOT NULL DEFAULT '{}'::jsonb,
+    "encrypted_secret"    TEXT,
+    "encrypted_secret_iv" TEXT,
+    "updated_at"          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    "updated_by"          UUID
+);
+
+CREATE TABLE "notification_type_default" (
+    "type"       TEXT NOT NULL,
+    "channel"    TEXT NOT NULL,
+    "enabled"    BOOLEAN NOT NULL,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY ("type", "channel")
+);

--- a/apps/portal-api/prisma/schema.prisma
+++ b/apps/portal-api/prisma/schema.prisma
@@ -737,3 +737,38 @@ model Notification {
   @@map("notification")
 }
 
+/// Singleton-ish key/value bag for platform settings the admin can
+/// edit from the UI (no env file editing). Today: SMTP config under
+/// key='smtp'. JSON column carries non-secret fields; the encrypted
+/// pair carries any secret material (SMTP password) via the existing
+/// AES-256-GCM credential cipher with key as AAD.
+///
+/// When multi-org tenancy lands (#47), this gets an orgId column and
+/// a composite primary key. For now there's a single row per key
+/// platform-wide.
+model SystemSetting {
+  key                String   @id
+  value              Json     @default("{}")
+  encryptedSecret    String?  @map("encrypted_secret")
+  encryptedSecretIv  String?  @map("encrypted_secret_iv")
+  updatedAt          DateTime @updatedAt @map("updated_at")
+  updatedBy          String?  @map("updated_by") @db.Uuid
+
+  @@map("system_setting")
+}
+
+/// Per-(NotificationType, NotificationChannel) org-wide override of
+/// the code-level default in notification-types.ts. Sparse: an admin
+/// keeping the code default has no row. When materialising a user's
+/// effective state, the chain is:
+///   notification_preference (user-specific) > notification_type_default (org) > code default
+model NotificationTypeDefault {
+  type      NotificationType
+  channel   NotificationChannel
+  enabled   Boolean
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@id([type, channel])
+  @@map("notification_type_default")
+}
+

--- a/apps/portal-api/src/admin/keycloak-admin.service.ts
+++ b/apps/portal-api/src/admin/keycloak-admin.service.ts
@@ -8,6 +8,8 @@ import {
   ServiceUnavailableException,
 } from '@nestjs/common';
 
+import { SystemSettingsService } from '../notifications/system-settings.service.js';
+
 /**
  * Thin wrapper around Keycloak's Admin REST API.
  *
@@ -84,6 +86,8 @@ export class KeycloakAdminService implements OnModuleInit {
   private readonly logger = new Logger(KeycloakAdminService.name);
   private tokenCache: TokenCache | null = null;
 
+  constructor(private readonly settings: SystemSettingsService) {}
+
   /**
    * On boot, push our SMTP_* env vars into the Keycloak realm so that
    * Keycloak's built-in flows (invite emails, forgot-password, email
@@ -102,7 +106,11 @@ export class KeycloakAdminService implements OnModuleInit {
    */
   async onModuleInit(): Promise<void> {
     if (!this.isConfigured()) return;
-    if (!process.env.SMTP_HOST) return;
+    // Skip the sync when SMTP isn't configured yet (no DB row, no
+    // env). The admin can configure SMTP via /admin/notifications
+    // and saveSmtp() will trigger the sync at that point.
+    const cfg = await this.settings.getSmtpConfig();
+    if (!cfg || !cfg.host) return;
     try {
       await this.syncRealmSmtp();
     } catch (err) {
@@ -435,36 +443,26 @@ export class KeycloakAdminService implements OnModuleInit {
    * only onModuleInit calls it.
    */
   async syncRealmSmtp(): Promise<Record<string, string>> {
-    const host = process.env.SMTP_HOST;
-    if (!host) {
-      throw new Error('SMTP_HOST is not set');
+    const cfg = await this.settings.getSmtpConfig();
+    if (!cfg || !cfg.host) {
+      throw new Error(
+        'SMTP not configured. Save SMTP via /admin/notifications first.',
+      );
     }
-    const port = process.env.SMTP_PORT ?? '587';
-    const user = process.env.SMTP_USER ?? '';
-    const pass = process.env.SMTP_PASS ?? '';
-    const fromRaw =
-      process.env.SMTP_FROM ?? 'GratisGIS <noreply@gratisgis.local>';
-    // SMTP_FROM commonly looks like 'Display Name <addr@host>'. Split
-    // for Keycloak which wants address + display name in separate keys.
-    const { from, fromDisplayName } = parseFrom(fromRaw);
-    const secure =
-      (process.env.SMTP_SECURE ?? '').toLowerCase() === 'true' ||
-      port === '465';
-
     // Keycloak's smtpServer is Map<String,String>: stringified booleans,
     // ports, etc. STARTTLS is the default for port 587 so we set
     // starttls=true and ssl=false there; ssl=true on 465.
     const smtpServer: Record<string, string> = {
-      host,
-      port,
-      from,
-      fromDisplayName,
-      ssl: secure ? 'true' : 'false',
-      starttls: secure ? 'false' : 'true',
-      auth: user ? 'true' : 'false',
+      host: cfg.host,
+      port: String(cfg.port),
+      from: cfg.fromAddress,
+      fromDisplayName: cfg.fromDisplayName,
+      ssl: cfg.secure ? 'true' : 'false',
+      starttls: cfg.secure ? 'false' : 'true',
+      auth: cfg.user ? 'true' : 'false',
     };
-    if (user) smtpServer.user = user;
-    if (pass) smtpServer.password = pass;
+    if (cfg.user) smtpServer.user = cfg.user;
+    if (cfg.password) smtpServer.password = cfg.password;
 
     const token = await this.getAccessToken();
     // Keycloak's PUT on the realm endpoint accepts a partial body and
@@ -493,7 +491,7 @@ export class KeycloakAdminService implements OnModuleInit {
       );
     }
     this.logger.log(
-      `Synced SMTP config to Keycloak realm '${this.realm}' (host=${host} port=${port} secure=${secure})`,
+      `Synced SMTP config to Keycloak realm '${this.realm}' (host=${cfg.host} port=${cfg.port} secure=${cfg.secure})`,
     );
     return smtpServer;
   }
@@ -511,17 +509,3 @@ function combineName(
   return username;
 }
 
-/**
- * Split an RFC-5322 style "Display Name <addr@host>" string into the
- * pieces Keycloak's smtpServer map wants. Falls back to treating the
- * whole input as the address if no angle brackets are present.
- */
-function parseFrom(raw: string): { from: string; fromDisplayName: string } {
-  const m = raw.match(/^\s*(?:"?(.*?)"?\s*)?<([^>]+)>\s*$/);
-  if (m) {
-    const display = (m[1] ?? '').trim();
-    const addr = (m[2] ?? '').trim();
-    return { from: addr, fromDisplayName: display };
-  }
-  return { from: raw.trim(), fromDisplayName: '' };
-}

--- a/apps/portal-api/src/notifications/admin.controller.ts
+++ b/apps/portal-api/src/notifications/admin.controller.ts
@@ -1,10 +1,68 @@
-import { Controller, Get, Param, Post, UseGuards } from '@nestjs/common';
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
-import { NotificationStatus, NotificationType } from '@prisma/client';
+import {
+  IsBoolean,
+  IsEmail,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
+import {
+  NotificationChannel,
+  NotificationStatus,
+  NotificationType,
+} from '@prisma/client';
 
 import { AdminGuard } from '../admin/admin.guard.js';
+import { CurrentUser } from '../auth/current-user.decorator.js';
+import type { AuthUser } from '../auth/auth-sync.service.js';
 import { PrismaService } from '../prisma/prisma.service.js';
-import { NOTIFICATION_TYPES } from './notification-types.js';
+import { NOTIFICATION_TYPES, getTypeMeta } from './notification-types.js';
+import { SystemSettingsService, type SmtpConfig } from './system-settings.service.js';
+import { NotificationTypeDefaultService } from './notification-type-default.service.js';
+import { EmailTransport } from './email-transport.js';
+import { renderNotification } from './templates.js';
+import { SAMPLE_PAYLOADS } from './sample-payloads.js';
+import { KeycloakAdminService } from '../admin/keycloak-admin.service.js';
+
+class SaveSmtpDto {
+  @IsBoolean() enabled!: boolean;
+  @IsString() host!: string;
+  @IsInt() @Min(1) @Max(65535) port!: number;
+  @IsBoolean() secure!: boolean;
+  @IsString() fromAddress!: string;
+  @IsString() fromDisplayName!: string;
+  @IsString() user!: string;
+  /** Omit to keep the existing password; empty string to clear. */
+  @IsOptional() @IsString() password?: string;
+}
+
+class TestSmtpDto {
+  @IsEmail() to!: string;
+  /** When provided, send the test against this unsaved config so the
+   *  admin can verify before clicking Save. Optional; falls back to
+   *  the stored config. */
+  @IsOptional() config?: SaveSmtpDto;
+}
+
+class PutDefaultDto {
+  @IsEnum(NotificationType) type!: NotificationType;
+  @IsEnum(NotificationChannel) channel!: NotificationChannel;
+  @IsBoolean() enabled!: boolean;
+}
 
 interface StatsPayload {
   /** Total queued + sending rows. The "in-flight" backlog. */
@@ -62,7 +120,13 @@ interface RecentRow {
 @UseGuards(AdminGuard)
 @Controller('admin/notifications')
 export class NotificationsAdminController {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly settings: SystemSettingsService,
+    private readonly defaults: NotificationTypeDefaultService,
+    private readonly transport: EmailTransport,
+    private readonly keycloak: KeycloakAdminService,
+  ) {}
 
   @Get('stats')
   async stats(): Promise<StatsPayload> {
@@ -204,4 +268,223 @@ export class NotificationsAdminController {
     });
     return { retried: r.count > 0 };
   }
+
+  // ---- SMTP config (#137) ---------------------------------------
+
+  /** Current effective SMTP config. Password is never returned --
+   *  only `hasPassword` so the form can show "stored" state without
+   *  leaking secret material to the browser. */
+  @Get('smtp')
+  async getSmtp(): Promise<SmtpStatePayload> {
+    const cfg = await this.settings.getSmtpConfig();
+    if (!cfg) {
+      return {
+        configured: false,
+        enabled: false,
+        host: '',
+        port: 587,
+        secure: false,
+        fromAddress: '',
+        fromDisplayName: '',
+        user: '',
+        hasPassword: false,
+      };
+    }
+    return {
+      configured: true,
+      enabled: cfg.enabled,
+      host: cfg.host,
+      port: cfg.port,
+      secure: cfg.secure,
+      fromAddress: cfg.fromAddress,
+      fromDisplayName: cfg.fromDisplayName,
+      user: cfg.user,
+      hasPassword: cfg.hasPassword,
+    };
+  }
+
+  /**
+   * Persist SMTP config. Reloads the EmailTransport so the next send
+   * uses the new credentials, and re-runs the Keycloak realm SMTP
+   * sync so invite / password-reset emails ride the new relay too.
+   * Both reloads are best-effort: a failure here should not block
+   * the admin's Save (the row is written either way).
+   */
+  @Put('smtp')
+  async saveSmtp(
+    @CurrentUser() me: AuthUser,
+    @Body() dto: SaveSmtpDto,
+  ): Promise<SmtpStatePayload> {
+    const input: Omit<SmtpConfig, 'hasPassword'> = {
+      enabled: dto.enabled,
+      host: dto.host,
+      port: dto.port,
+      secure: dto.secure,
+      fromAddress: dto.fromAddress,
+      fromDisplayName: dto.fromDisplayName,
+      user: dto.user,
+    };
+    if (dto.password !== undefined) input.password = dto.password;
+    await this.settings.saveSmtpConfig(input, me.id);
+    // Reload the in-process transport pool first so worker drains
+    // pick up fresh creds without an api restart.
+    try {
+      await this.transport.reload();
+    } catch {
+      // Reload failures don't unwind the save -- next worker tick
+      // will lazy-rebuild on demand.
+    }
+    // Push the new config into the Keycloak realm so invite /
+    // forgot-password / verify-email emails share the relay.
+    if (this.keycloak.isConfigured()) {
+      try {
+        await this.keycloak.syncRealmSmtp();
+      } catch {
+        // Logged inside syncRealmSmtp; surface to the admin via
+        // the next "send test" attempt rather than breaking save.
+      }
+    }
+    return this.getSmtp();
+  }
+
+  /**
+   * One-shot test send. When `config` is provided we send through a
+   * single-use transport built from those (possibly unsaved) creds
+   * so the admin can verify before clicking Save; without it we use
+   * the stored config.
+   */
+  @Post('smtp/test')
+  @HttpCode(200)
+  async testSmtp(@Body() dto: TestSmtpDto): Promise<{ ok: boolean; error?: string }> {
+    const builtCfg: SmtpConfig | null = await (async () => {
+      if (!dto.config) return this.settings.getSmtpConfig();
+      const c: SmtpConfig = {
+        enabled: dto.config.enabled,
+        host: dto.config.host,
+        port: dto.config.port,
+        secure: dto.config.secure,
+        fromAddress: dto.config.fromAddress,
+        fromDisplayName: dto.config.fromDisplayName,
+        user: dto.config.user,
+        password: dto.config.password,
+        hasPassword:
+          typeof dto.config.password === 'string' &&
+          dto.config.password.length > 0,
+      };
+      // If admin left password blank in the form but a stored one
+      // exists, fall back to the stored value so the test exercises
+      // the real config the worker would use.
+      if (c.password === undefined) {
+        const stored = await this.settings.getSmtpConfig();
+        if (stored?.password) c.password = stored.password;
+      }
+      return c;
+    })();
+    if (!builtCfg || !builtCfg.host) {
+      return { ok: false, error: 'SMTP host is empty' };
+    }
+    const cfg: SmtpConfig = builtCfg;
+    try {
+      await this.transport.sendTest(
+        cfg,
+        dto.to,
+        'GratisGIS notifications: test email',
+        'This is a test email from your GratisGIS portal. ' +
+          'If you can read this, your SMTP relay is working.',
+        '<p>This is a test email from your GratisGIS portal.</p>' +
+          '<p>If you can read this, your SMTP relay is working.</p>',
+      );
+      return { ok: true };
+    } catch (err) {
+      return {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  // ---- Per-type org defaults (#137) -----------------------------
+
+  @Get('defaults')
+  async listDefaults(): Promise<DefaultsPayload> {
+    return { rows: await this.defaults.list() };
+  }
+
+  @Put('defaults')
+  async putDefault(@Body() dto: PutDefaultDto): Promise<{ ok: true }> {
+    await this.defaults.setOverride(dto.type, dto.channel, dto.enabled);
+    return { ok: true };
+  }
+
+  // ---- Template preview (#137) ----------------------------------
+
+  /**
+   * Render a template against a hardcoded sample payload so admins
+   * can see what each notification looks like without firing a
+   * real trigger. Uses PORTAL_BASE_URL / PORTAL_NAME for context
+   * just like a real send.
+   */
+  @Get('preview/:type')
+  async preview(
+    @Param('type') typeRaw: string,
+  ): Promise<PreviewPayload> {
+    const type = typeRaw as NotificationType;
+    const meta = getTypeMeta(type);
+    if (!meta) {
+      throw new BadRequestException(`Unknown notification type: ${typeRaw}`);
+    }
+    const payload = SAMPLE_PAYLOADS[type];
+    if (payload === undefined) {
+      throw new BadRequestException(
+        `No sample payload registered for ${type}. Add one in sample-payloads.ts.`,
+      );
+    }
+    const orgLabel = process.env.PORTAL_NAME ?? 'GratisGIS';
+    const baseUrl = process.env.PORTAL_BASE_URL ?? 'http://localhost:3000';
+    const rendered = renderNotification(type, payload, { orgLabel, baseUrl });
+    if (!rendered) {
+      throw new BadRequestException(
+        `No renderer registered for ${type}. Add one in templates.ts.`,
+      );
+    }
+    return {
+      type,
+      label: meta.label,
+      subject: rendered.subject,
+      text: rendered.text,
+      html: rendered.html,
+    };
+  }
+}
+
+interface SmtpStatePayload {
+  configured: boolean;
+  enabled: boolean;
+  host: string;
+  port: number;
+  secure: boolean;
+  fromAddress: string;
+  fromDisplayName: string;
+  user: string;
+  hasPassword: boolean;
+}
+
+interface DefaultsPayload {
+  rows: Array<{
+    type: NotificationType;
+    channel: NotificationChannel;
+    label: string;
+    category: string;
+    codeDefault: boolean;
+    effective: boolean;
+    isOverride: boolean;
+  }>;
+}
+
+interface PreviewPayload {
+  type: NotificationType;
+  label: string;
+  subject: string;
+  text: string;
+  html: string;
 }

--- a/apps/portal-api/src/notifications/email-transport.ts
+++ b/apps/portal-api/src/notifications/email-transport.ts
@@ -1,89 +1,94 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
 import nodemailer, { type Transporter } from 'nodemailer';
 
+import {
+  SystemSettingsService,
+  type SmtpConfig,
+} from './system-settings.service.js';
+
 /**
- * Thin nodemailer wrapper: build the SMTP transport from env once,
- * expose a single `send()` the worker calls per queued
- * notification. Connection pooling is on by default; nodemailer
- * keeps a small pool of authenticated SMTP connections open and
- * reuses them across messages.
+ * Thin nodemailer wrapper sourced from SystemSettingsService (#137).
+ * The DB row written by the admin /admin/notifications SMTP form is
+ * the source of truth; env vars (SMTP_HOST etc.) act as a seed for
+ * fresh deployments before the admin saves anything.
  *
- * Configuration is env-only for Phase 1. Phase 2 may move SMTP
- * creds into an encrypted DB table (mirroring ItemCredential) so
- * org admins can change SMTP settings without a redeploy. Today
- * the env wins so a typo can't lock the queue.
- *
- * Required env (NOTIFICATIONS_ENABLED must be 'true' for any of
- * this to matter):
- *   SMTP_HOST   - smtp.example.org
- *   SMTP_PORT   - 587 (default)
- *   SMTP_USER   - mailbox username (optional for unauthed relays)
- *   SMTP_PASS   - mailbox password (optional, paired with SMTP_USER)
- *   SMTP_FROM   - "GratisGIS <noreply@example.org>"
- *   SMTP_SECURE - 'true' to force TLS-on-connect (defaults: true on
- *                 port 465, false elsewhere). Most modern relays
- *                 use STARTTLS on 587 which nodemailer negotiates
- *                 automatically when SMTP_SECURE=false.
+ * Connection pooling is on by default; nodemailer keeps a small pool
+ * of authenticated SMTP connections open and reuses them across
+ * messages. The pool is rebuilt whenever reload() is called -- which
+ * the admin save endpoint triggers so the next send picks up new
+ * creds without an api restart.
  */
 @Injectable()
 export class EmailTransport {
   private readonly log = new Logger(EmailTransport.name);
   private transporter: Transporter | null = null;
-  private readonly fromAddress: string;
-  private readonly enabled: boolean;
+  private cachedFrom: string = 'GratisGIS <noreply@gratisgis.local>';
 
-  constructor(private readonly cfg: ConfigService) {
-    this.enabled =
-      (this.cfg.get<string>('NOTIFICATIONS_ENABLED') ?? '').toLowerCase() ===
-      'true';
-    this.fromAddress =
-      this.cfg.get<string>('SMTP_FROM') ?? 'GratisGIS <noreply@gratisgis.local>';
-  }
+  constructor(private readonly settings: SystemSettingsService) {}
 
   /**
-   * Lazily build the transporter on first send. Defers any "is the
-   * SMTP host reachable" failures to the moment the worker actually
-   * has something to deliver, rather than the api boot where a
-   * misconfigured SMTP would crash startup for everyone.
+   * Lazily build the transporter on first send (or on reload after an
+   * admin save). Defers any "is the SMTP host reachable" failure to
+   * the moment the worker actually has something to deliver, rather
+   * than at api boot where a misconfigured SMTP would crash startup
+   * for everyone.
    */
-  private getTransporter(): Transporter | null {
-    if (!this.enabled) return null;
+  private async getTransporter(): Promise<Transporter | null> {
     if (this.transporter) return this.transporter;
-    const host = this.cfg.get<string>('SMTP_HOST');
-    if (!host) {
+    const cfg = await this.settings.getSmtpConfig();
+    if (!cfg || !cfg.enabled) return null;
+    if (!cfg.host) {
       this.log.warn(
-        'NOTIFICATIONS_ENABLED=true but SMTP_HOST is unset; email delivery disabled.',
+        'SMTP enabled but no host configured; email delivery disabled.',
       );
       return null;
     }
-    const portRaw = this.cfg.get<string>('SMTP_PORT') ?? '587';
-    const port = Number(portRaw);
-    if (!Number.isFinite(port) || port < 1 || port > 65535) {
-      this.log.warn(`SMTP_PORT=${portRaw} is invalid; email delivery disabled.`);
+    if (!Number.isFinite(cfg.port) || cfg.port < 1 || cfg.port > 65535) {
+      this.log.warn(
+        `SMTP port=${cfg.port} is invalid; email delivery disabled.`,
+      );
       return null;
     }
-    const secureRaw = (this.cfg.get<string>('SMTP_SECURE') ?? '').toLowerCase();
-    // Default to true on port 465 (SMTPS), false elsewhere -- the
-    // canonical pairing nodemailer's docs recommend.
-    const secure = secureRaw === 'true' || (secureRaw === '' && port === 465);
-    const user = this.cfg.get<string>('SMTP_USER');
-    const pass = this.cfg.get<string>('SMTP_PASS');
-
+    this.cachedFrom = formatFrom(cfg);
     this.transporter = nodemailer.createTransport({
-      host,
-      port,
-      secure,
-      ...(user ? { auth: { user, pass: pass ?? '' } } : {}),
+      host: cfg.host,
+      port: cfg.port,
+      secure: cfg.secure,
+      ...(cfg.user
+        ? { auth: { user: cfg.user, pass: cfg.password ?? '' } }
+        : {}),
       pool: true,
     });
-    this.log.log(`SMTP transport configured: host=${host} port=${port} secure=${secure}`);
+    this.log.log(
+      `SMTP transport configured: host=${cfg.host} port=${cfg.port} secure=${cfg.secure}`,
+    );
     return this.transporter;
   }
 
-  /** True when env is configured well enough to attempt delivery. */
-  isAvailable(): boolean {
-    return this.getTransporter() !== null;
+  /** True when the active config is good enough to attempt delivery. */
+  async isAvailable(): Promise<boolean> {
+    return (await this.getTransporter()) !== null;
+  }
+
+  /**
+   * Reload the transport from current settings -- invoked by the
+   * admin save endpoint so the very next send uses the new config.
+   * Closes the old pool first so existing TCP connections don't
+   * stick around with stale auth.
+   */
+  async reload(): Promise<void> {
+    const old = this.transporter;
+    this.transporter = null;
+    this.settings.invalidateSmtpCache();
+    try {
+      old?.close();
+    } catch {
+      // Closing a partially-initialised pool can throw on some
+      // nodemailer versions; ignore -- we're throwing it away
+      // anyway.
+    }
+    // Eagerly rebuild so the next send is hot.
+    await this.getTransporter();
   }
 
   /**
@@ -98,16 +103,64 @@ export class EmailTransport {
     text: string;
     html: string;
   }): Promise<void> {
-    const t = this.getTransporter();
+    const t = await this.getTransporter();
     if (!t) {
       throw new Error('SMTP transport not configured');
     }
     await t.sendMail({
-      from: this.fromAddress,
+      from: this.cachedFrom,
       to: opts.to,
       subject: opts.subject,
       text: opts.text,
       html: opts.html,
     });
   }
+
+  /**
+   * One-shot test send that bypasses the queue and pool entirely.
+   * Used by /admin/notifications/smtp/test so admins can verify
+   * config without enqueueing a real notification. Builds a fresh
+   * single-use transport from the supplied (possibly unsaved)
+   * config so the admin can hit Send test before clicking Save.
+   */
+  async sendTest(
+    cfg: SmtpConfig,
+    to: string,
+    subject: string,
+    text: string,
+    html: string,
+  ): Promise<void> {
+    if (!cfg.host) throw new Error('SMTP host is empty');
+    const transport = nodemailer.createTransport({
+      host: cfg.host,
+      port: cfg.port,
+      secure: cfg.secure,
+      ...(cfg.user
+        ? { auth: { user: cfg.user, pass: cfg.password ?? '' } }
+        : {}),
+    });
+    try {
+      await transport.sendMail({
+        from: formatFrom(cfg),
+        to,
+        subject,
+        text,
+        html,
+      });
+    } finally {
+      try {
+        transport.close();
+      } catch {
+        // Same defensive close as in reload()
+      }
+    }
+  }
+}
+
+function formatFrom(cfg: SmtpConfig): string {
+  if (!cfg.fromAddress) return 'GratisGIS <noreply@gratisgis.local>';
+  if (cfg.fromDisplayName) {
+    return `${cfg.fromDisplayName} <${cfg.fromAddress}>`;
+  }
+  return cfg.fromAddress;
 }

--- a/apps/portal-api/src/notifications/notification-type-default.service.ts
+++ b/apps/portal-api/src/notifications/notification-type-default.service.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@nestjs/common';
+import { NotificationChannel, NotificationType } from '@prisma/client';
+
+import { PrismaService } from '../prisma/prisma.service.js';
+import {
+  NOTIFICATION_TYPES,
+  getTypeMeta,
+} from './notification-types.js';
+
+/**
+ * Per-(NotificationType, NotificationChannel) org-wide default
+ * service (#137). Wraps the `notification_type_default` table and
+ * implements the precedence chain a runtime evaluator needs:
+ *
+ *   user notification_preference  >  org notification_type_default  >  code default
+ *
+ * Sparse-write contract: a row that matches the code default is
+ * deleted so the table stays minimal -- a future code-default flip
+ * naturally affects every (org, type, channel) combo that hasn't
+ * been overridden.
+ */
+@Injectable()
+export class NotificationTypeDefaultService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Effective default for a (type, channel). Resolves the override
+   * with a single point lookup; falls back to the code default when
+   * no row exists.
+   */
+  async effectiveDefault(
+    type: NotificationType,
+    channel: NotificationChannel,
+  ): Promise<boolean> {
+    const row = await this.prisma.notificationTypeDefault.findUnique({
+      where: { type_channel: { type, channel } },
+    });
+    if (row) return row.enabled;
+    const meta = getTypeMeta(type);
+    if (!meta) return true;
+    return meta.defaultByChannel[channel] ?? true;
+  }
+
+  /**
+   * Bulk version of effectiveDefault used by NotificationsService at
+   * dispatch time. Returns a Map keyed by `${type}|${channel}` so
+   * the caller can mix code-default and override lookups in one
+   * pass.
+   */
+  async loadOverrideMap(): Promise<Map<string, boolean>> {
+    const rows = await this.prisma.notificationTypeDefault.findMany();
+    return new Map(rows.map((r) => [`${r.type}|${r.channel}`, r.enabled]));
+  }
+
+  /**
+   * Materialised list for the admin page: every (type, channel) the
+   * catalog declares, with code default + current effective default
+   * + a flag indicating whether it's an admin override.
+   */
+  async list(): Promise<
+    Array<{
+      type: NotificationType;
+      channel: NotificationChannel;
+      label: string;
+      category: string;
+      codeDefault: boolean;
+      effective: boolean;
+      isOverride: boolean;
+    }>
+  > {
+    const overrides = await this.loadOverrideMap();
+    const out: Array<{
+      type: NotificationType;
+      channel: NotificationChannel;
+      label: string;
+      category: string;
+      codeDefault: boolean;
+      effective: boolean;
+      isOverride: boolean;
+    }> = [];
+    for (const meta of NOTIFICATION_TYPES) {
+      for (const channel of meta.channels) {
+        const codeDefault = meta.defaultByChannel[channel] ?? true;
+        const overrideKey = `${meta.type}|${channel}`;
+        const isOverride = overrides.has(overrideKey);
+        const effective = isOverride
+          ? overrides.get(overrideKey)!
+          : codeDefault;
+        out.push({
+          type: meta.type,
+          channel,
+          label: meta.label,
+          category: meta.category,
+          codeDefault,
+          effective,
+          isOverride,
+        });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Upsert one (type, channel) override. When `enabled` matches the
+   * code default we delete the row to keep the table sparse -- same
+   * trick the per-user notification_preference table uses, for the
+   * same reason.
+   */
+  async setOverride(
+    type: NotificationType,
+    channel: NotificationChannel,
+    enabled: boolean,
+  ): Promise<void> {
+    const meta = getTypeMeta(type);
+    if (!meta || !meta.channels.includes(channel)) return;
+    const codeDefault = meta.defaultByChannel[channel] ?? true;
+    if (enabled === codeDefault) {
+      await this.prisma.notificationTypeDefault.deleteMany({
+        where: { type, channel },
+      });
+      return;
+    }
+    await this.prisma.notificationTypeDefault.upsert({
+      where: { type_channel: { type, channel } },
+      create: { type, channel, enabled },
+      update: { enabled },
+    });
+  }
+}

--- a/apps/portal-api/src/notifications/notifications.module.ts
+++ b/apps/portal-api/src/notifications/notifications.module.ts
@@ -7,6 +7,8 @@ import { NotificationsService } from './notifications.service.js';
 import { NotificationsWorker } from './notifications.worker.js';
 import { NotificationsCron } from './notifications-cron.service.js';
 import { NotificationPreferencesController } from './preferences.controller.js';
+import { SystemSettingsService } from './system-settings.service.js';
+import { NotificationTypeDefaultService } from './notification-type-default.service.js';
 
 /**
  * Cross-cutting notifications platform (#127). Other modules import
@@ -28,7 +30,19 @@ import { NotificationPreferencesController } from './preferences.controller.js';
     NotificationsWorker,
     NotificationsCron,
     EmailTransport,
+    SystemSettingsService,
+    NotificationTypeDefaultService,
   ],
-  exports: [NotificationsService],
+  // Export the platform settings + default services so the admin
+  // controller (registered in AdminModule, not here, to avoid a
+  // circular import) can inject them. EmailTransport is exported
+  // for the same reason -- the admin controller's "send test" path
+  // reuses the existing pool wrapper for one-shot delivery.
+  exports: [
+    NotificationsService,
+    SystemSettingsService,
+    NotificationTypeDefaultService,
+    EmailTransport,
+  ],
 })
 export class NotificationsModule {}

--- a/apps/portal-api/src/notifications/notifications.service.ts
+++ b/apps/portal-api/src/notifications/notifications.service.ts
@@ -8,6 +8,8 @@ import {
 } from '@prisma/client';
 
 import { PrismaService } from '../prisma/prisma.service.js';
+import { NotificationTypeDefaultService } from './notification-type-default.service.js';
+import { getTypeMeta } from './notification-types.js';
 
 /**
  * Public entry point for any service that wants to notify a user.
@@ -48,6 +50,7 @@ export class NotificationsService {
 
   constructor(
     private readonly prisma: PrismaService,
+    private readonly defaults: NotificationTypeDefaultService,
     cfg: ConfigService,
   ) {
     this.enabled =
@@ -80,11 +83,19 @@ export class NotificationsService {
         this.log.warn(`notify: user ${userId} not found, dropping ${type}`);
         return;
       }
-      // Resolve the per-(user, type, channel) preference; absence
-      // of a row is "use the default" which today is always true.
-      const prefs = await this.prisma.notificationPreference.findMany({
-        where: { userId, type },
-      });
+      // Resolve the per-(user, type, channel) preference and the
+      // org-wide override in parallel. Precedence chain at dispatch
+      // time:
+      //   user pref > org default override > code default
+      // An admin muting share_expiring platform-wide (#137) flips
+      // every user who hasn't explicitly opted in -- but a user who
+      // has explicitly opted in still wins.
+      const [prefs, overrides] = await Promise.all([
+        this.prisma.notificationPreference.findMany({
+          where: { userId, type },
+        }),
+        this.defaults.loadOverrideMap(),
+      ]);
       const prefByChannel = new Map(
         prefs.map((p) => [p.channel, p.enabled] as const),
       );
@@ -93,9 +104,15 @@ export class NotificationsService {
       // over a list here and pick the right address per channel.
       const channels: NotificationChannel[] = ['email'];
       for (const channel of channels) {
-        const enabled = prefByChannel.has(channel)
-          ? prefByChannel.get(channel)!
-          : defaultPreference(type, channel);
+        const userPref = prefByChannel.get(channel);
+        const overrideKey = `${type}|${channel}`;
+        const orgOverride = overrides.get(overrideKey);
+        const enabled =
+          userPref !== undefined
+            ? userPref
+            : orgOverride !== undefined
+              ? orgOverride
+              : codeDefault(type, channel);
         if (!enabled) continue;
         const address = resolveAddress(channel, user);
         if (!address) {
@@ -145,16 +162,18 @@ export class NotificationsService {
 }
 
 /**
- * Per-(type, channel) default opt-in. Today everything defaults to
- * on; the table override turns specific combinations off when the
- * user opts out via the (Phase 3) settings UI. Centralised here so
- * the service + the future preferences UI agree on the baseline.
+ * Code-level default opt-in derived from the catalog in
+ * notification-types.ts. Org admin overrides (notification_type_default)
+ * and per-user prefs (notification_preference) override this in
+ * dispatch.
  */
-function defaultPreference(
-  _type: NotificationType,
-  _channel: NotificationChannel,
+function codeDefault(
+  type: NotificationType,
+  channel: NotificationChannel,
 ): boolean {
-  return true;
+  const meta = getTypeMeta(type);
+  if (!meta) return true;
+  return meta.defaultByChannel[channel] ?? true;
 }
 
 /**

--- a/apps/portal-api/src/notifications/notifications.worker.ts
+++ b/apps/portal-api/src/notifications/notifications.worker.ts
@@ -73,9 +73,10 @@ export class NotificationsWorker {
       // this tick rather than overlap; the next one is 30s away.
       return;
     }
-    if (!this.transport.isAvailable()) {
+    if (!(await this.transport.isAvailable())) {
       // SMTP misconfigured. Logged once per process by EmailTransport;
-      // we silently skip ticks until env is fixed.
+      // we silently skip ticks until the admin saves SMTP via
+      // /admin/notifications and the transport reload picks it up.
       return;
     }
     this.busy = true;

--- a/apps/portal-api/src/notifications/preferences.controller.ts
+++ b/apps/portal-api/src/notifications/preferences.controller.ts
@@ -15,6 +15,7 @@ import {
   NOTIFICATION_TYPES,
   getTypeMeta,
 } from './notification-types.js';
+import { NotificationTypeDefaultService } from './notification-type-default.service.js';
 
 class UpsertPreferenceDto {
   @IsEnum(NotificationType)
@@ -68,18 +69,27 @@ interface PreferencesPayload {
 @ApiBearerAuth()
 @Controller('users/me/notification-preferences')
 export class NotificationPreferencesController {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly defaults: NotificationTypeDefaultService,
+  ) {}
 
   /** Materialized per-(type, channel) state, ready for the UI to
    *  render. Combines the catalog from notification-types.ts with
-   *  any rows the user has stored. Channels they haven't touched
-   *  fall through to the default + isDefault: true. */
+   *  any user rows AND any org-wide override rows (#137). The
+   *  "default" the user sees is the org default if one exists,
+   *  otherwise the code default -- so when an admin mutes
+   *  share_expiring platform-wide, every user with no opt-in row
+   *  sees the toggle as off-by-default. */
   @Get()
   async list(@CurrentUser() user: AuthUser): Promise<PreferencesPayload> {
-    const rows = await this.prisma.notificationPreference.findMany({
-      where: { userId: user.id },
-      select: { type: true, channel: true, enabled: true },
-    });
+    const [rows, overrideMap] = await Promise.all([
+      this.prisma.notificationPreference.findMany({
+        where: { userId: user.id },
+        select: { type: true, channel: true, enabled: true },
+      }),
+      this.defaults.loadOverrideMap(),
+    ]);
     // Build a (type, channel) -> stored row index for O(1) merge below.
     const byKey = new Map<string, boolean>();
     for (const r of rows) {
@@ -92,6 +102,9 @@ export class NotificationPreferencesController {
         const preferences = {} as Record<NotificationChannel, PreferenceState>;
         for (const channel of meta.channels) {
           const key = `${meta.type}|${channel}`;
+          const orgDefault = overrideMap.has(key)
+            ? overrideMap.get(key)!
+            : meta.defaultByChannel[channel];
           if (byKey.has(key)) {
             preferences[channel] = {
               enabled: byKey.get(key)!,
@@ -99,7 +112,7 @@ export class NotificationPreferencesController {
             };
           } else {
             preferences[channel] = {
-              enabled: meta.defaultByChannel[channel],
+              enabled: orgDefault,
               isDefault: true,
             };
           }
@@ -135,7 +148,15 @@ export class NotificationPreferencesController {
       // catalog change doesn't 400 the user.
       return { enabled: true, isDefault: true };
     }
-    const defaultEnabled = meta.defaultByChannel[body.channel];
+    // The "default" we delete-down-to is the effective default the
+    // user sees, which is the org override if any, otherwise the
+    // code default. Without this fold, an admin-muted type would
+    // get re-opted-in for any user who toggled then matched the
+    // code default.
+    const defaultEnabled = await this.defaults.effectiveDefault(
+      body.type,
+      body.channel,
+    );
     if (body.enabled === defaultEnabled) {
       // Match default -> remove the row so this (user, type, channel)
       // tracks the default if it ever changes.

--- a/apps/portal-api/src/notifications/sample-payloads.ts
+++ b/apps/portal-api/src/notifications/sample-payloads.ts
@@ -1,0 +1,61 @@
+import { NotificationType } from '@prisma/client';
+
+import type {
+  ShareCreatedPayload,
+  ShareExpiryPayload,
+  UserDisablePayload,
+  EditorFeatureCreatedPayload,
+} from './templates.js';
+
+/**
+ * Realistic-looking sample payloads keyed by NotificationType, used
+ * by the admin /admin/notifications/preview/:type endpoint so admins
+ * can see what each email actually looks like without firing a real
+ * trigger (#137).
+ *
+ * Adding a new NotificationType: extend this map alongside the
+ * renderer in templates.ts. The preview endpoint refuses unknown
+ * types so a missed entry doesn't crash the page.
+ */
+export const SAMPLE_PAYLOADS: { [K in NotificationType]?: unknown } = {
+  share_created: {
+    itemId: '00000000-0000-4000-8000-000000000001',
+    itemTitle: 'City Park Trees',
+    itemType: 'data-layer',
+    permission: 'view',
+    sharedByName: 'Bob Example',
+    expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+  } satisfies ShareCreatedPayload,
+  share_expiring: {
+    itemId: '00000000-0000-4000-8000-000000000001',
+    itemTitle: 'City Park Trees',
+    itemType: 'data-layer',
+    expiresAt: new Date(Date.now() + 3 * 24 * 60 * 60 * 1000).toISOString(),
+    principalType: 'user',
+    principalId: '00000000-0000-4000-8000-0000000000aa',
+  } satisfies ShareExpiryPayload,
+  share_expired: {
+    itemId: '00000000-0000-4000-8000-000000000001',
+    itemTitle: 'City Park Trees',
+    itemType: 'data-layer',
+    expiresAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+    principalType: 'user',
+    principalId: '00000000-0000-4000-8000-0000000000aa',
+  } satisfies ShareExpiryPayload,
+  user_auto_disable_warning: {
+    autoDisableAt: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(),
+  } satisfies UserDisablePayload,
+  user_disabled: {
+    autoDisableAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+  } satisfies UserDisablePayload,
+  editor_feature_created: {
+    editorId: '00000000-0000-4000-8000-000000000010',
+    editorTitle: 'Storm Drain Inspection',
+    dataLayerId: '00000000-0000-4000-8000-000000000020',
+    dataLayerTitle: 'Storm Drains',
+    layerKey: 'drains',
+    featureId: 'drains/123',
+    createdByName: 'Alice Example',
+    summary: 'Inspection #4127 (cracked grate)',
+  } satisfies EditorFeatureCreatedPayload,
+};

--- a/apps/portal-api/src/notifications/system-settings.service.ts
+++ b/apps/portal-api/src/notifications/system-settings.service.ts
@@ -1,0 +1,223 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+import { PrismaService } from '../prisma/prisma.service.js';
+import {
+  encryptCredential,
+  decryptCredential,
+} from '../items/credential-cipher.js';
+
+/**
+ * Platform-level settings the admin manages from the UI rather than
+ * env files (#137). Today's only key is `smtp`. The shape is
+ * key/value JSON for non-secret fields plus an encrypted blob for
+ * secret material; the same AES-256-GCM cipher we use for ItemCredential
+ * is reused, with the setting key as AAD so a password row can't
+ * silently move between settings via SQL.
+ *
+ * The env vars (SMTP_HOST etc.) remain a *seed* layer: when the
+ * system_setting row is absent we fall back to env, so a fresh
+ * deployment with the env populated still works. Once an admin
+ * saves config in the UI, the DB row wins forever (or until they
+ * clear it).
+ */
+export interface SmtpConfig {
+  enabled: boolean;
+  host: string;
+  port: number;
+  secure: boolean;
+  fromAddress: string;
+  fromDisplayName: string;
+  user: string;
+  /** Plaintext only when freshly written; otherwise empty + the
+   *  hasPassword flag tells callers / UI we have one stored.
+   *  Explicit `undefined` is allowed to keep object-literal callers
+   *  happy under exactOptionalPropertyTypes without forcing every
+   *  caller to delete the key when it's empty. */
+  password?: string | undefined;
+  hasPassword: boolean;
+}
+
+const SMTP_KEY = 'smtp';
+
+@Injectable()
+export class SystemSettingsService {
+  private readonly log = new Logger(SystemSettingsService.name);
+  /** Memoised SMTP config. Cleared by saveSmtpConfig() so a fresh
+   *  read always reflects the most recent admin write. */
+  private smtpCache: SmtpConfig | null | undefined = undefined;
+
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly cfg: ConfigService,
+  ) {}
+
+  /**
+   * Effective SMTP config: DB row if present, env fallback otherwise.
+   * Returns null only when neither source has a host -- callers that
+   * need to know whether SMTP is configured at all check
+   * `cfg !== null && cfg.enabled && cfg.host`.
+   */
+  async getSmtpConfig(): Promise<SmtpConfig | null> {
+    if (this.smtpCache !== undefined) return this.smtpCache;
+    const row = await this.prisma.systemSetting.findUnique({
+      where: { key: SMTP_KEY },
+    });
+    if (row) {
+      const parsed = parseSmtpRow(
+        row.value as Record<string, unknown>,
+        row.encryptedSecret,
+        row.encryptedSecretIv,
+      );
+      this.smtpCache = parsed;
+      return parsed;
+    }
+    // Fallback: synthesise from env vars so first-run deployments
+    // that wrote SMTP_HOST etc. don't break before the admin clicks
+    // Save.
+    const fromEnv = this.smtpFromEnv();
+    this.smtpCache = fromEnv;
+    return fromEnv;
+  }
+
+  /**
+   * Persist SMTP config to system_setting. Empty `password` means
+   * "leave the existing encrypted password alone"; an explicit
+   * empty-string write would set hasPassword=false. The UI
+   * distinguishes by sending `password` only on rotate.
+   */
+  async saveSmtpConfig(
+    input: Omit<SmtpConfig, 'hasPassword'>,
+    actorId: string,
+  ): Promise<SmtpConfig> {
+    const existing = await this.prisma.systemSetting.findUnique({
+      where: { key: SMTP_KEY },
+    });
+    const value: Record<string, unknown> = {
+      enabled: input.enabled,
+      host: input.host,
+      port: input.port,
+      secure: input.secure,
+      fromAddress: input.fromAddress,
+      fromDisplayName: input.fromDisplayName,
+      user: input.user,
+    };
+    let encryptedSecret: string | null = existing?.encryptedSecret ?? null;
+    let encryptedSecretIv: string | null = existing?.encryptedSecretIv ?? null;
+    if (input.password !== undefined) {
+      if (input.password.length === 0) {
+        encryptedSecret = null;
+        encryptedSecretIv = null;
+      } else {
+        const enc = encryptCredential(input.password, SMTP_KEY);
+        encryptedSecret = enc.ciphertext;
+        encryptedSecretIv = enc.iv;
+      }
+    }
+    await this.prisma.systemSetting.upsert({
+      where: { key: SMTP_KEY },
+      create: {
+        key: SMTP_KEY,
+        value: value as object,
+        encryptedSecret,
+        encryptedSecretIv,
+        updatedBy: actorId,
+      },
+      update: {
+        value: value as object,
+        encryptedSecret,
+        encryptedSecretIv,
+        updatedBy: actorId,
+      },
+    });
+    this.smtpCache = undefined;
+    const fresh = await this.getSmtpConfig();
+    if (!fresh) {
+      throw new Error('saveSmtpConfig wrote but readback returned null');
+    }
+    this.log.log(
+      `SMTP config saved by ${actorId} (host=${fresh.host} port=${fresh.port} hasPassword=${fresh.hasPassword})`,
+    );
+    return fresh;
+  }
+
+  /** Drop the in-memory cache. Used by other services that want a
+   *  fresh read after they know config changed elsewhere. */
+  invalidateSmtpCache(): void {
+    this.smtpCache = undefined;
+  }
+
+  private smtpFromEnv(): SmtpConfig | null {
+    const host = this.cfg.get<string>('SMTP_HOST');
+    if (!host) return null;
+    const portRaw = this.cfg.get<string>('SMTP_PORT') ?? '587';
+    const port = Number(portRaw);
+    const secureRaw = (this.cfg.get<string>('SMTP_SECURE') ?? '').toLowerCase();
+    const secure = secureRaw === 'true' || (secureRaw === '' && port === 465);
+    const user = this.cfg.get<string>('SMTP_USER') ?? '';
+    const pass = this.cfg.get<string>('SMTP_PASS') ?? '';
+    const fromRaw =
+      this.cfg.get<string>('SMTP_FROM') ?? 'GratisGIS <noreply@gratisgis.local>';
+    const { from, fromDisplayName } = parseFrom(fromRaw);
+    const enabled =
+      (this.cfg.get<string>('NOTIFICATIONS_ENABLED') ?? '').toLowerCase() ===
+      'true';
+    return {
+      enabled,
+      host,
+      port: Number.isFinite(port) ? port : 587,
+      secure,
+      fromAddress: from,
+      fromDisplayName,
+      user,
+      password: pass || undefined,
+      hasPassword: pass.length > 0,
+    };
+  }
+}
+
+function parseSmtpRow(
+  value: Record<string, unknown>,
+  encryptedSecret: string | null,
+  encryptedSecretIv: string | null,
+): SmtpConfig {
+  const password =
+    encryptedSecret && encryptedSecretIv
+      ? safeDecrypt(encryptedSecret, encryptedSecretIv)
+      : undefined;
+  return {
+    enabled: Boolean(value.enabled),
+    host: typeof value.host === 'string' ? value.host : '',
+    port: typeof value.port === 'number' ? value.port : 587,
+    secure: Boolean(value.secure),
+    fromAddress:
+      typeof value.fromAddress === 'string' ? value.fromAddress : '',
+    fromDisplayName:
+      typeof value.fromDisplayName === 'string' ? value.fromDisplayName : '',
+    user: typeof value.user === 'string' ? value.user : '',
+    password,
+    hasPassword: typeof password === 'string' && password.length > 0,
+  };
+}
+
+function safeDecrypt(ct: string, iv: string): string | undefined {
+  try {
+    return decryptCredential(ct, iv, SMTP_KEY);
+  } catch {
+    // CREDENTIAL_ENCRYPTION_KEY may have rotated, AAD mismatch, etc.
+    // Return undefined so the rest of the system behaves like
+    // "password not configured"; admin re-saves to recover.
+    return undefined;
+  }
+}
+
+function parseFrom(raw: string): { from: string; fromDisplayName: string } {
+  const m = raw.match(/^\s*(?:"?(.*?)"?\s*)?<([^>]+)>\s*$/);
+  if (m) {
+    return {
+      from: (m[2] ?? '').trim(),
+      fromDisplayName: (m[1] ?? '').trim(),
+    };
+  }
+  return { from: raw.trim(), fromDisplayName: '' };
+}

--- a/apps/portal-web/src/app/admin/notifications/notifications-admin-view.tsx
+++ b/apps/portal-web/src/app/admin/notifications/notifications-admin-view.tsx
@@ -5,9 +5,14 @@ import {
   AlertTriangle,
   CheckCircle2,
   Clock,
+  Eye,
   Loader2,
+  Mail,
   RefreshCcw,
   RotateCw,
+  Save,
+  Send,
+  X,
 } from 'lucide-react';
 
 export interface Stats {
@@ -37,32 +42,67 @@ export interface RecentRow {
   createdAt: string;
 }
 
+export interface SmtpState {
+  configured: boolean;
+  enabled: boolean;
+  host: string;
+  port: number;
+  secure: boolean;
+  fromAddress: string;
+  fromDisplayName: string;
+  user: string;
+  hasPassword: boolean;
+}
+
+export interface DefaultsRow {
+  type: string;
+  channel: 'email';
+  label: string;
+  category: string;
+  codeDefault: boolean;
+  effective: boolean;
+  isOverride: boolean;
+}
+
+interface PreviewPayload {
+  type: string;
+  label: string;
+  subject: string;
+  text: string;
+  html: string;
+}
+
 interface Props {
   initialStats: Stats;
   initialRecent: RecentRow[];
+  initialSmtp: SmtpState;
+  initialDefaults: DefaultsRow[];
 }
 
 /**
- * Admin notifications dashboard view (#130). Shows the four
- * top-line metrics, the per-type rollup, and the recent-activity
- * list with per-row Retry on failed rows. The Refresh button at
- * the top re-fetches both stats + recent in one round-trip-pair
- * so the page stays current without a full reload.
+ * Admin notifications dashboard view (#130, extended in #137). Adds
+ * three editable surfaces on top of the original health metrics:
  *
- * Optimistic Retry: clicking Retry flips the local row to "queued"
- * with attempts: 0, then PUTs. On error we revert. The server-side
- * retry is idempotent on already-non-failed rows so a double-click
- * doesn't cause weird state.
+ *   - SMTP card: form-edit + send-test + status badges so admins
+ *     configure the relay from the UI rather than env files.
+ *   - Defaults toggles: per-NotificationType org-wide on/off folded
+ *     into the existing By Type rollup. An admin muting a type here
+ *     turns it off for every user who hasn't explicitly opted in.
+ *   - Preview modal: per-type "see what the email looks like"
+ *     rendered against a hardcoded sample payload from the server.
  */
 export function NotificationsAdminView({
   initialStats,
   initialRecent,
+  initialSmtp,
+  initialDefaults,
 }: Props) {
   const [stats, setStats] = useState<Stats>(initialStats);
   const [recent, setRecent] = useState<RecentRow[]>(initialRecent);
   const [refreshing, setRefreshing] = useState(false);
   const [retryingId, setRetryingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<PreviewPayload | null>(null);
 
   async function refresh() {
     setRefreshing(true);
@@ -90,7 +130,6 @@ export function NotificationsAdminView({
   async function retry(id: string) {
     setRetryingId(id);
     setError(null);
-    // Optimistic: flip the row to queued so the UI confirms instantly.
     const prev = recent;
     setRecent((cur) =>
       cur.map((r) =>
@@ -107,8 +146,6 @@ export function NotificationsAdminView({
       if (!res.ok) {
         throw new Error(`${res.status} ${await res.text()}`);
       }
-      // Re-pull stats so the queueDepth / failedTotal counters
-      // reflect the change.
       const s = (await fetch(
         '/api/portal/admin/notifications/stats',
       ).then((r) => r.json())) as Stats;
@@ -123,14 +160,30 @@ export function NotificationsAdminView({
     }
   }
 
+  async function openPreview(type: string) {
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/portal/admin/notifications/preview/${type}`,
+      );
+      if (!res.ok) {
+        throw new Error(`${res.status} ${await res.text()}`);
+      }
+      setPreview((await res.json()) as PreviewPayload);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Could not load preview.',
+      );
+    }
+  }
+
   return (
     <div className="space-y-6">
+      <SmtpCard initial={initialSmtp} />
+
       <div className="flex items-center justify-end gap-2">
         {error ? (
-          <span
-            className="text-xs text-danger"
-            role="alert"
-          >
+          <span className="text-xs text-danger" role="alert">
             {error}
           </span>
         ) : null}
@@ -149,7 +202,6 @@ export function NotificationsAdminView({
         </button>
       </div>
 
-      {/* Top-line metrics. */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         <Metric
           icon={<Clock className="h-4 w-4" />}
@@ -188,44 +240,12 @@ export function NotificationsAdminView({
         />
       </div>
 
-      {/* Per-type rollup. */}
-      <section className="rounded-lg border border-border bg-surface-1 p-4 shadow-card">
-        <h2 className="mb-3 text-xs font-medium uppercase tracking-wide text-muted">
-          By type
-        </h2>
-        <table className="min-w-full text-xs">
-          <thead className="text-muted">
-            <tr>
-              <th className="pb-1 text-left font-medium">Type</th>
-              <th className="pb-1 text-right font-medium">Queued</th>
-              <th className="pb-1 text-right font-medium">Sent</th>
-              <th className="pb-1 text-right font-medium">Failed</th>
-            </tr>
-          </thead>
-          <tbody>
-            {stats.byType.map((row) => (
-              <tr key={row.type} className="border-t border-border">
-                <td className="py-1.5 text-ink-1">{row.label}</td>
-                <td className="py-1.5 text-right tabular-nums">
-                  {row.queued.toLocaleString()}
-                </td>
-                <td className="py-1.5 text-right tabular-nums">
-                  {row.sent.toLocaleString()}
-                </td>
-                <td
-                  className={`py-1.5 text-right tabular-nums ${
-                    row.failed > 0 ? 'text-amber-700' : ''
-                  }`}
-                >
-                  {row.failed.toLocaleString()}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </section>
+      <DefaultsCard
+        initial={initialDefaults}
+        statsByType={stats.byType}
+        onPreview={(type) => void openPreview(type)}
+      />
 
-      {/* Recent activity. */}
       <section className="rounded-lg border border-border bg-surface-1 p-4 shadow-card">
         <h2 className="mb-3 text-xs font-medium uppercase tracking-wide text-muted">
           Recent activity
@@ -254,9 +274,7 @@ export function NotificationsAdminView({
                   const failed = row.status === 'failed';
                   return (
                     <tr key={row.id} className="border-t border-border">
-                      <td className="py-1.5 align-top text-ink-1">
-                        {row.type}
-                      </td>
+                      <td className="py-1.5 align-top text-ink-1">{row.type}</td>
                       <td className="py-1.5 align-top">{row.address}</td>
                       <td className="py-1.5 align-top">
                         <StatusBadge status={row.status} />
@@ -303,7 +321,487 @@ export function NotificationsAdminView({
           </div>
         )}
       </section>
+
+      {preview ? (
+        <PreviewModal preview={preview} onClose={() => setPreview(null)} />
+      ) : null}
     </div>
+  );
+}
+
+// ---- SMTP card ---------------------------------------------------
+
+function SmtpCard({ initial }: { initial: SmtpState }) {
+  const [form, setForm] = useState<SmtpState & { password: string }>({
+    ...initial,
+    password: '',
+  });
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [testTo, setTestTo] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [msg, setMsg] = useState<
+    { kind: 'ok' | 'err'; text: string } | null
+  >(null);
+
+  async function save() {
+    setSaving(true);
+    setMsg(null);
+    try {
+      const body: Record<string, unknown> = {
+        enabled: form.enabled,
+        host: form.host,
+        port: form.port,
+        secure: form.secure,
+        fromAddress: form.fromAddress,
+        fromDisplayName: form.fromDisplayName,
+        user: form.user,
+      };
+      if (form.password.length > 0) body.password = form.password;
+      const res = await fetch('/api/portal/admin/notifications/smtp', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error(`${res.status} ${await res.text()}`);
+      const fresh = (await res.json()) as SmtpState;
+      setForm({ ...fresh, password: '' });
+      setMsg({ kind: 'ok', text: 'Saved. Worker will use new SMTP on next send.' });
+    } catch (err) {
+      setMsg({
+        kind: 'err',
+        text: err instanceof Error ? err.message : 'Save failed.',
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function sendTest() {
+    if (!testTo.includes('@')) {
+      setMsg({ kind: 'err', text: 'Enter a valid email address to test.' });
+      return;
+    }
+    setTesting(true);
+    setMsg(null);
+    try {
+      const config: Record<string, unknown> = {
+        enabled: form.enabled,
+        host: form.host,
+        port: form.port,
+        secure: form.secure,
+        fromAddress: form.fromAddress,
+        fromDisplayName: form.fromDisplayName,
+        user: form.user,
+      };
+      if (form.password.length > 0) config.password = form.password;
+      const res = await fetch('/api/portal/admin/notifications/smtp/test', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ to: testTo, config }),
+      });
+      const out = (await res.json()) as { ok: boolean; error?: string };
+      if (out.ok) {
+        setMsg({ kind: 'ok', text: `Test sent to ${testTo}.` });
+      } else {
+        setMsg({
+          kind: 'err',
+          text: out.error ?? 'Test failed without a clear error.',
+        });
+      }
+    } catch (err) {
+      setMsg({
+        kind: 'err',
+        text: err instanceof Error ? err.message : 'Test failed.',
+      });
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  return (
+    <section className="rounded-lg border border-border bg-surface-1 p-4 shadow-card">
+      <header className="mb-3 flex items-center gap-2">
+        <Mail className="h-4 w-4 text-accent" />
+        <h2 className="text-sm font-medium tracking-tight">SMTP</h2>
+        {form.host ? (
+          <span
+            className={`ml-2 inline-flex rounded-full px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${
+              form.enabled
+                ? 'bg-emerald-100 text-emerald-800'
+                : 'bg-surface-2 text-muted'
+            }`}
+          >
+            {form.enabled ? 'enabled' : 'paused'}
+          </span>
+        ) : (
+          <span className="ml-2 inline-flex rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-amber-900">
+            not configured
+          </span>
+        )}
+      </header>
+      <p className="mb-3 text-xs text-muted">
+        Same SMTP relay drives product notifications + Keycloak invite
+        / password-reset emails. Save here and the realm sync runs
+        automatically.
+      </p>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <Field label="Host" hint="e.g. smtp.example.org">
+          <input
+            type="text"
+            value={form.host}
+            onChange={(e) => setForm({ ...form, host: e.target.value })}
+            className={inputClass}
+          />
+        </Field>
+        <Field label="Port">
+          <input
+            type="number"
+            value={form.port}
+            onChange={(e) =>
+              setForm({ ...form, port: Number(e.target.value) || 0 })
+            }
+            className={inputClass}
+          />
+        </Field>
+        <Field label="From address" hint="appears in the From header">
+          <input
+            type="email"
+            value={form.fromAddress}
+            onChange={(e) => setForm({ ...form, fromAddress: e.target.value })}
+            className={inputClass}
+          />
+        </Field>
+        <Field label="From display name">
+          <input
+            type="text"
+            value={form.fromDisplayName}
+            onChange={(e) =>
+              setForm({ ...form, fromDisplayName: e.target.value })
+            }
+            className={inputClass}
+          />
+        </Field>
+        <Field label="Username" hint="leave blank for unauthenticated relay">
+          <input
+            type="text"
+            value={form.user}
+            onChange={(e) => setForm({ ...form, user: e.target.value })}
+            className={inputClass}
+          />
+        </Field>
+        <Field
+          label="Password"
+          hint={
+            form.hasPassword && form.password.length === 0
+              ? 'A password is stored. Type to replace.'
+              : 'Stored encrypted at rest.'
+          }
+        >
+          <div className="flex h-9 items-stretch">
+            <input
+              type={showPassword ? 'text' : 'password'}
+              value={form.password}
+              onChange={(e) =>
+                setForm({ ...form, password: e.target.value })
+              }
+              placeholder={
+                form.hasPassword ? '(unchanged)' : 'enter password'
+              }
+              className={`${inputClass} flex-1 rounded-r-none`}
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((s) => !s)}
+              className="rounded-r-md border border-l-0 border-border bg-surface-2 px-2 text-xs text-muted hover:text-ink-0"
+            >
+              {showPassword ? 'hide' : 'show'}
+            </button>
+          </div>
+        </Field>
+      </div>
+      <div className="mt-3 flex flex-wrap items-center gap-3 text-xs">
+        <label className="inline-flex items-center gap-1.5">
+          <input
+            type="checkbox"
+            checked={form.enabled}
+            onChange={(e) => setForm({ ...form, enabled: e.target.checked })}
+          />
+          <span>Enabled</span>
+        </label>
+        <label className="inline-flex items-center gap-1.5">
+          <input
+            type="checkbox"
+            checked={form.secure}
+            onChange={(e) => setForm({ ...form, secure: e.target.checked })}
+          />
+          <span>SSL / TLS on connect (port 465)</span>
+        </label>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-end gap-2 border-t border-border pt-3">
+        <button
+          type="button"
+          onClick={() => void save()}
+          disabled={saving}
+          className="inline-flex h-8 items-center gap-1 rounded-md bg-accent px-3 text-xs font-medium text-accent-foreground hover:opacity-90 disabled:opacity-50"
+        >
+          {saving ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <Save className="h-3.5 w-3.5" />
+          )}
+          Save
+        </button>
+        <div className="ml-auto flex items-end gap-2">
+          <Field label="Send test to">
+            <input
+              type="email"
+              value={testTo}
+              onChange={(e) => setTestTo(e.target.value)}
+              placeholder="you@example.com"
+              className={`${inputClass} w-56`}
+            />
+          </Field>
+          <button
+            type="button"
+            onClick={() => void sendTest()}
+            disabled={testing}
+            className="inline-flex h-9 items-center gap-1 rounded-md border border-border bg-surface-1 px-3 text-xs font-medium text-ink-1 hover:bg-surface-2 disabled:opacity-50"
+          >
+            {testing ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Send className="h-3.5 w-3.5" />
+            )}
+            Send test
+          </button>
+        </div>
+      </div>
+      {msg ? (
+        <p
+          className={`mt-2 text-xs ${
+            msg.kind === 'ok' ? 'text-emerald-700' : 'text-danger'
+          }`}
+        >
+          {msg.text}
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+// ---- Defaults card -----------------------------------------------
+
+function DefaultsCard({
+  initial,
+  statsByType,
+  onPreview,
+}: {
+  initial: DefaultsRow[];
+  statsByType: Stats['byType'];
+  onPreview: (type: string) => void;
+}) {
+  const [rows, setRows] = useState<DefaultsRow[]>(initial);
+  const [busy, setBusy] = useState<string | null>(null);
+  const statsLookup = new Map(statsByType.map((s) => [s.type, s] as const));
+
+  async function setOverride(row: DefaultsRow, enabled: boolean) {
+    const key = `${row.type}|${row.channel}`;
+    setBusy(key);
+    const prev = rows;
+    const newIsOverride = enabled !== row.codeDefault;
+    setRows((cur) =>
+      cur.map((r) =>
+        r.type === row.type && r.channel === row.channel
+          ? { ...r, effective: enabled, isOverride: newIsOverride }
+          : r,
+      ),
+    );
+    try {
+      const res = await fetch('/api/portal/admin/notifications/defaults', {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          type: row.type,
+          channel: row.channel,
+          enabled,
+        }),
+      });
+      if (!res.ok) throw new Error(`${res.status} ${await res.text()}`);
+    } catch {
+      setRows(prev);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <section className="rounded-lg border border-border bg-surface-1 p-4 shadow-card">
+      <h2 className="mb-3 text-xs font-medium uppercase tracking-wide text-muted">
+        Notification types
+      </h2>
+      <table className="min-w-full text-xs">
+        <thead className="text-muted">
+          <tr>
+            <th className="pb-1 text-left font-medium">Type</th>
+            <th className="pb-1 text-right font-medium">Queued</th>
+            <th className="pb-1 text-right font-medium">Sent</th>
+            <th className="pb-1 text-right font-medium">Failed</th>
+            <th className="pb-1 text-right font-medium">Default</th>
+            <th className="pb-1 text-right font-medium">Preview</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const s = statsLookup.get(row.type);
+            const key = `${row.type}|${row.channel}`;
+            return (
+              <tr key={key} className="border-t border-border">
+                <td className="py-1.5 text-ink-1">
+                  {row.label}
+                  {row.isOverride ? (
+                    <span className="ml-1.5 inline-flex rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-amber-900">
+                      override
+                    </span>
+                  ) : null}
+                </td>
+                <td className="py-1.5 text-right tabular-nums">
+                  {(s?.queued ?? 0).toLocaleString()}
+                </td>
+                <td className="py-1.5 text-right tabular-nums">
+                  {(s?.sent ?? 0).toLocaleString()}
+                </td>
+                <td
+                  className={`py-1.5 text-right tabular-nums ${
+                    (s?.failed ?? 0) > 0 ? 'text-amber-700' : ''
+                  }`}
+                >
+                  {(s?.failed ?? 0).toLocaleString()}
+                </td>
+                <td className="py-1.5 text-right">
+                  <label className="inline-flex items-center gap-1 text-[11px]">
+                    <input
+                      type="checkbox"
+                      checked={row.effective}
+                      disabled={busy === key}
+                      onChange={(e) =>
+                        void setOverride(row, e.target.checked)
+                      }
+                    />
+                    <span>{row.effective ? 'on' : 'off'}</span>
+                  </label>
+                </td>
+                <td className="py-1.5 text-right">
+                  <button
+                    type="button"
+                    onClick={() => onPreview(row.type)}
+                    className="inline-flex items-center gap-1 rounded border border-border bg-surface-1 px-1.5 py-0.5 text-[11px] font-medium text-ink-1 hover:bg-surface-2"
+                  >
+                    <Eye className="h-3 w-3" />
+                    Preview
+                  </button>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      <p className="mt-2 text-[11px] text-muted">
+        Off here mutes the type platform-wide for users who haven&apos;t
+        explicitly opted in. Per-user opt-ins still win.
+      </p>
+    </section>
+  );
+}
+
+// ---- Preview modal -----------------------------------------------
+
+function PreviewModal({
+  preview,
+  onClose,
+}: {
+  preview: PreviewPayload;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-30 flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-2xl rounded-lg border border-border bg-surface-1 shadow-raised"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted">
+              Preview
+            </p>
+            <p className="text-sm font-medium text-ink-0">{preview.label}</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 hover:bg-surface-2"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="space-y-3 px-4 py-3 text-xs">
+          <div>
+            <p className="text-[11px] uppercase tracking-wide text-muted">
+              Subject
+            </p>
+            <p className="mt-0.5 text-sm text-ink-0">{preview.subject}</p>
+          </div>
+          <div>
+            <p className="text-[11px] uppercase tracking-wide text-muted">
+              HTML
+            </p>
+            <div
+              className="mt-0.5 max-h-80 overflow-auto rounded border border-border bg-surface-0 p-3 text-sm"
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{ __html: preview.html }}
+            />
+          </div>
+          <details>
+            <summary className="cursor-pointer text-[11px] uppercase tracking-wide text-muted">
+              Plain-text fallback
+            </summary>
+            <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap rounded border border-border bg-surface-0 p-3 text-[11px] text-ink-1">
+              {preview.text}
+            </pre>
+          </details>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---- Shared bits -------------------------------------------------
+
+const inputClass =
+  'h-9 w-full rounded-md border border-border bg-surface-1 px-2 text-xs focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30';
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="block text-xs">
+      <span className="mb-1 block uppercase tracking-wide text-muted">
+        {label}
+      </span>
+      {children}
+      {hint ? <p className="mt-0.5 text-[11px] text-muted">{hint}</p> : null}
+    </label>
   );
 }
 

--- a/apps/portal-web/src/app/admin/notifications/page.tsx
+++ b/apps/portal-web/src/app/admin/notifications/page.tsx
@@ -3,7 +3,13 @@ import { redirect } from 'next/navigation';
 import { ArrowLeft, Bell } from 'lucide-react';
 
 import { apiFetch } from '@/lib/api';
-import { NotificationsAdminView, type Stats, type RecentRow } from './notifications-admin-view';
+import {
+  NotificationsAdminView,
+  type Stats,
+  type RecentRow,
+  type SmtpState,
+  type DefaultsRow,
+} from './notifications-admin-view';
 
 /**
  * Admin-only notifications status surface (#130). Shows queue
@@ -23,12 +29,20 @@ export default async function AdminNotificationsPage() {
 
   let stats: Stats | null = null;
   let recent: RecentRow[] = [];
+  let smtp: SmtpState | null = null;
+  let defaults: DefaultsRow[] = [];
   let error: string | null = null;
   try {
-    [stats, recent] = await Promise.all([
+    const [s, r, sm, df] = await Promise.all([
       apiFetch<Stats>('/api/admin/notifications/stats'),
       apiFetch<RecentRow[]>('/api/admin/notifications/recent'),
+      apiFetch<SmtpState>('/api/admin/notifications/smtp'),
+      apiFetch<{ rows: DefaultsRow[] }>('/api/admin/notifications/defaults'),
     ]);
+    stats = s;
+    recent = r;
+    smtp = sm;
+    defaults = df.rows;
   } catch (err) {
     error =
       err instanceof Error
@@ -69,8 +83,13 @@ export default async function AdminNotificationsPage() {
         </div>
       ) : null}
 
-      {stats ? (
-        <NotificationsAdminView initialStats={stats} initialRecent={recent} />
+      {stats && smtp ? (
+        <NotificationsAdminView
+          initialStats={stats}
+          initialRecent={recent}
+          initialSmtp={smtp}
+          initialDefaults={defaults}
+        />
       ) : null}
     </div>
   );


### PR DESCRIPTION
Three new admin surfaces on `/admin/notifications`, all DB-backed so
admins manage them from the UI and never edit env files directly.

## What changes

### 1. SMTP card

Edit host / port / from / user / password + Enabled / SSL toggles.
Hit **Send test** to fire a one-shot delivery via a single-use
transport (works against unsaved form values too, so the admin can
verify before clicking Save).

**Save** persists to the new `system_setting` table; passwords are
encrypted with the existing AES-256-GCM `credential-cipher`,
AAD-bound to the setting key. The save also:

- reloads the in-process `EmailTransport` pool, so the worker uses
  the new creds on its next tick
- re-runs the Keycloak realm SMTP sync, so invite / forgot-password
  emails ride the new relay too

Env vars (`SMTP_HOST`, etc.) remain a *seed* layer for fresh
deployments before the admin opens the UI.

### 2. Per-NotificationType org defaults

New `notification_type_default` table with sparse rows that override
the code defaults in `notification-types.ts`. Folded into:

- the **By type** rollup on the admin page (checkbox + "override"
  badge)
- `/settings/notifications` (the user-facing toggle) as the new
  "default" their toggle deletes-down-to
- `NotificationsService.notify()` dispatch with precedence
  `user pref > org default > code default`

Muting `share_expiring` platform-wide is now a one-click change.

### 3. Template preview

New `/admin/notifications/preview/:type` endpoint renders the
template against a hardcoded sample payload from
`notifications/sample-payloads.ts`. Per-row Preview button opens a
modal showing the rendered subject + HTML preview + plain-text
fallback in a details pane. Lets an admin verify "what does this
email actually look like" without firing a real trigger.

## Schema

New migration `20260428040000_admin_notifications_config`:

- `system_setting (key, value JSONB, encrypted_secret, encrypted_secret_iv, updated_at, updated_by)`
- `notification_type_default (type, channel, enabled, updated_at)`

## Knock-on cleanups

`KeycloakAdminService.syncRealmSmtp()` and `EmailTransport` now both
read from `SystemSettingsService` rather than `process.env`. Single
source of truth for SMTP. The env parsing helper moved into
`SystemSettingsService`.

## Quality gate

- `pnpm typecheck` passes
- `pnpm lint` passes (existing import-type warnings only)
- `pnpm test` passes
- migration applied locally via `prisma migrate deploy`

Closes #137.
