### PR TITLE
fix(auth): admin invite passes org slug; auth-sync rejects UUID slugs (#140)

### DIFF
--- a/apps/portal-api/src/admin/admin-users.controller.ts
+++ b/apps/portal-api/src/admin/admin-users.controller.ts
@@ -159,7 +159,12 @@ export class AdminUsersController {
       email: dto.email,
       sendSetupEmail: dto.sendSetupEmail ?? true,
       enabled: true,
-      org: me.orgId,
+      // The Keycloak `org` user-attribute (and the JWT `org` claim
+      // it produces) is the org SLUG, not the id. auth-sync looks
+      // up Organization by slug; passing the UUID here causes it
+      // to create a phantom Organization with slug=name=UUID for
+      // the invitee on their first login.
+      org: me.orgSlug,
     };
     if (dto.firstName !== undefined) input.firstName = dto.firstName;
     if (dto.lastName !== undefined) input.lastName = dto.lastName;

--- a/apps/portal-api/src/auth/auth-sync.service.ts
+++ b/apps/portal-api/src/auth/auth-sync.service.ts
@@ -11,6 +11,16 @@ import {
 export interface AuthUser {
   id: string;
   orgId: string;
+  /**
+   * Org slug -- the human-readable identifier we use as the value of
+   * the Keycloak `org` user-attribute and as the JWT `org` claim.
+   * Carry it on AuthUser so anything that mints downstream identity
+   * (e.g. admin invite, service tokens) reaches for the slug rather
+   * than the UUID. Passing the UUID would re-trigger the phantom-org
+   * bug where auth-sync upserts a brand-new org keyed on the UUID
+   * because no slug matches.
+   */
+  orgSlug: string;
   username: string;
   email: string;
   orgRole: OrgRole;
@@ -77,11 +87,27 @@ export class AuthSyncService {
         ? 'contributor'
         : ((rawRole as OrgRole | undefined) ?? 'viewer');
 
-    const org = await this.prisma.organization.upsert({
-      where: { slug: orgSlug },
-      update: {},
-      create: { slug: orgSlug, name: orgSlug },
-    });
+    // Defense against the admin-invite bug where the new user's `org`
+    // attribute was historically set to the inviter's UUID instead of
+    // their slug. If we see a UUID-shaped value, prefer looking up
+    // the existing org by id rather than minting a phantom org with
+    // slug = UUID, name = UUID. The invite path is fixed (we now
+    // pass slug, not id), but stray Keycloak users from before the
+    // fix would otherwise create garbage orgs on first login.
+    const looksLikeUuid =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        orgSlug,
+      );
+    let org = looksLikeUuid
+      ? await this.prisma.organization.findUnique({ where: { id: orgSlug } })
+      : null;
+    if (!org) {
+      org = await this.prisma.organization.upsert({
+        where: { slug: orgSlug },
+        update: {},
+        create: { slug: orgSlug, name: orgSlug },
+      });
+    }
 
     // We key on `username` rather than Keycloak's `sub`. The local user.id is
     // our own stable identifier (possibly seeded or provisioned before the user
@@ -200,6 +226,7 @@ export class AuthSyncService {
     return {
       id: user.id,
       orgId: user.orgId,
+      orgSlug: org.slug,
       username: user.username,
       email: user.email,
       orgRole: user.orgRole,


### PR DESCRIPTION
**What you saw**: top-bar showed `Matthew Palavido` with `11111111-1111-1111-1111-111111111111` underneath where the org name should be, plus `Failed to load capabilities (404)` on the Edit-user dialog.

**Why**:

1. Admin invite (`AdminUsersController.invite`) was setting the new Keycloak user's `org` user-attribute to `me.orgId` -- a UUID. The `org` attribute drives the JWT `org` claim, which `auth-sync.service` treats as the **org slug**. Since no org has slug `11111111-...`, auth-sync's slug-keyed upsert created a brand-new "phantom" Organization with `slug = name = <UUID>`, then assigned the invitee to that phantom org. The invitee saw the UUID in their org name slot and ran into 404s on capabilities (the per-user admin lookup gates on `user.orgId === actor.orgId`, and the invitee was now in a different org from the inviting admin).

2. Even if (1) were fixed in code, any pre-existing Keycloak users with the bad UUID-shaped `org` attribute would still create phantom orgs on their first login.

**Fix**:

1. `AuthUser` gains an `orgSlug` field (filled from `Organization.slug`). `AdminUsersController.invite` sends `me.orgSlug` instead of `me.orgId`. New invitees now carry the correct slug.

2. `auth-sync.upsertFromClaims` first tries to resolve the Organization by `id` when the JWT `org` claim is UUID-shaped, and only falls through to the slug-keyed upsert if that misses. Defense-in-depth for stray Keycloak users provisioned before fix (1) -- on their first login, the right Organization gets resolved by id rather than minting a phantom one.

**Already done out-of-band**:

- Deleted the phantom `d08ba218-5c80-4e50-9f69-be4a0e23df5f` Organization row from the dev DB.
- Patched matt@palavido.org's Keycloak `org` attribute from `11111111-...` to `acme`.

After this PR + the cleanups, sign matt out and back in (so his JWT picks up the fixed `org` claim) and the menu should show `Acme Corp` and the Edit-user capabilities should load.

## Quality gate

- `pnpm typecheck` passes
- `pnpm lint` passes (existing import-type warnings only)
- `pnpm test` passes

Closes #140.
