### PR TITLE
fix: styled in-app dialogs replace native browser popups; idempotent admin user delete (#138)

### DIFF
--- a/apps/portal-api/src/admin/admin-users.controller.ts
+++ b/apps/portal-api/src/admin/admin-users.controller.ts
@@ -259,10 +259,72 @@ export class AdminUsersController {
     };
   }
 
+  /**
+   * Remove a user from both Keycloak and the local mirror. Idempotent
+   * with respect to Keycloak: a user that's already missing upstream
+   * (dev-realm reset, prior partial delete, manual cleanup) is treated
+   * as success and we still purge our local row. The local cleanup
+   * keys on USERNAME so seeded accounts -- whose local user.id differs
+   * from the Keycloak sub -- get cleaned up too.
+   *
+   * If the user has no Keycloak entry AND no local row matching by id
+   * or username, we 404 the caller; this preserves the "operating on
+   * a thing that doesn't exist" semantics for the rare malicious /
+   * stale path while making the common case (just-purged user) work.
+   */
   @Delete(':id')
   @HttpCode(204)
   async remove(@Param('id') id: string): Promise<void> {
-    await this.kc.deleteUser(id);
+    // First try to grab the Keycloak record so we know the username
+    // for local cleanup. Either the user is there (we'll delete) or
+    // they aren't (we'll fall through to local cleanup by id alone).
+    let username: string | null = null;
+    try {
+      const kc = await this.kc.getUser(id);
+      username = kc.username ?? null;
+    } catch {
+      // Treat any failure as "not in Keycloak"; if it was a real
+      // upstream / token error the local cleanup path is still safe
+      // and the next admin action will surface the auth issue.
+    }
+
+    let deletedUpstream = false;
+    try {
+      await this.kc.deleteUser(id);
+      deletedUpstream = true;
+    } catch (err) {
+      // 404 from Keycloak is the dev-realm-reset case: nothing to
+      // delete upstream, fall through and clean up our side. Anything
+      // else is a real failure -- bubble up.
+      if (!(err instanceof NotFoundException)) {
+        throw err;
+      }
+    }
+
+    // Local cleanup. Match by id first (covers the modern path where
+    // local user.id === Keycloak sub) and by username (covers seeded
+    // users with mismatched ids per docs/data-model.md).
+    const localById = await this.prisma.user.findUnique({ where: { id } }).catch(() => null);
+    const localByUsername = username
+      ? await this.prisma.user.findUnique({ where: { username } })
+      : null;
+    let deletedLocal = false;
+    if (localById) {
+      await this.prisma.user.delete({ where: { id } });
+      deletedLocal = true;
+    } else if (localByUsername) {
+      await this.prisma.user.delete({ where: { id: localByUsername.id } });
+      deletedLocal = true;
+    }
+
+    // If neither side had the user, surface a 404 so the caller knows
+    // they were operating on a fully ghost row -- the UI can refresh
+    // its list to re-sync.
+    if (!deletedUpstream && !deletedLocal) {
+      throw new NotFoundException(
+        `User ${id} not found in Keycloak or local store.`,
+      );
+    }
   }
 
   /**

--- a/apps/portal-web/src/app/admin/users/admin-users-view.tsx
+++ b/apps/portal-web/src/app/admin/users/admin-users-view.tsx
@@ -22,6 +22,7 @@ import type { AdminUserRow } from './page';
 import { ReassignOwnerDialog } from '@/components/reassign-owner-dialog';
 import { ShareExpiryPicker } from '@/components/share-expiry-picker';
 import { UserAccessDialog } from './user-access-dialog';
+import { useAlert, useConfirm } from '@/components/dialog-provider';
 
 /**
  * Admin-side users table.
@@ -42,6 +43,8 @@ interface Props {
 }
 
 export function AdminUsersView({ initialUsers }: Props) {
+  const confirm = useConfirm();
+  const alert = useAlert();
   const [users, setUsers] = useState<AdminUserRow[]>(initialUsers);
   const [query, setQuery] = useState('');
   const [inviteOpen, setInviteOpen] = useState(false);
@@ -144,6 +147,13 @@ export function AdminUsersView({ initialUsers }: Props) {
    * Actual delete call: assumes the caller has already verified the
    * user has no owned items (or has reassigned them). Called either
    * directly (clean path) or from the reassign-and-delete flow below.
+   *
+   * Idempotency: a 404 from upstream means the user is already gone
+   * from Keycloak (dev-realm reset, prior partial delete, etc.). We
+   * still drop the row from the local table state and surface the
+   * deletion as successful since "user is gone" is the desired
+   * end state -- the server-side handler does the local-DB cleanup
+   * by username.
    */
   async function performDelete(user: AdminUserRow) {
     setWorking(user.id);
@@ -152,7 +162,7 @@ export function AdminUsersView({ initialUsers }: Props) {
       method: 'DELETE',
     });
     setWorking(null);
-    if (!res.ok) {
+    if (!res.ok && res.status !== 404) {
       setError(`Delete failed: ${res.status}`);
       return;
     }
@@ -188,13 +198,13 @@ export function AdminUsersView({ initialUsers }: Props) {
     } finally {
       setWorking(null);
     }
-    if (
-      !confirm(
-        `Permanently delete ${user.username}? This cannot be undone and will remove their portal account.`,
-      )
-    ) {
-      return;
-    }
+    const ok = await confirm({
+      title: 'Delete user?',
+      message: `Permanently delete ${user.username}? This cannot be undone and will remove their portal account.`,
+      confirmLabel: 'Delete',
+      variant: 'danger',
+    });
+    if (!ok) return;
     await performDelete(user);
   }
 
@@ -503,6 +513,7 @@ interface InviteDialogProps {
 }
 
 function InviteUserDialog({ onClose, onInvited }: InviteDialogProps) {
+  const alert = useAlert();
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [firstName, setFirstName] = useState('');
@@ -546,13 +557,15 @@ function InviteUserDialog({ onClose, onInvited }: InviteDialogProps) {
     // Confirm with the admin so they're not surprised when the user
     // says "I didn't get an email". The user row is still added.
     if (created.setupEmailError) {
-      // eslint-disable-next-line no-alert
-      window.alert(
-        `User "${created.username}" was created, but the password-setup ` +
+      await alert({
+        title: 'User created, email failed',
+        tone: 'warn',
+        message:
+          `User "${created.username}" was created, but the password-setup ` +
           `email could not be sent:\n\n${created.setupEmailError}\n\n` +
           `Once SMTP is healthy, click "Reset password" on this user to ` +
           `re-send the email.`,
-      );
+      });
     }
     onInvited(created);
   }

--- a/apps/portal-web/src/app/items/[id]/arcgis-service/editor.tsx
+++ b/apps/portal-web/src/app/items/[id]/arcgis-service/editor.tsx
@@ -11,6 +11,7 @@ import {
   Search,
 } from 'lucide-react';
 import type { ArcgisServiceData, ISODateString } from '@gratis-gis/shared-types';
+import { useConfirm } from '@/components/dialog-provider';
 import {
   DEFAULT_ARCGIS_SERVICE,
 } from '@gratis-gis/shared-types';
@@ -553,6 +554,7 @@ function CredentialsCard({
     updatedAt: string;
     updatedBy: string;
   } | { hasSecret: false };
+  const confirmDialog = useConfirm();
   const [meta, setMeta] = useState<Meta | null>(null);
   const [loading, setLoading] = useState(false);
   const [editorOpen, setEditorOpen] = useState(false);
@@ -627,9 +629,13 @@ function CredentialsCard({
   }
 
   async function clearCredential() {
-    if (!window.confirm('Remove the stored credential for this item?')) {
-      return;
-    }
+    const ok = await confirmDialog({
+      title: 'Remove stored credential?',
+      message: 'Remove the stored credential for this item? Future Probe / proxy calls will use no auth until you save a new one.',
+      confirmLabel: 'Remove',
+      variant: 'danger',
+    });
+    if (!ok) return;
     setBusy(true);
     setErr(null);
     try {

--- a/apps/portal-web/src/app/items/folder-rail.tsx
+++ b/apps/portal-web/src/app/items/folder-rail.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { ChevronRight, Folder as FolderIcon, FolderOpen } from 'lucide-react';
 import { FolderRowMenu } from './folder-row-menu';
+import { useAlert } from '@/components/dialog-provider';
 
 /** MIME-style key used to identify an item-card drag payload (#43).
  *  Kept narrow (`application/x-gratis-item`) so other dragged content
@@ -53,6 +54,7 @@ interface Props {
  */
 export function FolderRail({ folders, activeFolderId }: Props) {
   const router = useRouter();
+  const alert = useAlert();
   const folderById = useMemo(() => {
     const m = new Map<string, FolderRailNode>();
     for (const f of folders) m.set(f.id, f);
@@ -197,10 +199,11 @@ export function FolderRail({ folders, activeFolderId }: Props) {
       }
       router.refresh();
     } catch (err) {
-      // eslint-disable-next-line no-alert
-      window.alert(
-        err instanceof Error ? err.message : 'Could not move item.',
-      );
+      void alert({
+        tone: 'warn',
+        title: 'Move failed',
+        message: err instanceof Error ? err.message : 'Could not move item.',
+      });
     }
   }
 

--- a/apps/portal-web/src/app/items/folder-row-menu.tsx
+++ b/apps/portal-web/src/app/items/folder-row-menu.tsx
@@ -11,6 +11,8 @@ import {
   Trash2,
 } from 'lucide-react';
 
+import { useAlert, useConfirm } from '@/components/dialog-provider';
+
 /**
  * Right-click + kebab menu attached to a folder row in the FolderRail.
  * Same items either way so keyboard / trackpad users without
@@ -32,6 +34,8 @@ interface Props {
 
 export function FolderRowMenu({ folderId, folderTitle, canEdit }: Props) {
   const router = useRouter();
+  const confirm = useConfirm();
+  const alert = useAlert();
   const [open, setOpen] = useState(false);
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
   const [busy, setBusy] = useState(false);
@@ -71,20 +75,24 @@ export function FolderRowMenu({ folderId, folderTitle, canEdit }: Props) {
 
   async function moveToTrash() {
     if (!canEdit) return;
-    if (
-      !window.confirm(
-        `Move "${folderTitle}" to the recycle bin? The folder's contents stay where they are; only the folder arrangement is removed.`,
-      )
-    ) {
-      return;
-    }
+    const ok = await confirm({
+      title: 'Move folder to trash?',
+      message: `Move "${folderTitle}" to the recycle bin? The folder's contents stay where they are; only the folder arrangement is removed.`,
+      confirmLabel: 'Move to trash',
+      variant: 'danger',
+    });
+    if (!ok) return;
     setBusy(true);
     try {
       const res = await fetch(`/api/portal/items/${folderId}`, {
         method: 'DELETE',
       });
       if (!res.ok) {
-        window.alert(`Move to trash failed: ${res.status}`);
+        await alert({
+          tone: 'warn',
+          title: 'Could not move to trash',
+          message: `Move to trash failed: ${res.status}`,
+        });
         return;
       }
       setOpen(false);

--- a/apps/portal-web/src/app/providers.tsx
+++ b/apps/portal-web/src/app/providers.tsx
@@ -3,6 +3,12 @@
 import { SessionProvider } from 'next-auth/react';
 import type { ReactNode } from 'react';
 
+import { DialogProvider } from '@/components/dialog-provider';
+
 export function Providers({ children }: { children: ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <DialogProvider>{children}</DialogProvider>
+    </SessionProvider>
+  );
 }

--- a/apps/portal-web/src/components/dialog-provider.tsx
+++ b/apps/portal-web/src/components/dialog-provider.tsx
@@ -1,0 +1,326 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { AlertTriangle, Info } from 'lucide-react';
+
+/**
+ * In-app replacement for window.confirm / window.alert (#138).
+ *
+ * The native browser dialogs look like a 1995 system error in dark
+ * mode and break our visual language; this provider mounts a single
+ * styled modal at the root of the tree and exposes promise-returning
+ * hooks (`useConfirm`, `useAlert`) so callers keep the same
+ * "await -> proceed" shape they had with the native versions.
+ *
+ * - useConfirm({...})  -> Promise<boolean>
+ *     Resolves true when the primary button is clicked, false on
+ *     cancel / Escape / backdrop click.
+ *
+ * - useAlert({...})    -> Promise<void>
+ *     Resolves when the user dismisses (OK / Escape / backdrop).
+ *
+ * Variants ("default" | "danger") only affect the primary button
+ * tone -- the destructive red appears for delete confirmations.
+ *
+ * Why a Promise API: every existing window.confirm callsite already
+ * branches on a sync boolean, so wrapping it in `await` is a one-line
+ * edit. A render-prop component would force restructuring all of
+ * them.
+ *
+ * Stacking: at most one dialog is shown at a time. Calling
+ * confirm() while another dialog is open queues behind it; we
+ * handle that by simply replacing the queued one (the second
+ * caller's Promise resolves; the first remains unresolved). In
+ * practice nothing in the app calls confirm() during another
+ * confirm.
+ */
+
+interface ConfirmOptions {
+  title?: string;
+  message: string;
+  /** Label on the primary action; defaults to "OK" / "Delete"
+   *  depending on variant. */
+  confirmLabel?: string;
+  cancelLabel?: string;
+  variant?: 'default' | 'danger';
+}
+
+interface AlertOptions {
+  title?: string;
+  message: string;
+  /** Tone used to pick the icon + accent color. "warn" surfaces a
+   *  yellow triangle; "info" the blue circle. */
+  tone?: 'info' | 'warn';
+  okLabel?: string;
+}
+
+interface DialogContextValue {
+  confirm: (opts: ConfirmOptions) => Promise<boolean>;
+  alert: (opts: AlertOptions) => Promise<void>;
+}
+
+const DialogContext = createContext<DialogContextValue | null>(null);
+
+interface PendingConfirm {
+  kind: 'confirm';
+  opts: ConfirmOptions;
+  resolve: (v: boolean) => void;
+}
+interface PendingAlert {
+  kind: 'alert';
+  opts: AlertOptions;
+  resolve: () => void;
+}
+type Pending = PendingConfirm | PendingAlert;
+
+export function DialogProvider({ children }: { children: ReactNode }) {
+  const [pending, setPending] = useState<Pending | null>(null);
+  // Stash the most-recent pending in a ref so the close handlers
+  // resolve the right promise even if `pending` has been swapped
+  // mid-flight (defensive; not expected in normal use).
+  const pendingRef = useRef<Pending | null>(null);
+  pendingRef.current = pending;
+
+  const confirm = useCallback(
+    (opts: ConfirmOptions) =>
+      new Promise<boolean>((resolve) => {
+        setPending({ kind: 'confirm', opts, resolve });
+      }),
+    [],
+  );
+  const alertFn = useCallback(
+    (opts: AlertOptions) =>
+      new Promise<void>((resolve) => {
+        setPending({ kind: 'alert', opts, resolve });
+      }),
+    [],
+  );
+
+  const closeConfirm = useCallback((value: boolean) => {
+    const p = pendingRef.current;
+    if (p && p.kind === 'confirm') {
+      p.resolve(value);
+    }
+    setPending(null);
+  }, []);
+  const closeAlert = useCallback(() => {
+    const p = pendingRef.current;
+    if (p && p.kind === 'alert') {
+      p.resolve();
+    }
+    setPending(null);
+  }, []);
+
+  // Esc / Enter shortcuts. Esc cancels (confirm: false; alert:
+  // dismiss). Enter accepts confirm primary. We bind on document so
+  // the modal doesn't have to be focused for the keyboard to work.
+  useEffect(() => {
+    if (!pending) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        if (pendingRef.current?.kind === 'confirm') closeConfirm(false);
+        else if (pendingRef.current?.kind === 'alert') closeAlert();
+      } else if (e.key === 'Enter') {
+        // Don't hijack Enter when the focus is in a textarea; in
+        // text inputs Enter accepts so it's fine.
+        const tag = (e.target as HTMLElement | null)?.tagName ?? '';
+        if (tag === 'TEXTAREA') return;
+        e.preventDefault();
+        if (pendingRef.current?.kind === 'confirm') closeConfirm(true);
+        else if (pendingRef.current?.kind === 'alert') closeAlert();
+      }
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [pending, closeConfirm, closeAlert]);
+
+  const value = useMemo<DialogContextValue>(
+    () => ({ confirm, alert: alertFn }),
+    [confirm, alertFn],
+  );
+
+  return (
+    <DialogContext.Provider value={value}>
+      {children}
+      {pending ? (
+        pending.kind === 'confirm' ? (
+          <ConfirmDialog opts={pending.opts} onClose={closeConfirm} />
+        ) : (
+          <AlertDialog opts={pending.opts} onClose={closeAlert} />
+        )
+      ) : null}
+    </DialogContext.Provider>
+  );
+}
+
+export function useConfirm(): DialogContextValue['confirm'] {
+  const ctx = useContext(DialogContext);
+  if (!ctx) {
+    throw new Error('useConfirm must be used inside <DialogProvider>');
+  }
+  return ctx.confirm;
+}
+
+export function useAlert(): DialogContextValue['alert'] {
+  const ctx = useContext(DialogContext);
+  if (!ctx) {
+    throw new Error('useAlert must be used inside <DialogProvider>');
+  }
+  return ctx.alert;
+}
+
+// ---- Internals ---------------------------------------------------
+
+function ConfirmDialog({
+  opts,
+  onClose,
+}: {
+  opts: ConfirmOptions;
+  onClose: (v: boolean) => void;
+}) {
+  const variant = opts.variant ?? 'default';
+  const confirmLabel =
+    opts.confirmLabel ?? (variant === 'danger' ? 'Delete' : 'OK');
+  const cancelLabel = opts.cancelLabel ?? 'Cancel';
+  const title = opts.title ?? (variant === 'danger' ? 'Confirm delete' : 'Confirm');
+  return (
+    <Backdrop onClose={() => onClose(false)}>
+      <DialogShell>
+        <DialogHeader>
+          <span
+            className={`flex h-9 w-9 items-center justify-center rounded-full ${
+              variant === 'danger'
+                ? 'bg-danger/10 text-danger'
+                : 'bg-accent/10 text-accent'
+            }`}
+          >
+            <AlertTriangle className="h-4 w-4" />
+          </span>
+          <h2 className="text-base font-semibold tracking-tight text-ink-0">
+            {title}
+          </h2>
+        </DialogHeader>
+        <p className="px-5 pb-4 text-sm leading-relaxed text-ink-1">
+          {opts.message}
+        </p>
+        <DialogFooter>
+          <button
+            type="button"
+            onClick={() => onClose(false)}
+            className="inline-flex h-9 items-center rounded-md border border-border bg-surface-1 px-3 text-sm font-medium text-ink-1 hover:bg-surface-2"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={() => onClose(true)}
+            autoFocus
+            className={`inline-flex h-9 items-center rounded-md px-3 text-sm font-medium text-accent-foreground hover:opacity-90 ${
+              variant === 'danger' ? 'bg-danger' : 'bg-accent'
+            }`}
+          >
+            {confirmLabel}
+          </button>
+        </DialogFooter>
+      </DialogShell>
+    </Backdrop>
+  );
+}
+
+function AlertDialog({
+  opts,
+  onClose,
+}: {
+  opts: AlertOptions;
+  onClose: () => void;
+}) {
+  const tone = opts.tone ?? 'info';
+  const title = opts.title ?? (tone === 'warn' ? 'Heads up' : 'Notice');
+  const Icon = tone === 'warn' ? AlertTriangle : Info;
+  return (
+    <Backdrop onClose={onClose}>
+      <DialogShell>
+        <DialogHeader>
+          <span
+            className={`flex h-9 w-9 items-center justify-center rounded-full ${
+              tone === 'warn'
+                ? 'bg-amber-100 text-amber-800'
+                : 'bg-accent/10 text-accent'
+            }`}
+          >
+            <Icon className="h-4 w-4" />
+          </span>
+          <h2 className="text-base font-semibold tracking-tight text-ink-0">
+            {title}
+          </h2>
+        </DialogHeader>
+        <p className="whitespace-pre-line px-5 pb-4 text-sm leading-relaxed text-ink-1">
+          {opts.message}
+        </p>
+        <DialogFooter>
+          <button
+            type="button"
+            onClick={onClose}
+            autoFocus
+            className="inline-flex h-9 items-center rounded-md bg-accent px-3 text-sm font-medium text-accent-foreground hover:opacity-90"
+          >
+            {opts.okLabel ?? 'OK'}
+          </button>
+        </DialogFooter>
+      </DialogShell>
+    </Backdrop>
+  );
+}
+
+function Backdrop({
+  onClose,
+  children,
+}: {
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/40 p-4"
+    >
+      <div onClick={(e) => e.stopPropagation()} className="contents">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function DialogShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="w-full max-w-md rounded-lg border border-border bg-surface-1 shadow-raised">
+      {children}
+    </div>
+  );
+}
+
+function DialogHeader({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-3 px-5 pb-3 pt-4">{children}</div>
+  );
+}
+
+function DialogFooter({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex items-center justify-end gap-2 border-t border-border px-5 py-3">
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Two related fixes triggered by the admin Users page (delete a user, get an ugly native confirm popup, and the delete itself 404s).

## 1. Styled in-app dialogs

New `DialogProvider` mounted in `Providers` exposes:

- `useConfirm()` -> `(opts) => Promise<boolean>` (variants: `default`, `danger`)
- `useAlert()` -> `(opts) => Promise<void>` (tones: `info`, `warn`)

Esc cancels confirm; Enter accepts the primary action. All four
pre-existing `window.confirm` / `window.alert` callsites converted:

- admin user delete confirmation
- invite "user created but email failed" alert
- `folder-rail` move-failed alert
- `folder-row-menu` move-to-trash confirm + error
- `arcgis-service/editor` remove-credential confirm

## 2. Idempotent admin user delete

Symptom: in dev I had a row for `matthew` rendered in the admin
Users table that didn't actually exist in Keycloak (dev-realm
storage is `dev-file`, which resets on container restart). Clicking
the trash icon 404'd with no remediation.

Fix on both ends:

- **Backend** `remove()` resolves the username from Keycloak first
  (best-effort), tries the Keycloak delete (404 -> fall through),
  then deletes the local user row by id **or** by username -- the
  username path is the only one that works for seeded users whose
  local `user.id` differs from their Keycloak sub. Only 404s if
  neither side had the user.
- **Frontend** treats 404 as "already gone" and drops the row.

## Quality gate

- `pnpm typecheck` passes
- `pnpm lint` passes (existing import-type warnings only)
- `pnpm test` passes

Closes #138.
