### PR TITLE
feat(forms): Data Collection Phase 1 - shared schema, designer, mobile + offline runtime (#131)

### DIFF
--- a/apps/portal-api/prisma/migrations/20260428060000_form_submission/migration.sql
+++ b/apps/portal-api/prisma/migrations/20260428060000_form_submission/migration.sql
@@ -1,0 +1,35 @@
+-- Form Submission storage (#131).
+--
+-- Each row is one captured response against a form item. Keys:
+--   form_id        FK to the form item (the schema source of truth).
+--   client_id      idempotency key minted by the client at capture
+--                  time (so a re-drained offline queue is a no-op).
+--   schema_version the form schema version the response was captured
+--                  against; durable so a forward-rolled schema can
+--                  still resolve the row.
+--   response       the pruned Response JSON (only visible/answered
+--                  questions).
+--   submitted_by   user.id of the respondent. Nullable to keep
+--                  room for anonymous public-link submissions in
+--                  Phase 2 (org_id alone is enough to scope them).
+--   org_id         org tenancy key.
+--   captured_at    when the client originally captured the response
+--                  (may pre-date created_at by hours/days for
+--                  offline submissions).
+
+CREATE TABLE "form_submission" (
+    "id"             UUID         NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    "form_id"        UUID         NOT NULL REFERENCES "item"("id") ON DELETE CASCADE,
+    "org_id"         UUID         NOT NULL REFERENCES "organization"("id") ON DELETE CASCADE,
+    "client_id"      TEXT         NOT NULL,
+    "schema_version" INTEGER      NOT NULL,
+    "response"       JSONB        NOT NULL,
+    "submitted_by"   UUID         REFERENCES "user"("id") ON DELETE SET NULL,
+    "captured_at"    TIMESTAMPTZ  NOT NULL,
+    "created_at"     TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CONSTRAINT "form_submission_form_client_unique"
+        UNIQUE ("form_id", "client_id")
+);
+
+CREATE INDEX "form_submission_form_idx" ON "form_submission" ("form_id");
+CREATE INDEX "form_submission_submitted_by_idx" ON "form_submission" ("submitted_by");

--- a/apps/portal-api/prisma/schema.prisma
+++ b/apps/portal-api/prisma/schema.prisma
@@ -757,6 +757,28 @@ model SystemSetting {
   @@map("system_setting")
 }
 
+/// One captured response against a form item (#131). Idempotent on
+/// (formId, clientId) so a re-drained offline queue is safe. The
+/// captured `schemaVersion` is preserved so downstream consumers can
+/// still resolve the response against the right schema even if the
+/// form has been updated since capture.
+model FormSubmission {
+  id            String   @id @default(uuid()) @db.Uuid
+  formId        String   @map("form_id") @db.Uuid
+  orgId         String   @map("org_id") @db.Uuid
+  clientId      String   @map("client_id")
+  schemaVersion Int      @map("schema_version")
+  response      Json
+  submittedBy   String?  @map("submitted_by") @db.Uuid
+  capturedAt    DateTime @map("captured_at")
+  createdAt     DateTime @default(now()) @map("created_at")
+
+  @@unique([formId, clientId], map: "form_submission_form_client_unique")
+  @@index([formId], map: "form_submission_form_idx")
+  @@index([submittedBy], map: "form_submission_submitted_by_idx")
+  @@map("form_submission")
+}
+
 /// Per-(NotificationType, NotificationChannel) org-wide override of
 /// the code-level default in notification-types.ts. Sparse: an admin
 /// keeping the code default has no row. When materialising a user's

--- a/apps/portal-api/src/app.module.ts
+++ b/apps/portal-api/src/app.module.ts
@@ -17,6 +17,7 @@ import { V3FeaturesModule } from './features-v3/v3-features.module.js';
 import { PublicModule } from './public/public.module.js';
 import { BackupModule } from './backup/backup.module.js';
 import { NotificationsModule } from './notifications/notifications.module.js';
+import { FormsModule } from './forms/forms.module.js';
 import { JwtAuthGuard } from './auth/jwt-auth.guard.js';
 
 @Module({
@@ -36,6 +37,7 @@ import { JwtAuthGuard } from './auth/jwt-auth.guard.js';
     PublicModule,
     BackupModule,
     NotificationsModule,
+    FormsModule,
   ],
   controllers: [HealthController],
   providers: [

--- a/apps/portal-api/src/forms/forms.controller.ts
+++ b/apps/portal-api/src/forms/forms.controller.ts
@@ -1,0 +1,75 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import {
+  IsInt,
+  IsObject,
+  IsOptional,
+  IsString,
+  Length,
+  Min,
+} from 'class-validator';
+
+import { CurrentUser } from '../auth/current-user.decorator.js';
+import type { AuthUser } from '../auth/auth-sync.service.js';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard.js';
+import { FormsService } from './forms.service.js';
+
+class SubmitDto {
+  @IsString() @Length(8, 100) clientId!: string;
+  @IsInt() @Min(1) schemaVersion!: number;
+  @IsObject() response!: Record<string, unknown>;
+  @IsString() capturedAt!: string;
+}
+
+@ApiTags('forms')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('forms')
+export class FormsController {
+  constructor(private readonly forms: FormsService) {}
+
+  /**
+   * Submit a response. Idempotent on (formId, clientId) so a re-
+   * drained offline queue is a no-op. Returns 200 + { id, created }
+   * either way -- callers don't need to distinguish first-write from
+   * re-drain.
+   */
+  @Post(':id/submissions')
+  @HttpCode(200)
+  async submit(
+    @CurrentUser() user: AuthUser,
+    @Param('id') id: string,
+    @Body() dto: SubmitDto,
+  ): Promise<{ id: string; created: boolean }> {
+    return this.forms.submit(id, user, dto);
+  }
+
+  @Get(':id/submissions')
+  async list(
+    @CurrentUser() user: AuthUser,
+    @Param('id') id: string,
+    @Query('limit') limitRaw?: string,
+  ) {
+    const limit = limitRaw === undefined ? undefined : Math.max(1, Number(limitRaw));
+    const opts: { limit?: number } = {};
+    if (limit !== undefined) opts.limit = limit;
+    return this.forms.list(id, user, opts);
+  }
+
+  @Get(':id/submissions/_count')
+  async count(
+    @CurrentUser() user: AuthUser,
+    @Param('id') id: string,
+  ): Promise<{ count: number }> {
+    return { count: await this.forms.count(id, user) };
+  }
+}

--- a/apps/portal-api/src/forms/forms.module.ts
+++ b/apps/portal-api/src/forms/forms.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+
+import { PrismaModule } from '../prisma/prisma.module.js';
+import { FormsController } from './forms.controller.js';
+import { FormsService } from './forms.service.js';
+
+/**
+ * Form submission storage + access (#131). The form item itself
+ * (the schema) lives in the Items module; this module only owns
+ * captured responses.
+ */
+@Module({
+  imports: [PrismaModule],
+  controllers: [FormsController],
+  providers: [FormsService],
+  exports: [FormsService],
+})
+export class FormsModule {}

--- a/apps/portal-api/src/forms/forms.service.ts
+++ b/apps/portal-api/src/forms/forms.service.ts
@@ -1,0 +1,155 @@
+import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+
+import { PrismaService } from '../prisma/prisma.service.js';
+import type { AuthUser } from '../auth/auth-sync.service.js';
+
+/**
+ * Persistence and access control for form submissions (#131).
+ *
+ * Idempotency: writes go through `upsert` keyed on (formId, clientId)
+ * so a re-drained offline queue is a no-op rather than a duplicate.
+ *
+ * Access control today:
+ *   - The respondent must be able to see the form item (either by
+ *     ownership, by share, or by org-wide access). We piggyback on
+ *     the existing item visibility rules: if you can read the form,
+ *     you can submit to it. Phase 2 introduces explicit "respondent"
+ *     vs "viewer" share tiers.
+ *   - Listing submissions requires either ownership of the form or
+ *     org-admin role.
+ */
+@Injectable()
+export class FormsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Fetch the form item, gating by visibility for the caller. Used
+   *  to look up the orgId we'll stamp on the submission. */
+  private async getVisibleForm(formId: string, user: AuthUser) {
+    const item = await this.prisma.item.findUnique({
+      where: { id: formId },
+      select: { id: true, type: true, orgId: true, ownerId: true, access: true },
+    });
+    if (!item || item.type !== 'form') {
+      throw new NotFoundException('Form not found.');
+    }
+    // Same org check is the cheap baseline. Org-wide-public forms
+    // pass; private forms only pass when the respondent has a share.
+    if (item.orgId !== user.orgId) {
+      throw new ForbiddenException('Form is not in your organization.');
+    }
+    if (item.access === 'private' && item.ownerId !== user.id) {
+      const share = await this.prisma.itemShare.findFirst({
+        where: {
+          itemId: item.id,
+          OR: [
+            { principalType: 'user', principalId: user.id },
+            {
+              principalType: 'group',
+              principalId: { in: user.groupIds },
+            },
+          ],
+        },
+        select: { itemId: true },
+      });
+      if (!share) {
+        throw new ForbiddenException('You do not have access to this form.');
+      }
+    }
+    return item;
+  }
+
+  async submit(
+    formId: string,
+    user: AuthUser,
+    dto: {
+      clientId: string;
+      schemaVersion: number;
+      response: Record<string, unknown>;
+      capturedAt: string;
+    },
+  ): Promise<{ id: string; created: boolean }> {
+    const form = await this.getVisibleForm(formId, user);
+    const captured = new Date(dto.capturedAt);
+    if (Number.isNaN(captured.getTime())) {
+      throw new ForbiddenException('Invalid capturedAt.');
+    }
+    const result = await this.prisma.formSubmission.upsert({
+      where: { formId_clientId: { formId: form.id, clientId: dto.clientId } },
+      create: {
+        formId: form.id,
+        orgId: form.orgId,
+        clientId: dto.clientId,
+        schemaVersion: dto.schemaVersion,
+        response: dto.response as Prisma.InputJsonValue,
+        submittedBy: user.id,
+        capturedAt: captured,
+      },
+      update: {}, // idempotent on re-drain; never overwrite a stored row
+      select: { id: true, createdAt: true },
+    });
+    // `created` is true only when the row didn't already exist -- we
+    // proxy it via createdAt being equal to "right now" within
+    // tolerance, which is good enough for the UI and avoids a second
+    // query. Phase 2 may switch to a tx-level WAS-CREATED flag.
+    const justCreated =
+      Date.now() - result.createdAt.getTime() < 5_000;
+    return { id: result.id, created: justCreated };
+  }
+
+  async list(
+    formId: string,
+    user: AuthUser,
+    opts: { limit?: number } = {},
+  ): Promise<
+    Array<{
+      id: string;
+      clientId: string;
+      response: unknown;
+      submittedBy: string | null;
+      capturedAt: string;
+      createdAt: string;
+      schemaVersion: number;
+    }>
+  > {
+    const form = await this.getVisibleForm(formId, user);
+    if (form.ownerId !== user.id && user.orgRole !== 'admin') {
+      throw new ForbiddenException(
+        'Only the form owner or an org admin can view submissions.',
+      );
+    }
+    const rows = await this.prisma.formSubmission.findMany({
+      where: { formId: form.id },
+      orderBy: { createdAt: 'desc' },
+      take: Math.max(1, Math.min(opts.limit ?? 100, 500)),
+      select: {
+        id: true,
+        clientId: true,
+        response: true,
+        submittedBy: true,
+        capturedAt: true,
+        createdAt: true,
+        schemaVersion: true,
+      },
+    });
+    return rows.map((r) => ({
+      id: r.id,
+      clientId: r.clientId,
+      response: r.response,
+      submittedBy: r.submittedBy,
+      capturedAt: r.capturedAt.toISOString(),
+      createdAt: r.createdAt.toISOString(),
+      schemaVersion: r.schemaVersion,
+    }));
+  }
+
+  async count(formId: string, user: AuthUser): Promise<number> {
+    const form = await this.getVisibleForm(formId, user);
+    if (form.ownerId !== user.id && user.orgRole !== 'admin') {
+      throw new ForbiddenException(
+        'Only the form owner or an org admin can view submission counts.',
+      );
+    }
+    return this.prisma.formSubmission.count({ where: { formId: form.id } });
+  }
+}

--- a/apps/portal-web/package.json
+++ b/apps/portal-web/package.json
@@ -10,6 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@gratis-gis/form-schema": "workspace:*",
     "@gratis-gis/shared-types": "workspace:*",
     "@gratis-gis/ui": "workspace:*",
     "@tmcw/togeojson": "^6.0.1",

--- a/apps/portal-web/src/app/forms/[id]/respond/page.tsx
+++ b/apps/portal-web/src/app/forms/[id]/respond/page.tsx
@@ -1,0 +1,51 @@
+import type { FormSchema } from '@gratis-gis/form-schema';
+import { apiFetch } from '@/lib/api';
+import { RespondClient } from './respond-client';
+
+interface Props {
+  params: { id: string };
+}
+
+interface ItemPayload {
+  id: string;
+  type: string;
+  title: string;
+  data: unknown;
+}
+
+/**
+ * Public-ish respond page for a form item (#131). Server-renders the
+ * form schema once for fast first paint, hands off to the client for
+ * the actual capture. The client handles offline queueing -- so once
+ * the user has loaded this page once, they can keep submitting from
+ * the field without connectivity.
+ *
+ * Auth: today the page sits behind the same JWT-cookie middleware as
+ * the rest of the portal, so respondents need a portal account. A
+ * follow-up adds a public-link mode (anonymous tokens, share-by-
+ * URL) for surveys you genuinely want to expose to the world.
+ */
+export default async function FormRespondPage({ params }: Props) {
+  const item = await apiFetch<ItemPayload>(`/api/items/${params.id}`);
+  if (item.type !== 'form') {
+    return (
+      <div className="mx-auto max-w-xl px-4 py-12 text-center text-sm text-muted">
+        That item is not a form.
+      </div>
+    );
+  }
+  const schema =
+    item.data &&
+    typeof item.data === 'object' &&
+    'questions' in (item.data as object)
+      ? ((item.data as unknown) as FormSchema)
+      : null;
+  if (!schema || schema.questions.length === 0) {
+    return (
+      <div className="mx-auto max-w-xl px-4 py-12 text-center text-sm text-muted">
+        This form has no questions yet.
+      </div>
+    );
+  }
+  return <RespondClient form={schema} formItemTitle={item.title} />;
+}

--- a/apps/portal-web/src/app/forms/[id]/respond/respond-client.tsx
+++ b/apps/portal-web/src/app/forms/[id]/respond/respond-client.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { CloudOff, RefreshCcw, Wifi } from 'lucide-react';
+import type { FormSchema, Response } from '@gratis-gis/form-schema';
+import { FormRuntime } from '@/components/form-runtime';
+import {
+  drain,
+  listQueued,
+  queueSubmission,
+  type QueuedSubmission,
+} from '@/lib/form-offline';
+
+interface Props {
+  form: FormSchema;
+  formItemTitle: string;
+}
+
+/**
+ * Client wrapper around FormRuntime that handles online/offline,
+ * IndexedDB queueing, and outbox surfacing.
+ *
+ * Submission strategy:
+ *   1. Always queue first (IndexedDB) so submissions survive a
+ *      crash / page-close.
+ *   2. If online, immediately attempt to drain the queue against
+ *      the server. The newly-queued row goes through the same
+ *      drain path as anything stale.
+ *   3. If offline, leave it queued; the periodic check (or the
+ *      next online event) will drain.
+ *
+ * Server-side endpoint: POST /api/portal/forms/:id/submissions with
+ *   { clientId, schemaVersion, response, capturedAt }
+ * Idempotent on clientId at the server (a re-drained row is a no-op).
+ */
+export function RespondClient({ form, formItemTitle }: Props) {
+  const [online, setOnline] = useState<boolean>(() =>
+    typeof navigator !== 'undefined' ? navigator.onLine : true,
+  );
+  const [outbox, setOutbox] = useState<QueuedSubmission[]>([]);
+  const [draining, setDraining] = useState(false);
+
+  const refreshOutbox = useCallback(async () => {
+    try {
+      const all = await listQueued();
+      setOutbox(all.filter((r) => r.formId === form.id && r.status !== 'sent'));
+    } catch {
+      // IndexedDB unavailable (private browsing, etc) -- runtime still
+      // works for online-only submissions.
+    }
+  }, [form.id]);
+
+  const drainOnce = useCallback(async () => {
+    if (draining) return;
+    setDraining(true);
+    try {
+      await drain(form.id, async (row) => {
+        const res = await fetch(
+          `/api/portal/forms/${form.id}/submissions`,
+          {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({
+              clientId: row.clientId,
+              schemaVersion: row.schemaVersion,
+              response: row.response,
+              capturedAt: row.capturedAt,
+            }),
+          },
+        );
+        if (!res.ok) {
+          throw new Error(`${res.status} ${await res.text().catch(() => '')}`);
+        }
+      });
+    } finally {
+      setDraining(false);
+      await refreshOutbox();
+    }
+  }, [draining, form.id, refreshOutbox]);
+
+  useEffect(() => {
+    const onOnline = () => {
+      setOnline(true);
+      void drainOnce();
+    };
+    const onOffline = () => setOnline(false);
+    window.addEventListener('online', onOnline);
+    window.addEventListener('offline', onOffline);
+    void refreshOutbox();
+    if (navigator.onLine) void drainOnce();
+    return () => {
+      window.removeEventListener('online', onOnline);
+      window.removeEventListener('offline', onOffline);
+    };
+  }, [drainOnce, refreshOutbox]);
+
+  async function handleSubmit(response: Response) {
+    await queueSubmission({
+      formId: form.id,
+      schemaVersion: form.schemaVersion,
+      response,
+    });
+    await refreshOutbox();
+    if (navigator.onLine) {
+      // Best-effort drain. If it fails the row stays queued and the
+      // user sees it in the outbox.
+      await drainOnce();
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-surface-0">
+      <div className="border-b border-border bg-surface-1 px-4 py-2 text-xs text-ink-1">
+        <div className="mx-auto flex w-full max-w-xl items-center justify-between gap-2">
+          <span className="truncate">{formItemTitle}</span>
+          <span
+            className={`inline-flex items-center gap-1 ${
+              online ? 'text-emerald-700' : 'text-amber-700'
+            }`}
+          >
+            {online ? <Wifi className="h-3.5 w-3.5" /> : <CloudOff className="h-3.5 w-3.5" />}
+            {online ? 'Online' : 'Offline'}
+          </span>
+        </div>
+      </div>
+
+      <FormRuntime form={form} onSubmit={handleSubmit} submitLabel="Submit" />
+
+      {outbox.length > 0 ? (
+        <div className="mx-auto w-full max-w-xl px-4 py-4">
+          <div className="rounded-md border border-border bg-surface-1 p-3">
+            <div className="mb-2 flex items-center justify-between">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted">
+                Outbox ({outbox.length})
+              </p>
+              <button
+                type="button"
+                onClick={() => void drainOnce()}
+                disabled={draining || !online}
+                className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-surface-1 px-2 text-[11px] font-medium text-ink-1 hover:bg-surface-2 disabled:opacity-50"
+              >
+                <RefreshCcw className="h-3 w-3" />
+                {draining ? 'Sending...' : online ? 'Try again' : 'Offline'}
+              </button>
+            </div>
+            <ul className="space-y-1.5 text-xs">
+              {outbox.map((r) => (
+                <li
+                  key={r.clientId}
+                  className="flex items-start justify-between gap-2 rounded border border-border bg-surface-0 px-2 py-1"
+                >
+                  <span className="truncate">
+                    {new Date(r.capturedAt).toLocaleString()}
+                  </span>
+                  <span
+                    className={`inline-flex rounded-full px-1.5 text-[10px] uppercase tracking-wide ${
+                      r.status === 'failed'
+                        ? 'bg-amber-100 text-amber-900'
+                        : 'bg-surface-2 text-muted'
+                    }`}
+                  >
+                    {r.status}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -1,0 +1,791 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import {
+  AlignLeft,
+  Calculator,
+  Calendar,
+  CalendarClock,
+  Camera,
+  CheckSquare,
+  Circle,
+  Clock,
+  Eye,
+  GripVertical,
+  Hash,
+  ListChecks,
+  Loader2,
+  MapPin,
+  Plus,
+  Save,
+  Sliders,
+  SplitSquareHorizontal,
+  Square,
+  Star,
+  Text as TextIcon,
+  ToggleLeft,
+  Trash2,
+  Type,
+  Workflow,
+} from 'lucide-react';
+import {
+  collectIds,
+  CURRENT_FORM_SCHEMA_VERSION,
+  defaultQuestion,
+  emptyForm,
+  QUESTION_TYPES,
+  suggestQuestionId,
+  uniqueQuestionId,
+  type Choice,
+  type Expression,
+  type FormSchema,
+  type Question,
+  type QuestionId,
+  type QuestionType,
+} from '@gratis-gis/form-schema';
+import { FormRuntime } from '@/components/form-runtime';
+
+interface Props {
+  itemId: string;
+  initial: FormSchema | null;
+  canEdit: boolean;
+}
+
+/**
+ * Three-panel form designer (#131). Survey123-style layout: palette on
+ * the left, canvas in the middle, properties on the right; a Preview
+ * tab swaps the canvas with the live runtime so authors can sanity-
+ * check what respondents will see.
+ *
+ * Persistence: the schema lives on the form item's `data_json`. Save
+ * does a PUT to /api/portal/items/<id> with the full data field.
+ *
+ * Drag-drop: HTML5 native (no extra deps). Drag from palette into the
+ * canvas to add; drag a canvas row by its grip to reorder. Touch
+ * drag-drop is awkward on phones, so the palette + canvas also
+ * support tap-to-add (selecting a palette tile inserts at the end of
+ * the canvas).
+ */
+export function FormDesigner({ itemId, initial, canEdit }: Props) {
+  const [form, setForm] = useState<FormSchema>(
+    () => initial ?? emptyForm(itemId, 'Untitled form'),
+  );
+  const [selectedId, setSelectedId] = useState<QuestionId | null>(null);
+  const [tab, setTab] = useState<'design' | 'preview'>('design');
+  const [saving, setSaving] = useState(false);
+  const [savedAt, setSavedAt] = useState<Date | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const selected = useMemo(
+    () => (selectedId ? form.questions.find((q) => q.id === selectedId) ?? null : null),
+    [form.questions, selectedId],
+  );
+
+  const addQuestion = useCallback(
+    (type: QuestionType) => {
+      const baseId = suggestQuestionId(type);
+      const id = uniqueQuestionId(form, baseId);
+      const q = defaultQuestion(type, id);
+      setForm((f) => ({ ...f, questions: [...f.questions, q] }));
+      setSelectedId(id);
+    },
+    [form],
+  );
+
+  const updateQuestion = useCallback(
+    (id: QuestionId, patch: Partial<Question>) => {
+      setForm((f) => ({
+        ...f,
+        questions: f.questions.map((q) =>
+          q.id === id ? ({ ...q, ...patch } as Question) : q,
+        ),
+      }));
+    },
+    [],
+  );
+
+  const removeQuestion = useCallback((id: QuestionId) => {
+    setForm((f) => ({
+      ...f,
+      questions: f.questions.filter((q) => q.id !== id),
+    }));
+    setSelectedId(null);
+  }, []);
+
+  const reorder = useCallback((from: number, to: number) => {
+    setForm((f) => {
+      const next = f.questions.slice();
+      const [moved] = next.splice(from, 1);
+      if (moved) next.splice(to, 0, moved);
+      return { ...f, questions: next };
+    });
+  }, []);
+
+  async function save() {
+    if (!canEdit) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/portal/items/${itemId}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ data: form }),
+      });
+      if (!res.ok) throw new Error(`${res.status} ${await res.text()}`);
+      setSavedAt(new Date());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-border bg-surface-1 shadow-card">
+      <header className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
+        <div className="flex items-center gap-3">
+          <input
+            type="text"
+            value={form.title}
+            disabled={!canEdit}
+            onChange={(e) => setForm({ ...form, title: e.target.value })}
+            className="rounded-md border border-border bg-surface-1 px-2 py-1 text-sm font-medium text-ink-0 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30 disabled:opacity-60"
+          />
+          <span className="text-[10px] uppercase tracking-wide text-muted">
+            schema v{CURRENT_FORM_SCHEMA_VERSION}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="inline-flex rounded-md border border-border bg-surface-2 p-0.5 text-xs">
+            <button
+              type="button"
+              onClick={() => setTab('design')}
+              className={`px-2 py-1 ${
+                tab === 'design'
+                  ? 'rounded bg-surface-1 text-ink-0 shadow-sm'
+                  : 'text-muted'
+              }`}
+            >
+              Design
+            </button>
+            <button
+              type="button"
+              onClick={() => setTab('preview')}
+              className={`px-2 py-1 ${
+                tab === 'preview'
+                  ? 'rounded bg-surface-1 text-ink-0 shadow-sm'
+                  : 'text-muted'
+              }`}
+            >
+              <Eye className="mr-1 inline h-3 w-3" />
+              Preview
+            </button>
+          </div>
+          {canEdit ? (
+            <button
+              type="button"
+              onClick={() => void save()}
+              disabled={saving}
+              className="inline-flex h-8 items-center gap-1 rounded-md bg-accent px-3 text-xs font-medium text-accent-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              {saving ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Save className="h-3.5 w-3.5" />
+              )}
+              Save
+            </button>
+          ) : null}
+        </div>
+      </header>
+
+      {error ? (
+        <p className="border-b border-danger/40 bg-danger/5 px-4 py-2 text-xs text-danger">
+          {error}
+        </p>
+      ) : null}
+      {savedAt && !error ? (
+        <p className="border-b border-emerald-300 bg-emerald-50 px-4 py-1 text-[11px] text-emerald-800">
+          Saved {savedAt.toLocaleTimeString()}.
+        </p>
+      ) : null}
+
+      {tab === 'design' ? (
+        <div className="grid grid-cols-1 lg:grid-cols-[200px_1fr_280px]">
+          <Palette canEdit={canEdit} onAdd={addQuestion} />
+          <Canvas
+            form={form}
+            selectedId={selectedId}
+            canEdit={canEdit}
+            onSelect={setSelectedId}
+            onRemove={removeQuestion}
+            onReorder={reorder}
+            onAdd={addQuestion}
+          />
+          <Properties
+            form={form}
+            question={selected}
+            canEdit={canEdit}
+            onChange={(patch) => {
+              if (selected) updateQuestion(selected.id, patch);
+            }}
+            onRename={(newId) => {
+              if (!selected) return;
+              if (newId === selected.id) return;
+              const ids = collectIds(form);
+              ids.delete(selected.id);
+              if (ids.has(newId)) {
+                setError(`Question id "${newId}" is already used.`);
+                return;
+              }
+              setError(null);
+              setForm((f) => ({
+                ...f,
+                questions: f.questions.map((q) =>
+                  q.id === selected.id ? ({ ...q, id: newId } as Question) : q,
+                ),
+              }));
+              setSelectedId(newId);
+            }}
+            onUpdateForm={(patch) => setForm({ ...form, ...patch })}
+          />
+        </div>
+      ) : (
+        <div className="border-t border-border bg-surface-0">
+          <FormRuntime
+            form={form}
+            onSubmit={async () => {
+              /* preview discards submission */
+            }}
+            readOnly
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---- Palette ----------------------------------------------------
+
+interface PaletteEntry {
+  type: QuestionType;
+  label: string;
+  icon: typeof Type;
+  group: 'basic' | 'choice' | 'time' | 'media' | 'spatial' | 'logic' | 'layout';
+}
+
+const PALETTE: PaletteEntry[] = [
+  { type: 'text', label: 'Short text', icon: Type, group: 'basic' },
+  { type: 'multiline', label: 'Long text', icon: AlignLeft, group: 'basic' },
+  { type: 'number', label: 'Number', icon: Hash, group: 'basic' },
+  { type: 'integer', label: 'Whole number', icon: Hash, group: 'basic' },
+  { type: 'boolean', label: 'Yes / No', icon: ToggleLeft, group: 'basic' },
+  { type: 'select-one', label: 'Single choice', icon: Circle, group: 'choice' },
+  { type: 'select-many', label: 'Multiple choice', icon: CheckSquare, group: 'choice' },
+  { type: 'date', label: 'Date', icon: Calendar, group: 'time' },
+  { type: 'time', label: 'Time', icon: Clock, group: 'time' },
+  { type: 'datetime', label: 'Date + time', icon: CalendarClock, group: 'time' },
+  { type: 'photo', label: 'Photo', icon: Camera, group: 'media' },
+  { type: 'signature', label: 'Signature', icon: Type, group: 'media' },
+  { type: 'geopoint', label: 'Location', icon: MapPin, group: 'spatial' },
+  { type: 'geotrace', label: 'Path', icon: SplitSquareHorizontal, group: 'spatial' },
+  { type: 'geoshape', label: 'Area', icon: Square, group: 'spatial' },
+  { type: 'rating', label: 'Rating', icon: Star, group: 'basic' },
+  { type: 'slider', label: 'Slider', icon: Sliders, group: 'basic' },
+  { type: 'calculated', label: 'Calculated', icon: Calculator, group: 'logic' },
+  { type: 'note', label: 'Note', icon: TextIcon, group: 'layout' },
+  { type: 'page', label: 'Page break', icon: Workflow, group: 'layout' },
+  { type: 'group', label: 'Group', icon: ListChecks, group: 'layout' },
+];
+
+function Palette({
+  canEdit,
+  onAdd,
+}: {
+  canEdit: boolean;
+  onAdd: (type: QuestionType) => void;
+}) {
+  return (
+    <aside className="border-b border-border bg-surface-2/40 p-3 lg:border-b-0 lg:border-r">
+      <p className="mb-2 text-[10px] font-medium uppercase tracking-wide text-muted">
+        Add a question
+      </p>
+      <div className="flex flex-wrap gap-1.5 lg:flex-col">
+        {QUESTION_TYPES.map((t) => {
+          const entry = PALETTE.find((e) => e.type === t);
+          if (!entry) return null;
+          const Icon = entry.icon;
+          return (
+            <button
+              type="button"
+              key={t}
+              draggable={canEdit}
+              onDragStart={(e) => {
+                e.dataTransfer.setData('text/x-question-type', t);
+                e.dataTransfer.effectAllowed = 'copy';
+              }}
+              onClick={() => canEdit && onAdd(t)}
+              disabled={!canEdit}
+              className="inline-flex w-full items-center gap-1.5 rounded-md border border-border bg-surface-1 px-2 py-1.5 text-xs text-ink-1 hover:bg-surface-2 disabled:opacity-50"
+            >
+              <Icon className="h-3.5 w-3.5 text-muted" />
+              <span className="truncate text-left">{entry.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}
+
+// ---- Canvas -----------------------------------------------------
+
+function Canvas({
+  form,
+  selectedId,
+  canEdit,
+  onSelect,
+  onRemove,
+  onReorder,
+  onAdd,
+}: {
+  form: FormSchema;
+  selectedId: QuestionId | null;
+  canEdit: boolean;
+  onSelect: (id: QuestionId) => void;
+  onRemove: (id: QuestionId) => void;
+  onReorder: (from: number, to: number) => void;
+  onAdd: (type: QuestionType) => void;
+}) {
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
+
+  function onDropTarget(toIndex: number, e: React.DragEvent) {
+    e.preventDefault();
+    const newType = e.dataTransfer.getData('text/x-question-type');
+    if (newType) {
+      // adding from palette
+      onAdd(newType as QuestionType);
+      return;
+    }
+    if (dragIndex !== null) {
+      onReorder(dragIndex, toIndex);
+    }
+    setDragIndex(null);
+    setOverIndex(null);
+  }
+
+  return (
+    <main
+      className="min-h-[420px] border-b border-border bg-surface-0 p-4 lg:border-b-0"
+      onDragOver={(e) => {
+        if (canEdit) e.preventDefault();
+      }}
+      onDrop={(e) => {
+        if (!canEdit) return;
+        const newType = e.dataTransfer.getData('text/x-question-type');
+        if (newType) onAdd(newType as QuestionType);
+      }}
+    >
+      {form.questions.length === 0 ? (
+        <div className="flex h-64 flex-col items-center justify-center rounded-md border border-dashed border-border bg-surface-1 text-center text-sm text-muted">
+          <Plus className="mb-2 h-5 w-5" />
+          Drag a question type from the left, or tap one to add it.
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {form.questions.map((q, i) => (
+            <li key={q.id}>
+              <div
+                className={`relative rounded-md border ${
+                  q.id === selectedId
+                    ? 'border-accent ring-2 ring-accent/30'
+                    : 'border-border'
+                } bg-surface-1 p-3 ${
+                  overIndex === i ? 'border-t-2 border-t-accent' : ''
+                }`}
+                onClick={() => onSelect(q.id)}
+                onDragOver={(e) => {
+                  if (!canEdit) return;
+                  e.preventDefault();
+                  setOverIndex(i);
+                }}
+                onDrop={(e) => {
+                  if (!canEdit) return;
+                  onDropTarget(i, e);
+                }}
+                onDragLeave={() => setOverIndex(null)}
+              >
+                <div className="flex items-start gap-2">
+                  {canEdit ? (
+                    <button
+                      type="button"
+                      draggable
+                      onDragStart={(e) => {
+                        e.dataTransfer.setData('text/x-reorder', String(i));
+                        e.dataTransfer.effectAllowed = 'move';
+                        setDragIndex(i);
+                      }}
+                      onDragEnd={() => {
+                        setDragIndex(null);
+                        setOverIndex(null);
+                      }}
+                      className="cursor-grab text-muted hover:text-ink-0"
+                      aria-label="Drag to reorder"
+                    >
+                      <GripVertical className="h-4 w-4" />
+                    </button>
+                  ) : null}
+                  <div className="flex-1">
+                    <p className="text-xs uppercase tracking-wide text-muted">
+                      {q.type} · <span className="font-mono">{q.id}</span>
+                    </p>
+                    <p className="text-sm font-medium text-ink-0">{q.label}</p>
+                    {q.hint ? (
+                      <p className="text-xs text-muted">{q.hint}</p>
+                    ) : null}
+                  </div>
+                  {canEdit ? (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onRemove(q.id);
+                      }}
+                      className="rounded p-1 text-muted hover:bg-surface-2 hover:text-danger"
+                      aria-label="Remove question"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}
+
+// ---- Properties -------------------------------------------------
+
+function Properties({
+  form,
+  question,
+  canEdit,
+  onChange,
+  onRename,
+  onUpdateForm,
+}: {
+  form: FormSchema;
+  question: Question | null;
+  canEdit: boolean;
+  onChange: (patch: Partial<Question>) => void;
+  onRename: (newId: string) => void;
+  onUpdateForm: (patch: Partial<FormSchema>) => void;
+}) {
+  if (!question) {
+    return (
+      <aside className="border-l border-border bg-surface-2/40 p-3">
+        <p className="mb-2 text-[10px] font-medium uppercase tracking-wide text-muted">
+          Form
+        </p>
+        <Field label="Description">
+          <textarea
+            rows={3}
+            value={form.description ?? ''}
+            disabled={!canEdit}
+            onChange={(e) => onUpdateForm({ description: e.target.value })}
+            className={inputCls}
+          />
+        </Field>
+        <p className="mt-3 text-[11px] text-muted">
+          Select a question on the left to edit it.
+        </p>
+      </aside>
+    );
+  }
+  return (
+    <aside className="border-l border-border bg-surface-2/40 p-3">
+      <p className="mb-2 text-[10px] font-medium uppercase tracking-wide text-muted">
+        {question.type} properties
+      </p>
+
+      <Field label="Label">
+        <input
+          type="text"
+          value={question.label}
+          disabled={!canEdit}
+          onChange={(e) => onChange({ label: e.target.value })}
+          className={inputCls}
+        />
+      </Field>
+
+      <Field label="Question id" hint="Used as the column name in the layer schema.">
+        <input
+          type="text"
+          value={question.id}
+          disabled={!canEdit}
+          onChange={(e) => onRename(e.target.value)}
+          className={`${inputCls} font-mono`}
+        />
+      </Field>
+
+      <Field label="Hint">
+        <textarea
+          rows={2}
+          value={question.hint ?? ''}
+          disabled={!canEdit}
+          onChange={(e) => onChange({ hint: e.target.value || undefined })}
+          className={inputCls}
+        />
+      </Field>
+
+      <label className="mb-2 inline-flex items-center gap-2 text-xs">
+        <input
+          type="checkbox"
+          checked={Boolean(question.required)}
+          disabled={!canEdit}
+          onChange={(e) => onChange({ required: e.target.checked })}
+        />
+        <span>Required</span>
+      </label>
+
+      {/* Type-specific bits */}
+      {question.type === 'select-one' || question.type === 'select-many' ? (
+        <ChoicesEditor
+          choices={question.choices}
+          canEdit={canEdit}
+          onChange={(choices) => onChange({ choices } as Partial<Question>)}
+        />
+      ) : null}
+
+      {question.type === 'number' || question.type === 'integer' ? (
+        <div className="grid grid-cols-2 gap-2">
+          <Field label="Min">
+            <input
+              type="number"
+              value={question.min ?? ''}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({
+                  min: e.target.value === '' ? undefined : Number(e.target.value),
+                } as Partial<Question>)
+              }
+              className={inputCls}
+            />
+          </Field>
+          <Field label="Max">
+            <input
+              type="number"
+              value={question.max ?? ''}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({
+                  max: e.target.value === '' ? undefined : Number(e.target.value),
+                } as Partial<Question>)
+              }
+              className={inputCls}
+            />
+          </Field>
+        </div>
+      ) : null}
+
+      {question.type === 'text' || question.type === 'multiline' ? (
+        <Field label="Max length">
+          <input
+            type="number"
+            value={question.maxLength ?? ''}
+            disabled={!canEdit}
+            onChange={(e) =>
+              onChange({
+                maxLength: e.target.value === '' ? undefined : Number(e.target.value),
+              } as Partial<Question>)
+            }
+            className={inputCls}
+          />
+        </Field>
+      ) : null}
+
+      <details className="mt-3 rounded-md border border-border bg-surface-1 p-2 text-xs">
+        <summary className="cursor-pointer text-muted">Conditional logic</summary>
+        <div className="mt-2 space-y-2">
+          <ExpressionEditor
+            label="Visible if"
+            value={question.visibleIf}
+            allFields={form.questions.map((q) => ({ id: q.id, label: q.label }))}
+            disabled={!canEdit}
+            onChange={(visibleIf) => onChange({ visibleIf })}
+          />
+        </div>
+      </details>
+    </aside>
+  );
+}
+
+const inputCls =
+  'block w-full rounded-md border border-border bg-surface-1 px-2 py-1 text-xs focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30 disabled:opacity-60';
+
+function Field({
+  label,
+  hint,
+  children,
+}: {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="mb-2 block text-xs">
+      <span className="mb-0.5 block uppercase tracking-wide text-muted">
+        {label}
+      </span>
+      {children}
+      {hint ? <p className="mt-0.5 text-[11px] text-muted">{hint}</p> : null}
+    </label>
+  );
+}
+
+function ChoicesEditor({
+  choices,
+  canEdit,
+  onChange,
+}: {
+  choices: Choice[];
+  canEdit: boolean;
+  onChange: (next: Choice[]) => void;
+}) {
+  return (
+    <div className="mb-2">
+      <p className="mb-1 text-[10px] uppercase tracking-wide text-muted">Choices</p>
+      <div className="space-y-1">
+        {choices.map((c, i) => (
+          <div key={i} className="flex items-center gap-1">
+            <input
+              type="text"
+              value={c.value}
+              placeholder="value"
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange(
+                  choices.map((cc, ii) =>
+                    ii === i ? { ...cc, value: e.target.value } : cc,
+                  ),
+                )
+              }
+              className={`${inputCls} font-mono w-24`}
+            />
+            <input
+              type="text"
+              value={c.label}
+              placeholder="label"
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange(
+                  choices.map((cc, ii) =>
+                    ii === i ? { ...cc, label: e.target.value } : cc,
+                  ),
+                )
+              }
+              className={`${inputCls} flex-1`}
+            />
+            {canEdit ? (
+              <button
+                type="button"
+                onClick={() => onChange(choices.filter((_, ii) => ii !== i))}
+                className="rounded p-1 text-muted hover:bg-surface-2 hover:text-danger"
+                aria-label="Remove choice"
+              >
+                <Trash2 className="h-3 w-3" />
+              </button>
+            ) : null}
+          </div>
+        ))}
+        {canEdit ? (
+          <button
+            type="button"
+            onClick={() =>
+              onChange([
+                ...choices,
+                { value: `option_${choices.length + 1}`, label: `Option ${choices.length + 1}` },
+              ])
+            }
+            className="inline-flex h-7 items-center gap-1 rounded-md border border-dashed border-border bg-surface-1 px-2 text-[11px] text-ink-1 hover:bg-surface-2"
+          >
+            <Plus className="h-3 w-3" />
+            Add choice
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function ExpressionEditor({
+  label,
+  value,
+  allFields,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  value: Expression | undefined;
+  allFields: Array<{ id: string; label: string }>;
+  disabled: boolean;
+  onChange: (next: Expression | undefined) => void;
+}) {
+  // Phase 1 minimal builder: a single `eq` between a question ref
+  // and a literal. The Expression type already supports the fuller
+  // shape; the builder UI catches up in Phase 2.
+  const eq =
+    value && value.op === 'eq' && 'ref' in value.left && 'value' in value.right
+      ? { ref: value.left.ref, val: value.right.value as string | number | boolean | null }
+      : null;
+  return (
+    <div>
+      <p className="mb-0.5 text-[10px] uppercase tracking-wide text-muted">{label}</p>
+      <div className="grid grid-cols-2 gap-1">
+        <select
+          value={eq?.ref ?? ''}
+          disabled={disabled}
+          onChange={(e) => {
+            const ref = e.target.value;
+            if (!ref) {
+              onChange(undefined);
+              return;
+            }
+            onChange({
+              op: 'eq',
+              left: { ref },
+              right: { value: eq?.val ?? '' },
+            });
+          }}
+          className={`${inputCls}`}
+        >
+          <option value="">none</option>
+          {allFields.map((f) => (
+            <option key={f.id} value={f.id}>
+              {f.label}
+            </option>
+          ))}
+        </select>
+        <input
+          type="text"
+          value={eq?.val === null || eq?.val === undefined ? '' : String(eq.val)}
+          placeholder="equals..."
+          disabled={disabled || !eq}
+          onChange={(e) => {
+            if (!eq) return;
+            onChange({
+              op: 'eq',
+              left: { ref: eq.ref },
+              right: { value: e.target.value },
+            });
+          }}
+          className={inputCls}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/portal-web/src/app/items/[id]/page.tsx
+++ b/apps/portal-web/src/app/items/[id]/page.tsx
@@ -104,6 +104,8 @@ import { PickListEditor } from './pick-list/editor';
 import { GeoBoundaryEditor } from './geo-boundary/editor';
 import { FolderDetail } from './folder/folder-detail';
 import { EditorDetail } from './editor/editor-detail';
+import { FormDesigner } from './form/designer';
+import type { FormSchema } from '@gratis-gis/form-schema';
 import { DataLayerProvenance } from './data-layer/provenance-panel';
 import { DataLayerSchema } from './data-layer/schema-panel';
 import { VersionHistoryPanel } from './data-layer/version-history-panel';
@@ -531,6 +533,29 @@ export default async function ItemDetailPage({ params }: Props) {
             }}
             canEdit={canManage}
           />
+        </section>
+      ) : item.type === 'form' ? (
+        <section className="mb-6">
+          <FormDesigner
+            itemId={item.id}
+            initial={
+              item.data && typeof item.data === 'object' && 'questions' in (item.data as object)
+                ? ((item.data as unknown) as FormSchema)
+                : null
+            }
+            canEdit={canManage}
+          />
+          <div className="mt-3 flex items-center gap-2 text-xs text-muted">
+            <span>
+              Respondent link:{' '}
+              <Link
+                href={`/forms/${item.id}/respond`}
+                className="font-mono text-accent hover:underline"
+              >
+                /forms/{item.id}/respond
+              </Link>
+            </span>
+          </div>
         </section>
       ) : (
         <section className="mb-6">

--- a/apps/portal-web/src/components/form-runtime.tsx
+++ b/apps/portal-web/src/components/form-runtime.tsx
@@ -1,0 +1,909 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Camera,
+  Check,
+  ChevronLeft,
+  ChevronRight,
+  Loader2,
+  MapPin,
+  Plus,
+  Trash2,
+} from 'lucide-react';
+import {
+  applyCalculations,
+  evaluate,
+  isRequired,
+  isVisible,
+  pruneHidden,
+  validate,
+  walkQuestions,
+  type Expression,
+  type FormSchema,
+  type Question,
+  type Response,
+  type ValidationError,
+} from '@gratis-gis/form-schema';
+
+/**
+ * Mobile-first runtime that renders any FormSchema and captures a
+ * Response. Used in two places:
+ *
+ *   - Designer preview pane: live preview of the form while
+ *     authoring, with the in-memory schema.
+ *   - Respondent page: end-user filling in a published form.
+ *     `/forms/<id>/respond` mounts this directly.
+ *
+ * Mobile + offline considerations:
+ *   - Single-column layout, generous tap targets (44+ px).
+ *   - Native input types (`date`, `time`, `datetime-local`, `tel`,
+ *     `number` with `inputmode`) so phone keyboards do the right
+ *     thing.
+ *   - No third-party UI deps -- everything renders even if assets
+ *     are stale in the service worker cache.
+ *   - The submit handler is a hook; the caller decides what to do
+ *     with the response (immediate POST when online, or drop into
+ *     the IndexedDB outbox when offline).
+ *
+ * Pages: when the schema contains a `page` question, the runtime
+ * renders one page at a time. Without pages, it's a single scroll.
+ */
+export interface FormRuntimeProps {
+  form: FormSchema;
+  /** Initial response (e.g. resuming a draft, or pre-filled values
+   *  from the Field runtime when the user tapped an existing
+   *  feature). */
+  initial?: Response;
+  /** Async submit handler. Receives the pruned response (hidden
+   *  fields stripped, calculations applied) and the form's
+   *  schemaVersion so the caller can stamp the submission. */
+  onSubmit: (response: Response) => Promise<void>;
+  /** Override the submit button label ("Submit" / "Save" / "Send"). */
+  submitLabel?: string;
+  /** When true, the form renders read-only with an empty submit
+   *  area -- used for designer preview to avoid accidental dummy
+   *  submissions. */
+  readOnly?: boolean;
+}
+
+export function FormRuntime({
+  form,
+  initial,
+  onSubmit,
+  submitLabel = 'Submit',
+  readOnly = false,
+}: FormRuntimeProps) {
+  const [response, setResponse] = useState<Response>(() =>
+    applyCalculations(form, initial ?? {}),
+  );
+  const [pageIndex, setPageIndex] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const [errors, setErrors] = useState<ValidationError[]>([]);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  // Re-run calculations whenever a referenced value might have
+  // changed. Cheap because applyCalculations short-circuits on
+  // identity equality when nothing actually changed.
+  useEffect(() => {
+    const next = applyCalculations(form, response);
+    if (next !== response) setResponse(next);
+  }, [form, response]);
+
+  const pages = useMemo(() => splitIntoPages(form), [form]);
+  const currentPage = pages[pageIndex] ?? pages[0]!;
+
+  const errorByQuestion = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const e of errors) m.set(e.questionId, e.message);
+    return m;
+  }, [errors]);
+
+  function setValue(id: string, value: unknown) {
+    setResponse((prev) => ({ ...prev, [id]: value }));
+  }
+
+  async function handleSubmit() {
+    if (readOnly) return;
+    const result = validate(form, response);
+    if (!result.ok) {
+      setErrors(result.errors);
+      // Jump to the first page with an error.
+      for (let i = 0; i < pages.length; i += 1) {
+        const ids = collectIdsOnPage(pages[i]!);
+        if (result.errors.some((e) => ids.has(e.questionId))) {
+          setPageIndex(i);
+          break;
+        }
+      }
+      return;
+    }
+    setErrors([]);
+    setSubmitError(null);
+    setSubmitting(true);
+    try {
+      await onSubmit(pruneHidden(form, response));
+      setSubmitted(true);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : 'Submit failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (submitted) {
+    return (
+      <div className="mx-auto flex w-full max-w-xl flex-col items-center gap-3 px-4 py-12 text-center">
+        <span className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 text-emerald-700">
+          <Check className="h-6 w-6" />
+        </span>
+        <h2 className="text-lg font-semibold tracking-tight text-ink-0">
+          Submitted
+        </h2>
+        <p className="text-sm text-muted">
+          Thanks. Your response has been recorded.
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            setResponse(applyCalculations(form, {}));
+            setPageIndex(0);
+            setSubmitted(false);
+          }}
+          className="mt-3 inline-flex h-9 items-center rounded-md border border-border bg-surface-1 px-3 text-sm font-medium text-ink-1 hover:bg-surface-2"
+        >
+          Submit another response
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-xl px-4 pb-24 pt-4 sm:pt-6">
+      <header className="mb-4">
+        <h1 className="text-xl font-semibold tracking-tight text-ink-0 sm:text-2xl">
+          {form.title}
+        </h1>
+        {form.description ? (
+          <p className="mt-1 text-sm text-muted">{form.description}</p>
+        ) : null}
+        {pages.length > 1 ? (
+          <div className="mt-3 flex items-center justify-between">
+            <p className="text-xs uppercase tracking-wide text-muted">
+              Page {pageIndex + 1} of {pages.length}
+            </p>
+            <div
+              className="h-1 flex-1 ml-3 overflow-hidden rounded bg-surface-2"
+              aria-hidden
+            >
+              <div
+                className="h-full bg-accent transition-all"
+                style={{
+                  width: `${((pageIndex + 1) / pages.length) * 100}%`,
+                }}
+              />
+            </div>
+          </div>
+        ) : null}
+      </header>
+
+      <form
+        className="space-y-5"
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (pageIndex < pages.length - 1) {
+            setPageIndex(pageIndex + 1);
+          } else {
+            void handleSubmit();
+          }
+        }}
+      >
+        {currentPage.questions.map((q) => (
+          <QuestionField
+            key={q.id}
+            q={q}
+            response={response}
+            error={errorByQuestion.get(q.id) ?? null}
+            readOnly={readOnly || isReadOnly(q, response)}
+            onChange={(v) => setValue(q.id, v)}
+          />
+        ))}
+
+        {submitError ? (
+          <p className="rounded-md border border-danger/40 bg-danger/5 px-3 py-2 text-sm text-danger">
+            {submitError}
+          </p>
+        ) : null}
+
+        <div className="sticky bottom-0 left-0 right-0 -mx-4 mt-6 flex items-center gap-2 border-t border-border bg-surface-1 px-4 py-3">
+          {pageIndex > 0 ? (
+            <button
+              type="button"
+              onClick={() => setPageIndex(pageIndex - 1)}
+              className="inline-flex h-11 items-center gap-1 rounded-md border border-border bg-surface-1 px-3 text-sm font-medium text-ink-1 hover:bg-surface-2"
+            >
+              <ChevronLeft className="h-4 w-4" />
+              Back
+            </button>
+          ) : null}
+          <div className="flex-1" />
+          {readOnly ? (
+            <span className="text-xs text-muted">Preview mode</span>
+          ) : pageIndex < pages.length - 1 ? (
+            <button
+              type="submit"
+              className="inline-flex h-11 items-center gap-1 rounded-md bg-accent px-4 text-sm font-medium text-accent-foreground hover:opacity-90"
+            >
+              Next
+              <ChevronRight className="h-4 w-4" />
+            </button>
+          ) : (
+            <button
+              type="submit"
+              disabled={submitting}
+              className="inline-flex h-11 items-center gap-2 rounded-md bg-accent px-4 text-sm font-medium text-accent-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              {submitting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : null}
+              {submitLabel}
+            </button>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}
+
+// ---- Per-question rendering -------------------------------------
+
+function QuestionField({
+  q,
+  response,
+  error,
+  readOnly,
+  onChange,
+}: {
+  q: Question;
+  response: Response;
+  error: string | null;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  if (!isVisible(q, response)) return null;
+
+  if (q.type === 'page') return null;
+  if (q.type === 'note') {
+    return (
+      <div className="rounded-md border border-border bg-surface-2/40 px-3 py-2 text-sm text-ink-1">
+        {q.label}
+      </div>
+    );
+  }
+  if (q.type === 'group') {
+    return <GroupField q={q} response={response} error={error} readOnly={readOnly} onChange={onChange} />;
+  }
+
+  const value = response[q.id];
+  const required = isRequired(q, response);
+  const requiredMark = required ? (
+    <span className="ml-0.5 text-danger" aria-hidden>
+      *
+    </span>
+  ) : null;
+
+  return (
+    <div className="space-y-1">
+      <label
+        className="block text-sm font-medium text-ink-0"
+        htmlFor={q.id}
+      >
+        {q.label}
+        {requiredMark}
+      </label>
+      {q.hint ? <p className="text-xs text-muted">{q.hint}</p> : null}
+      <Input q={q} value={value} readOnly={readOnly} onChange={onChange} />
+      {error ? (
+        <p className="text-xs text-danger" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function GroupField({
+  q,
+  response,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'group' }>;
+  response: Response;
+  error: string | null;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  // Repeating group: stored as an array of Response objects.
+  // Non-repeating group: child responses live at the top level
+  // (group is purely a visual container).
+  if (!q.repeat) {
+    return (
+      <fieldset className="rounded-md border border-border bg-surface-2/30 p-3">
+        <legend className="px-2 text-sm font-medium text-ink-0">
+          {q.label}
+        </legend>
+        <div className="space-y-4">
+          {q.children.map((child) => (
+            <QuestionField
+              key={child.id}
+              q={child}
+              response={response}
+              error={null}
+              readOnly={readOnly}
+              onChange={(v) => {
+                const fakeOnChange = (val: unknown) =>
+                  onChange({ ...(response[q.id] as object | undefined), [child.id]: val });
+                fakeOnChange(v);
+              }}
+            />
+          ))}
+        </div>
+      </fieldset>
+    );
+  }
+  const instances = (Array.isArray(response[q.id])
+    ? (response[q.id] as Response[])
+    : []) as Response[];
+  return (
+    <fieldset className="rounded-md border border-border bg-surface-2/30 p-3">
+      <legend className="px-2 text-sm font-medium text-ink-0">{q.label}</legend>
+      <div className="space-y-3">
+        {instances.map((inst, idx) => (
+          <div key={idx} className="rounded-md border border-border bg-surface-1 p-3">
+            <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-wide text-muted">
+              <span>Instance {idx + 1}</span>
+              {!readOnly ? (
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1 text-danger"
+                  onClick={() => {
+                    const next = instances.filter((_, i) => i !== idx);
+                    onChange(next);
+                  }}
+                >
+                  <Trash2 className="h-3 w-3" />
+                  Remove
+                </button>
+              ) : null}
+            </div>
+            <div className="space-y-3">
+              {q.children.map((child) => (
+                <QuestionField
+                  key={child.id}
+                  q={child}
+                  response={inst}
+                  error={null}
+                  readOnly={readOnly}
+                  onChange={(v) => {
+                    const next = instances.slice();
+                    next[idx] = { ...inst, [child.id]: v };
+                    onChange(next);
+                  }}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+        {!readOnly &&
+        (q.repeat.max === undefined || instances.length < q.repeat.max) ? (
+          <button
+            type="button"
+            onClick={() => {
+              onChange([...instances, {}]);
+            }}
+            className="inline-flex h-9 items-center gap-1 rounded-md border border-dashed border-border bg-surface-1 px-3 text-sm font-medium text-ink-1 hover:bg-surface-2"
+          >
+            <Plus className="h-4 w-4" />
+            {q.repeat.addLabel ?? `Add another ${q.label}`}
+          </button>
+        ) : null}
+      </div>
+    </fieldset>
+  );
+}
+
+// Per-type input renderers. Native HTML inputs everywhere -- mobile
+// pickers come for free.
+function Input({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Question;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  const baseClass =
+    'block w-full rounded-md border border-border bg-surface-1 px-3 py-2 text-base text-ink-0 placeholder:text-muted focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30 disabled:opacity-60';
+
+  switch (q.type) {
+    case 'text':
+      return (
+        <input
+          id={q.id}
+          type={q.obscured ? 'password' : 'text'}
+          inputMode="text"
+          value={(value as string) ?? ''}
+          maxLength={q.maxLength}
+          placeholder={q.placeholder}
+          disabled={readOnly}
+          onChange={(e) => onChange(e.target.value)}
+          className={baseClass}
+        />
+      );
+    case 'multiline':
+      return (
+        <textarea
+          id={q.id}
+          rows={q.rows ?? 3}
+          value={(value as string) ?? ''}
+          maxLength={q.maxLength}
+          placeholder={q.placeholder}
+          disabled={readOnly}
+          onChange={(e) => onChange(e.target.value)}
+          className={baseClass}
+        />
+      );
+    case 'number':
+      return (
+        <input
+          id={q.id}
+          type="number"
+          inputMode="decimal"
+          value={value === null || value === undefined ? '' : (value as number | string)}
+          step={q.step}
+          min={q.min}
+          max={q.max}
+          disabled={readOnly}
+          onChange={(e) => {
+            const v = e.target.value;
+            onChange(v === '' ? null : Number(v));
+          }}
+          className={baseClass}
+        />
+      );
+    case 'integer':
+      return (
+        <input
+          id={q.id}
+          type="number"
+          inputMode="numeric"
+          step={1}
+          value={value === null || value === undefined ? '' : (value as number | string)}
+          min={q.min}
+          max={q.max}
+          disabled={readOnly}
+          onChange={(e) => {
+            const v = e.target.value;
+            onChange(v === '' ? null : Math.trunc(Number(v)));
+          }}
+          className={baseClass}
+        />
+      );
+    case 'boolean':
+      return (
+        <div className="flex gap-2">
+          {[
+            { v: true, label: q.trueLabel ?? 'Yes' },
+            { v: false, label: q.falseLabel ?? 'No' },
+          ].map((opt) => (
+            <button
+              type="button"
+              key={String(opt.v)}
+              disabled={readOnly}
+              onClick={() => onChange(opt.v)}
+              className={`h-11 flex-1 rounded-md border text-sm font-medium ${
+                value === opt.v
+                  ? 'border-accent bg-accent/10 text-accent'
+                  : 'border-border bg-surface-1 text-ink-1 hover:bg-surface-2'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      );
+    case 'select-one':
+      if (q.appearance === 'dropdown') {
+        return (
+          <select
+            id={q.id}
+            value={(value as string) ?? ''}
+            disabled={readOnly}
+            onChange={(e) => onChange(e.target.value || null)}
+            className={baseClass}
+          >
+            <option value="">--</option>
+            {q.choices.map((c) => (
+              <option key={c.value} value={c.value}>
+                {c.label}
+              </option>
+            ))}
+          </select>
+        );
+      }
+      return (
+        <div className="space-y-1.5">
+          {q.choices.map((c) => (
+            <label
+              key={c.value}
+              className={`flex h-11 items-center gap-2 rounded-md border px-3 text-sm ${
+                value === c.value
+                  ? 'border-accent bg-accent/5'
+                  : 'border-border bg-surface-1'
+              }`}
+            >
+              <input
+                type="radio"
+                name={q.id}
+                value={c.value}
+                checked={value === c.value}
+                disabled={readOnly}
+                onChange={() => onChange(c.value)}
+              />
+              <span>{c.label}</span>
+            </label>
+          ))}
+        </div>
+      );
+    case 'select-many': {
+      const arr = (Array.isArray(value) ? (value as string[]) : []);
+      return (
+        <div className="space-y-1.5">
+          {q.choices.map((c) => {
+            const checked = arr.includes(c.value);
+            return (
+              <label
+                key={c.value}
+                className={`flex h-11 items-center gap-2 rounded-md border px-3 text-sm ${
+                  checked ? 'border-accent bg-accent/5' : 'border-border bg-surface-1'
+                }`}
+              >
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  disabled={readOnly}
+                  onChange={(e) =>
+                    onChange(
+                      e.target.checked
+                        ? [...arr, c.value]
+                        : arr.filter((v) => v !== c.value),
+                    )
+                  }
+                />
+                <span>{c.label}</span>
+              </label>
+            );
+          })}
+        </div>
+      );
+    }
+    case 'date':
+      return (
+        <input
+          id={q.id}
+          type="date"
+          value={(value as string) ?? ''}
+          min={q.min}
+          max={q.max}
+          disabled={readOnly}
+          onChange={(e) => onChange(e.target.value || null)}
+          className={baseClass}
+        />
+      );
+    case 'time':
+      return (
+        <input
+          id={q.id}
+          type="time"
+          value={(value as string) ?? ''}
+          min={q.min}
+          max={q.max}
+          disabled={readOnly}
+          onChange={(e) => onChange(e.target.value || null)}
+          className={baseClass}
+        />
+      );
+    case 'datetime':
+      return (
+        <input
+          id={q.id}
+          type="datetime-local"
+          value={(value as string) ?? ''}
+          disabled={readOnly}
+          onChange={(e) => onChange(e.target.value || null)}
+          className={baseClass}
+        />
+      );
+    case 'photo':
+      return <PhotoInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
+    case 'signature':
+      return (
+        <div className="rounded-md border border-dashed border-border bg-surface-2/30 p-4 text-center text-xs text-muted">
+          Signature capture is part of Phase 2 of the Data Collection rollout.
+        </div>
+      );
+    case 'geopoint':
+      return <GeoPointInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
+    case 'geotrace':
+    case 'geoshape':
+      return (
+        <div className="rounded-md border border-dashed border-border bg-surface-2/30 p-4 text-center text-xs text-muted">
+          Polyline / polygon capture is part of Phase 2 of the Data
+          Collection rollout.
+        </div>
+      );
+    case 'rating': {
+      const max = q.max ?? 5;
+      const cur = typeof value === 'number' ? value : 0;
+      return (
+        <div className="flex gap-1.5">
+          {Array.from({ length: max }, (_, i) => i + 1).map((n) => (
+            <button
+              type="button"
+              key={n}
+              disabled={readOnly}
+              onClick={() => onChange(n)}
+              className={`h-11 w-11 rounded-md border text-lg ${
+                n <= cur ? 'border-accent bg-accent/10 text-accent' : 'border-border bg-surface-1'
+              }`}
+              aria-label={`${n} of ${max}`}
+            >
+              {q.shape === 'heart' ? '♥' : q.shape === 'thumb' ? '\u{1F44D}' : '★'}
+            </button>
+          ))}
+        </div>
+      );
+    }
+    case 'slider': {
+      const cur = typeof value === 'number' ? value : q.min;
+      return (
+        <div>
+          <input
+            id={q.id}
+            type="range"
+            min={q.min}
+            max={q.max}
+            step={q.step ?? 1}
+            value={cur}
+            disabled={readOnly}
+            onChange={(e) => onChange(Number(e.target.value))}
+            className="h-11 w-full"
+          />
+          {q.showValue ? (
+            <p className="mt-1 text-right text-xs tabular-nums text-muted">{cur}</p>
+          ) : null}
+        </div>
+      );
+    }
+    case 'calculated':
+      return (
+        <div className="rounded-md border border-border bg-surface-2/40 px-3 py-2 text-sm text-ink-1">
+          {value === null || value === undefined || value === ''
+            ? '—'
+            : String(value)}
+        </div>
+      );
+    case 'note':
+    case 'page':
+    case 'group':
+      return null;
+  }
+}
+
+function PhotoInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'photo' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  // Phase 1: capture as data URLs in IndexedDB-friendly arrays. The
+  // server-side upload-to-MinIO wiring lands in Phase 2.
+  const photos: string[] = Array.isArray(value) ? (value as string[]) : [];
+  const max = q.maxCount ?? 1;
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-2">
+        {photos.map((src, i) => (
+          <div
+            key={i}
+            className="relative h-20 w-20 overflow-hidden rounded-md border border-border bg-surface-2"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={src} alt="" className="h-full w-full object-cover" />
+            {!readOnly ? (
+              <button
+                type="button"
+                onClick={() => onChange(photos.filter((_, j) => j !== i))}
+                className="absolute right-0 top-0 rounded-bl bg-black/60 p-0.5 text-white"
+                aria-label="Remove photo"
+              >
+                <Trash2 className="h-3 w-3" />
+              </button>
+            ) : null}
+          </div>
+        ))}
+        {!readOnly && photos.length < max ? (
+          <label className="flex h-20 w-20 cursor-pointer flex-col items-center justify-center gap-1 rounded-md border border-dashed border-border bg-surface-1 text-xs text-muted hover:bg-surface-2">
+            <Camera className="h-5 w-5" />
+            Photo
+            <input
+              type="file"
+              accept="image/*"
+              capture="environment"
+              className="hidden"
+              onChange={async (e) => {
+                const file = e.target.files?.[0];
+                if (!file) return;
+                const dataUrl = await fileToDataUrl(file);
+                onChange([...photos, dataUrl]);
+              }}
+            />
+          </label>
+        ) : null}
+      </div>
+      <p className="text-[11px] text-muted">
+        {photos.length} of {max} {max === 1 ? 'photo' : 'photos'}
+      </p>
+    </div>
+  );
+}
+
+function GeoPointInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'geopoint' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  const point = (value as { lat: number; lng: number; accuracy?: number } | null) ?? null;
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  function capture() {
+    if (!('geolocation' in navigator)) {
+      setErr('Geolocation not supported on this device.');
+      return;
+    }
+    setBusy(true);
+    setErr(null);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        onChange({
+          lat: pos.coords.latitude,
+          lng: pos.coords.longitude,
+          accuracy: pos.coords.accuracy,
+        });
+        setBusy(false);
+      },
+      (e) => {
+        setErr(e.message);
+        setBusy(false);
+      },
+      { enableHighAccuracy: true, timeout: 15000, maximumAge: 0 },
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {point ? (
+        <div className="rounded-md border border-border bg-surface-1 px-3 py-2 text-sm text-ink-1">
+          <p className="font-mono text-xs">
+            {point.lat.toFixed(6)}, {point.lng.toFixed(6)}
+          </p>
+          {point.accuracy !== undefined ? (
+            <p className="text-[11px] text-muted">
+              ± {point.accuracy.toFixed(0)} m
+            </p>
+          ) : null}
+        </div>
+      ) : (
+        <p className="text-sm text-muted">No location captured yet.</p>
+      )}
+      {!readOnly &&
+      (q.capture === 'auto' || q.capture === 'gps' || q.capture === undefined) ? (
+        <button
+          type="button"
+          onClick={capture}
+          disabled={busy}
+          className="inline-flex h-11 items-center gap-2 rounded-md border border-border bg-surface-1 px-3 text-sm font-medium text-ink-1 hover:bg-surface-2 disabled:opacity-50"
+        >
+          {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <MapPin className="h-4 w-4" />}
+          {point ? 'Recapture' : 'Capture location'}
+        </button>
+      ) : null}
+      {!readOnly && q.capture === 'manual' ? (
+        <div className="grid grid-cols-2 gap-2">
+          <input
+            type="number"
+            placeholder="Latitude"
+            value={point?.lat ?? ''}
+            onChange={(e) => onChange({ ...(point ?? { lng: 0 }), lat: Number(e.target.value) })}
+            className="block h-11 w-full rounded-md border border-border bg-surface-1 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
+          />
+          <input
+            type="number"
+            placeholder="Longitude"
+            value={point?.lng ?? ''}
+            onChange={(e) => onChange({ ...(point ?? { lat: 0 }), lng: Number(e.target.value) })}
+            className="block h-11 w-full rounded-md border border-border bg-surface-1 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
+          />
+        </div>
+      ) : null}
+      {err ? <p className="text-xs text-danger">{err}</p> : null}
+    </div>
+  );
+}
+
+// ---- helpers ----------------------------------------------------
+
+function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
+
+interface Page {
+  pageQuestion: Question | null;
+  questions: Question[];
+}
+
+function splitIntoPages(form: FormSchema): Page[] {
+  const pages: Page[] = [];
+  let current: Page = { pageQuestion: null, questions: [] };
+  for (const q of form.questions) {
+    if (q.type === 'page') {
+      if (current.questions.length > 0) pages.push(current);
+      current = { pageQuestion: q, questions: [] };
+    } else {
+      current.questions.push(q);
+    }
+  }
+  pages.push(current);
+  return pages;
+}
+
+function collectIdsOnPage(page: Page): Set<string> {
+  const ids = new Set<string>();
+  function walk(q: Question) {
+    ids.add(q.id);
+    if (q.type === 'group') q.children.forEach(walk);
+  }
+  page.questions.forEach(walk);
+  return ids;
+}
+
+function isReadOnly(q: Question, response: Response): boolean {
+  if (q.readOnly === undefined || q.readOnly === false) return false;
+  if (q.readOnly === true) return true;
+  return Boolean(evaluate(q.readOnly as Expression, response));
+}
+
+// Re-export for designer / runtime consumers.
+export { walkQuestions };

--- a/apps/portal-web/src/lib/form-offline.ts
+++ b/apps/portal-web/src/lib/form-offline.ts
@@ -1,0 +1,202 @@
+/**
+ * Offline-first submission queue for the Data Collection runtime
+ * (#131). Submissions are persisted to IndexedDB on capture and
+ * drained when network returns. Each queued row carries:
+ *
+ *   - clientId     stable client-generated UUID (idempotency key)
+ *   - formId       the form item the response was captured against
+ *   - schemaVersion of that form at capture time, so a forward-rolled
+ *                  schema can still resolve the submission server-side
+ *   - response     the pruned Response object
+ *   - capturedAt   ISO timestamp
+ *   - status       'queued' | 'sending' | 'sent' | 'failed'
+ *   - lastError    last failure reason for the Outbox UI
+ *   - attempts     number of send attempts so far
+ *
+ * The Phase 1 implementation here keeps the API surface small. We use
+ * the browser's native IndexedDB API directly (no `idb` package) so
+ * the runtime works without a network round-trip on first paint and
+ * doesn't pull in another dep just to wrap promises.
+ */
+
+const DB_NAME = 'gratisgis-forms';
+const DB_VERSION = 1;
+const STORE = 'submissions';
+
+export interface QueuedSubmission {
+  clientId: string;
+  formId: string;
+  schemaVersion: number;
+  response: Record<string, unknown>;
+  capturedAt: string;
+  status: 'queued' | 'sending' | 'sent' | 'failed';
+  lastError?: string;
+  attempts: number;
+}
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function openDb(): Promise<IDBDatabase> {
+  if (typeof indexedDB === 'undefined') {
+    return Promise.reject(new Error('IndexedDB not available'));
+  }
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        const store = db.createObjectStore(STORE, { keyPath: 'clientId' });
+        store.createIndex('byForm', 'formId');
+        store.createIndex('byStatus', 'status');
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error('IndexedDB open failed'));
+  });
+  return dbPromise;
+}
+
+function tx(
+  db: IDBDatabase,
+  mode: IDBTransactionMode,
+): IDBObjectStore {
+  return db.transaction(STORE, mode).objectStore(STORE);
+}
+
+function genClientId(): string {
+  // RFC 4122 v4 via crypto when available; otherwise a high-entropy
+  // fallback. Either way it's idempotency-strong enough for our use.
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof (crypto as Crypto & { randomUUID?: () => string }).randomUUID === 'function'
+  ) {
+    return (crypto as Crypto & { randomUUID: () => string }).randomUUID();
+  }
+  return `xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
+ * Queue a fresh submission. Returns the assigned clientId so the
+ * caller can show "saved" feedback before any network attempt.
+ */
+export async function queueSubmission(opts: {
+  formId: string;
+  schemaVersion: number;
+  response: Record<string, unknown>;
+}): Promise<QueuedSubmission> {
+  const db = await openDb();
+  const row: QueuedSubmission = {
+    clientId: genClientId(),
+    formId: opts.formId,
+    schemaVersion: opts.schemaVersion,
+    response: opts.response,
+    capturedAt: new Date().toISOString(),
+    status: 'queued',
+    attempts: 0,
+  };
+  await new Promise<void>((resolve, reject) => {
+    const r = tx(db, 'readwrite').add(row);
+    r.onsuccess = () => resolve();
+    r.onerror = () => reject(r.error);
+  });
+  return row;
+}
+
+export async function listQueued(): Promise<QueuedSubmission[]> {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const r = tx(db, 'readonly').getAll();
+    r.onsuccess = () => resolve((r.result as QueuedSubmission[]) ?? []);
+    r.onerror = () => reject(r.error);
+  });
+}
+
+export async function markSent(clientId: string): Promise<void> {
+  const db = await openDb();
+  await update(db, clientId, (row) => ({ ...row, status: 'sent' }));
+}
+
+export async function markFailed(
+  clientId: string,
+  error: string,
+): Promise<void> {
+  const db = await openDb();
+  await update(db, clientId, (row) => ({
+    ...row,
+    status: 'failed',
+    lastError: error,
+    attempts: row.attempts + 1,
+  }));
+}
+
+export async function clearSent(): Promise<void> {
+  const db = await openDb();
+  const all = (await listQueued()).filter((r) => r.status === 'sent');
+  await Promise.all(all.map((r) => del(db, r.clientId)));
+}
+
+function del(db: IDBDatabase, key: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const r = tx(db, 'readwrite').delete(key);
+    r.onsuccess = () => resolve();
+    r.onerror = () => reject(r.error);
+  });
+}
+
+function update(
+  db: IDBDatabase,
+  key: string,
+  patch: (row: QueuedSubmission) => QueuedSubmission,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const store = tx(db, 'readwrite');
+    const get = store.get(key);
+    get.onsuccess = () => {
+      const row = get.result as QueuedSubmission | undefined;
+      if (!row) {
+        resolve();
+        return;
+      }
+      const next = patch(row);
+      const put = store.put(next);
+      put.onsuccess = () => resolve();
+      put.onerror = () => reject(put.error);
+    };
+    get.onerror = () => reject(get.error);
+  });
+}
+
+/**
+ * Drain all queued submissions for a given form against the supplied
+ * sender. The sender is responsible for authentication; this helper
+ * only manages queue state. Errors per row don't abort the drain --
+ * the failed row stays queued for the next attempt.
+ *
+ * Returns counts so the caller can update the UI.
+ */
+export async function drain(
+  formId: string,
+  send: (s: QueuedSubmission) => Promise<void>,
+): Promise<{ sent: number; failed: number; remaining: number }> {
+  const all = await listQueued();
+  const mine = all.filter((r) => r.formId === formId && r.status !== 'sent');
+  let sent = 0;
+  let failed = 0;
+  for (const row of mine) {
+    try {
+      await send(row);
+      await markSent(row.clientId);
+      sent += 1;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Send failed';
+      await markFailed(row.clientId, msg);
+      failed += 1;
+    }
+  }
+  return { sent, failed, remaining: mine.length - sent };
+}

--- a/docs/data-collection-phase1.md
+++ b/docs/data-collection-phase1.md
@@ -1,0 +1,126 @@
+# Data Collection Phase 1 - Implementation Notes
+
+(#131) Implementation companion to `docs/editing-and-collection.md`,
+captured at the end of this branch.
+
+## What landed in this PR
+
+End-to-end form authoring + capture, online + offline, with shared
+designer + runtime that both Survey-style and Field-style entry
+points will reuse:
+
+- `@gratis-gis/form-schema` expanded into the full shared kernel:
+  21 question types, conditional visibility, calculations, validation,
+  layer-binding metadata, JSON-only expression DSL with a fixed
+  whitelist of builtins.
+- Form designer (`apps/portal-web/src/app/items/[id]/form/designer.tsx`):
+  three-panel UX (palette / canvas / properties), HTML5 native drag-
+  drop (no extra deps), tap-to-add for touch, live Preview tab that
+  swaps the canvas for the real runtime against the in-memory schema.
+- Form runtime (`apps/portal-web/src/components/form-runtime.tsx`):
+  mobile-first single-column layout, native input types so phone
+  keyboards do the right thing, sticky bottom bar with Next / Submit,
+  per-page progress, paged surveys when the schema includes `page`
+  questions, repeating groups, GPS capture for `geopoint`, photo
+  capture via `<input type=file capture=environment>`.
+- Public respond page (`/forms/[id]/respond`): server-renders the
+  schema for fast first paint, hands off to a client wrapper that
+  manages online/offline + the IndexedDB outbox.
+- Offline outbox (`apps/portal-web/src/lib/form-offline.ts`): zero-
+  dependency wrapper over native IndexedDB. Submissions queue with
+  a client-generated UUID, status flips queued -> sending -> sent /
+  failed, the wrapper auto-drains when `online` event fires.
+- Backend submissions store (`apps/portal-api/src/forms/`): new
+  `form_submission` table, `FormSubmission` Prisma model, controller
+  at `/api/forms/:id/submissions`. Idempotent upsert on
+  `(formId, clientId)` so a re-drained queue is a no-op. Captured
+  `schemaVersion` is preserved.
+
+## How the dual entry points share this
+
+The schema, the runtime, and the designer are agnostic to where the
+form was reached from. Two thin entry points feed them:
+
+- **Survey-first** (Survey123-style): `/forms/<id>/respond`. The user
+  hits the URL (link in email, QR code, etc.), `RespondClient` opens
+  with no pre-filled values. Geometry capture, if any, comes from a
+  `geopoint` question in the schema.
+- **Field-first** (Field Maps-style, Phase 1b): a `data_collection`
+  item type in `mode: "map"`. The user opens the runtime, sees a map
+  with the configured editable layers, taps "Add" against a layer.
+  The runtime opens the form bound to that layer, with the captured
+  geometry pre-filled into the `geopoint` question. This shares the
+  exact runtime + designer; the only differentiator is the entry
+  point and the `bindTo` metadata that maps each question to a
+  column on the target data_layer. The designer's palette filters by
+  `compatibleQuestionTypes(columnType)` when bound to a layer.
+
+The shared schema also makes "the same form, two ways" trivial: a
+`form` item in `Field` mode is just a `form` item that some
+`data_collection` references via `bindTo`. There's never an XLSForm-
+vs-Field-Maps split.
+
+## Open follow-ups for Phase 1b
+
+- `data_collection` item type: scaffolding (type enum, create wizard
+  with mode picker, draft state, targets editor). Wires a form to a
+  submission collection (Survey mode) or a map + per-layer forms
+  (Field mode).
+- Field runtime: map canvas + per-layer feature templates. The Editor
+  item already has all the moving parts (slices 3b-1 through 3b-5);
+  Field mode is mostly the Editor canvas + the FormRuntime opening
+  on Add instead of the existing AttributeForm.
+- Service worker pre-cache of the form runtime bundle + form schema
+  + target layer schemas, so a mobile user can install the PWA, go
+  out of range, capture, and sync on return. The IndexedDB outbox
+  is already in place; the missing piece is the SW pre-cache and a
+  manifest that lists the form-runtime route as a startable scope.
+- Drag-drop on touch devices. HTML5 native DnD is desktop-only on
+  iOS Safari; tap-to-add works there but reorder-by-grip doesn't.
+  Phase 1b adds a touch fallback (long-press + drag, or up/down
+  arrows on each row).
+- Conditional logic builder Phase 2: today the designer's logic
+  panel only writes a single `eq` between a ref and a literal. The
+  Expression DSL supports the fuller shape (and / or / not / between
+  / arithmetic / builtins); the UI catches up next.
+- Submission detail page on a form item: list captured submissions
+  with field-level inspection. The `/forms/:id/submissions` GET
+  already exists; it just needs a UI.
+
+## Schema-version contract
+
+Submissions carry `schemaVersion`. The current version is
+`CURRENT_FORM_SCHEMA_VERSION = 1`. When we bump, every renderer in
+the field that wrote a submission against v1 keeps working: the
+server stores the response as-is, and downstream consumers can
+inspect both the captured version and the current form schema to
+decide how to project. This matches the schema-evolution policy in
+`editing-and-collection.md` and is the explicit anti-Survey123
+position (no orphaned data, no broken in-flight queues on form
+edits).
+
+## Mobile + offline in numbers
+
+- **First paint**: the respond page is a server component, so the
+  user gets a working form (no spinner) before any JS hydrates.
+  Once hydrated, the runtime works fully offline.
+- **Outbox depth**: bounded by IndexedDB quota (~hundreds of MB on
+  modern phones); a single submission with a couple of photos is
+  ~200 KB-2 MB depending on image size. A field crew should be able
+  to queue dozens of submissions in a sub-50-MB outbox.
+- **Submission idempotency**: `clientId` UUID generated at capture
+  time; backend upserts on `(formId, clientId)`. A submission
+  drained twice is a no-op; the client only purges the outbox row
+  when the server returns 2xx for the matching `clientId`.
+
+## Where to test
+
+1. Create a form item via the Add menu -> Forms -> Form.
+2. Open the form item detail page; you'll get the designer.
+3. Drag question types from the left palette into the canvas; click
+   Save.
+4. Open the link at the bottom (`/forms/<id>/respond`) -- ideally
+   from your phone on the same Wi-Fi as the dev server.
+5. Fill in the form. Toggle airplane mode mid-response: the submit
+   queues to IndexedDB, the Outbox card appears, and re-enabling
+   network drains it.

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -1,82 +1,956 @@
 /**
- * Minimal form-schema definitions. This is a placeholder shape that will be
- * expanded when we port the Survey123 Designer form-builder work.
+ * Form schema for the Data Collection workflow (#131).
  *
- * Design goals:
- *   - JSON-serializable (safe to store as jsonb on Item.data_json)
- *   - Stable, versioned: `schemaVersion` lets us evolve without breaking forms
- *   - Renderer-agnostic (no React types in here)
+ * Two runtimes consume this schema:
+ *
+ *   - Survey runtime (form-first, Survey123 style): renders the
+ *     full form to a respondent. Geometry capture is optional and
+ *     declared by a geopoint/geotrace/geoshape question, if any.
+ *   - Field runtime (map-first, Field Maps style): the respondent
+ *     taps a layer on the map; the form bound to that layer opens
+ *     pre-bound to the new feature's geometry. Question types are
+ *     constrained to those compatible with the layer's column types.
+ *
+ * The two runtimes share this schema, the same designer (palette +
+ * canvas + properties), the same conditional-visibility evaluator,
+ * the same calculation evaluator, and the same validator. The only
+ * differentiator is the entry point. See docs/editing-and-collection.md.
+ *
+ * Goals:
+ *
+ *   - JSON-serializable (lives on Item.data_json as form-item content
+ *     and on Notification payloads when triggers fire).
+ *   - Renderer-agnostic (no React, no MapLibre).
+ *   - Stable + versioned: `schemaVersion` lets us evolve without
+ *     breaking already-captured submissions.
+ *   - Expression language is small and total: no eval(), no Function
+ *     constructor. The same evaluator runs in the browser and on
+ *     the server.
+ *   - Future-friendly to layer binding: each question optionally
+ *     declares `bindTo` (a column on a data_layer) so the Field
+ *     runtime can map a submission straight into a feature row,
+ *     while the Survey runtime can still treat the form as
+ *     standalone (submissions land in a form_submission_collection).
  */
 
+// ---------------------------------------------------------------------------
+// Versioning
+// ---------------------------------------------------------------------------
+
 export type FormSchemaVersion = 1;
+export const CURRENT_FORM_SCHEMA_VERSION: FormSchemaVersion = 1;
 
-export type FieldType =
-  | 'text'
-  | 'multiline'
-  | 'number'
-  | 'integer'
-  | 'boolean'
-  | 'select-one'
-  | 'select-many'
-  | 'date'
-  | 'datetime'
-  | 'photo'
-  | 'signature'
-  | 'geopoint'
-  | 'geotrace'
-  | 'geoshape';
+// ---------------------------------------------------------------------------
+// Question types
+// ---------------------------------------------------------------------------
 
-export interface FieldBase {
-  id: string;          // stable key; becomes a column in the submission table
-  label: string;
-  description?: string;
-  required?: boolean;
-  visibleIf?: Expression; // logical visibility (e.g. show if field X = 'yes')
-}
+/**
+ * Catalog of every question kind the runtimes know how to render.
+ * The Field runtime (map-first) hides kinds that can't bind to a
+ * given column type; see `compatibleColumnTypes` below.
+ */
+export const QUESTION_TYPES = [
+  'text', // single-line free text
+  'multiline', // multi-line free text (textarea)
+  'number', // free decimal
+  'integer', // whole number
+  'boolean', // yes/no toggle
+  'select-one', // radio buttons or dropdown (controlled by `appearance`)
+  'select-many', // checkboxes
+  'date', // calendar date
+  'time', // wall-clock time
+  'datetime', // calendar + clock
+  'photo', // one or more image attachments
+  'signature', // ink-on-canvas, stored as PNG
+  'geopoint', // single lat/lon
+  'geotrace', // polyline
+  'geoshape', // polygon
+  'rating', // 1-5 stars (or configurable max)
+  'slider', // numeric range slider
+  'calculated', // read-only, derived from `calculate` expression
+  'note', // display-only static text (no value captured)
+  'page', // page break (for paged surveys)
+  'group', // logical grouping with optional repeat (see `repeat`)
+] as const;
+
+export type QuestionType = (typeof QUESTION_TYPES)[number];
+
+// ---------------------------------------------------------------------------
+// Common shapes
+// ---------------------------------------------------------------------------
+
+/** Stable identifier for a question. Becomes the column name in the
+ *  generated layer schema (Path B) or maps to an existing column
+ *  (Path A) via `bindTo`. */
+export type QuestionId = string;
 
 export interface Choice {
   value: string;
   label: string;
+  /** Optional pick_list item id when this choice is sourced from a
+   *  reusable pick list. The designer can attach a pick_list item to
+   *  populate `choices` automatically. */
+  pickListId?: string;
 }
 
-export type Field =
-  | (FieldBase & { type: 'text'; placeholder?: string; maxLength?: number })
-  | (FieldBase & { type: 'multiline'; placeholder?: string; maxLength?: number })
-  | (FieldBase & { type: 'number'; min?: number; max?: number; step?: number })
-  | (FieldBase & { type: 'integer'; min?: number; max?: number })
-  | (FieldBase & { type: 'boolean' })
-  | (FieldBase & { type: 'select-one'; choices: Choice[] })
-  | (FieldBase & { type: 'select-many'; choices: Choice[] })
-  | (FieldBase & { type: 'date' })
-  | (FieldBase & { type: 'datetime' })
-  | (FieldBase & { type: 'photo'; maxCount?: number })
-  | (FieldBase & { type: 'signature' })
-  | (FieldBase & { type: 'geopoint' })
-  | (FieldBase & { type: 'geotrace' })
-  | (FieldBase & { type: 'geoshape' });
+/** Free-form short hint shown beneath the question. */
+export type Hint = string;
 
-export interface FormPage {
-  id: string;
-  title: string;
-  fields: Field[];
+/**
+ * Layer-binding metadata. When present, the Field runtime maps the
+ * captured value into the named column on the target data_layer.
+ * The Survey runtime ignores this field; submissions go into a
+ * form_submission_collection regardless.
+ *
+ * `column` is the on-disk column name (snake_case is the convention,
+ * matching how the data_layer schema is stored). When omitted, the
+ * Field runtime falls back to the question id.
+ */
+export interface BindTo {
+  /** Layer key inside the multi-layer data_layer item; matches
+   *  data_layer.layers[].key. Optional for single-layer data_layers. */
+  layerKey?: string;
+  /** Column name on the target table. Optional; when omitted the
+   *  question id is used. */
+  column?: string;
 }
+
+// ---------------------------------------------------------------------------
+// Per-question shapes
+// ---------------------------------------------------------------------------
+
+interface QuestionBase {
+  id: QuestionId;
+  /** User-facing label. Shown above the input. */
+  label: string;
+  /** Optional secondary explanatory text. */
+  hint?: Hint | undefined;
+  /** When false, the runtime hides the question and clears its
+   *  value before submit. Default true. */
+  visible?: boolean | undefined;
+  /** Conditional visibility -- evaluated against the in-progress
+   *  response. When false, behaves like `visible: false`. */
+  visibleIf?: Expression | undefined;
+  /** Required when truthy. Required-if when an Expression. */
+  required?: boolean | Expression | undefined;
+  /** Custom validation expression. */
+  constraint?: Expression | undefined;
+  /** Error message shown when `constraint` fails. */
+  message?: string | undefined;
+  /** Read-only: the runtime renders a value but does not allow edits. */
+  readOnly?: boolean | Expression | undefined;
+  /** Layer binding (Field runtime only). */
+  bindTo?: BindTo | undefined;
+  /** Free-form per-question metadata. */
+  meta?: Record<string, unknown> | undefined;
+}
+
+interface TextQuestion extends QuestionBase {
+  type: 'text';
+  placeholder?: string;
+  /** UTF-16 code-unit cap (matches HTML maxLength). */
+  maxLength?: number;
+  /** Regex pattern (anchored automatically). */
+  pattern?: string;
+  /** When true, hides the input value (password-like). Submission
+   *  payload is plaintext; this is purely a UI hint. */
+  obscured?: boolean;
+}
+
+interface MultilineQuestion extends QuestionBase {
+  type: 'multiline';
+  placeholder?: string;
+  maxLength?: number;
+  /** Suggested rows. UI may grow as the user types. */
+  rows?: number;
+}
+
+interface NumberQuestion extends QuestionBase {
+  type: 'number';
+  min?: number;
+  max?: number;
+  step?: number;
+  /** ISO 4217 currency code, when this is a money field. Renderer
+   *  uses it for the prefix/suffix and to choose precision. */
+  currency?: string;
+  /** Show as `12,345.67` rather than `12345.67`. */
+  thousandsSeparator?: boolean;
+}
+
+interface IntegerQuestion extends QuestionBase {
+  type: 'integer';
+  min?: number;
+  max?: number;
+}
+
+interface BooleanQuestion extends QuestionBase {
+  type: 'boolean';
+  /** "Yes" / "No" by default; renderer can override. */
+  trueLabel?: string;
+  falseLabel?: string;
+}
+
+interface SelectOneQuestion extends QuestionBase {
+  type: 'select-one';
+  choices: Choice[];
+  /** `radio` (default) or `dropdown`. */
+  appearance?: 'radio' | 'dropdown';
+  /** When set, choices come from this pick_list at runtime instead
+   *  of the inline `choices` array. The inline `choices` may still
+   *  be used as a designer-time preview. */
+  pickListId?: string;
+}
+
+interface SelectManyQuestion extends QuestionBase {
+  type: 'select-many';
+  choices: Choice[];
+  /** Minimum number of selected choices required. */
+  minSelected?: number;
+  /** Maximum allowed. */
+  maxSelected?: number;
+  pickListId?: string;
+}
+
+interface DateQuestion extends QuestionBase {
+  type: 'date';
+  /** ISO 8601 date or `today`. */
+  min?: string;
+  max?: string;
+}
+
+interface TimeQuestion extends QuestionBase {
+  type: 'time';
+  /** HH:mm 24-hour. */
+  min?: string;
+  max?: string;
+}
+
+interface DateTimeQuestion extends QuestionBase {
+  type: 'datetime';
+  /** ISO 8601 timestamp or `now`. */
+  min?: string;
+  max?: string;
+}
+
+interface PhotoQuestion extends QuestionBase {
+  type: 'photo';
+  /** Max number of attachments. Default 1. */
+  maxCount?: number;
+  /** Soft cap per file in bytes; renderer warns above this. */
+  maxBytes?: number;
+}
+
+interface SignatureQuestion extends QuestionBase {
+  type: 'signature';
+}
+
+interface GeoPointQuestion extends QuestionBase {
+  type: 'geopoint';
+  /** Capture mode hints. The runtime picks the strategy:
+   *  - `auto`: prefer GPS, fall back to map-pick.
+   *  - `gps`: GPS only.
+   *  - `map`: tap-on-map only.
+   *  - `manual`: lat/lon text inputs only. */
+  capture?: 'auto' | 'gps' | 'map' | 'manual';
+}
+
+interface GeoTraceQuestion extends QuestionBase {
+  type: 'geotrace';
+}
+
+interface GeoShapeQuestion extends QuestionBase {
+  type: 'geoshape';
+}
+
+interface RatingQuestion extends QuestionBase {
+  type: 'rating';
+  /** Number of icons (default 5). */
+  max?: number;
+  /** UI hint: `star` | `heart` | `thumb`. */
+  shape?: 'star' | 'heart' | 'thumb';
+}
+
+interface SliderQuestion extends QuestionBase {
+  type: 'slider';
+  min: number;
+  max: number;
+  step?: number;
+  showValue?: boolean;
+}
+
+interface CalculatedQuestion extends QuestionBase {
+  type: 'calculated';
+  /** Expression that produces this question's value at runtime.
+   *  Re-evaluated whenever a referenced field changes. */
+  calculate: Expression;
+  /** Display format hint: `text` (default) | `number` | `date`. */
+  format?: 'text' | 'number' | 'date';
+}
+
+interface NoteQuestion extends QuestionBase {
+  type: 'note';
+  /** Render as plain or markdown-lite (bold, italic, links). */
+  appearance?: 'plain' | 'markdown';
+}
+
+interface PageQuestion extends QuestionBase {
+  type: 'page';
+  /** Page header text (overrides `label` when present). */
+  title?: string;
+}
+
+interface GroupQuestion extends QuestionBase {
+  type: 'group';
+  /** When `repeat` is set, this is a repeating group: the user
+   *  captures multiple instances of the inner questions. The Field
+   *  runtime maps repeating groups to a related child layer. */
+  repeat?: {
+    /** Min / max instance count. */
+    min?: number;
+    max?: number;
+    /** UI label per added instance ("Add another inspection"). */
+    addLabel?: string;
+  };
+  /** Child questions. Pages/groups can nest. */
+  children: Question[];
+}
+
+export type Question =
+  | TextQuestion
+  | MultilineQuestion
+  | NumberQuestion
+  | IntegerQuestion
+  | BooleanQuestion
+  | SelectOneQuestion
+  | SelectManyQuestion
+  | DateQuestion
+  | TimeQuestion
+  | DateTimeQuestion
+  | PhotoQuestion
+  | SignatureQuestion
+  | GeoPointQuestion
+  | GeoTraceQuestion
+  | GeoShapeQuestion
+  | RatingQuestion
+  | SliderQuestion
+  | CalculatedQuestion
+  | NoteQuestion
+  | PageQuestion
+  | GroupQuestion;
+
+// ---------------------------------------------------------------------------
+// Top-level form
+// ---------------------------------------------------------------------------
 
 export interface FormSchema {
   schemaVersion: FormSchemaVersion;
-  id: string;          // matches the Item id the form is stored under
+  /** Matches the `form` item id this schema lives on. */
+  id: string;
   title: string;
   description?: string;
-  pages: FormPage[];
+  /** Linear list of questions; pages/groups nest inside. The runtime
+   *  walks this in order. */
+  questions: Question[];
+  /** Optional default geometry binding for the Field runtime. When
+   *  present, the layer's geometry column is filled from this question
+   *  rather than from a separate `geopoint` capture flow. */
+  geometryQuestionId?: QuestionId;
+  /** Designer metadata (palette state, last-edit timestamps) the
+   *  runtime ignores. */
+  meta?: Record<string, unknown>;
 }
 
+// ---------------------------------------------------------------------------
+// Expression language
+// ---------------------------------------------------------------------------
+
 /**
- * Tiny expression language for visibility/validation. Kept intentionally
- * minimal so the renderer and server can evaluate without a full JS sandbox.
- * Example: { op: 'eq', left: { ref: 'age_group' }, right: { value: 'adult' } }
+ * Tiny expression DSL used for visibility, validation, calculations,
+ * and required-if. JSON-serializable; no eval, no Function. The same
+ * evaluator runs on the browser and the server -- by design, we have
+ * one source of truth for "did this submission validate".
+ *
+ * Operands:
+ *   - { ref: 'questionId' }            value of another question
+ *   - { value: 42 | 'x' | true | null} literal
+ *   - { call: 'today' }                zero-arg builtin
+ *   - { call: 'len', args: [...] }     n-arg builtin
+ *
+ * Operators support short-circuiting via `and` / `or`.
  */
 export type Expression =
   | { op: 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte'; left: Operand; right: Operand }
   | { op: 'and' | 'or'; operands: Expression[] }
-  | { op: 'not'; operand: Expression };
+  | { op: 'not'; operand: Expression }
+  | { op: 'in'; left: Operand; right: Operand }
+  | { op: 'between'; value: Operand; min: Operand; max: Operand }
+  | {
+      op: 'add' | 'sub' | 'mul' | 'div';
+      left: Operand;
+      right: Operand;
+    }
+  | { op: 'concat'; operands: Operand[] }
+  | { op: 'if'; condition: Expression; then: Operand; else: Operand };
 
-export type Operand = { ref: string } | { value: string | number | boolean | null };
+export type Operand =
+  | { ref: QuestionId }
+  | { value: string | number | boolean | null }
+  | { call: BuiltinName; args?: Operand[] };
+
+/** Whitelist of builtins the evaluator knows. Extend deliberately:
+ *  every entry here ships in both the browser and the server. */
+export const BUILTINS = [
+  'today', // current date as YYYY-MM-DD string
+  'now', // current ISO datetime string
+  'len', // string length
+  'sum', // numeric sum of a list of refs/values
+  'count', // count of selected choices in a select-many
+  'coalesce', // first non-null
+  'lower',
+  'upper',
+] as const;
+export type BuiltinName = (typeof BUILTINS)[number];
+
+// ---------------------------------------------------------------------------
+// Evaluator
+// ---------------------------------------------------------------------------
+
+/** Map of `questionId -> currently captured value`. */
+export type Response = Record<string, unknown>;
+
+/**
+ * Evaluate an Expression against the in-progress response. Returns
+ * any JSON-serialisable value. Throws on malformed schemas (mainly
+ * for tests / designer validation).
+ */
+export function evaluate(expr: Expression | undefined, response: Response): unknown {
+  if (!expr) return null;
+  switch (expr.op) {
+    case 'eq':
+      return resolve(expr.left, response) === resolve(expr.right, response);
+    case 'neq':
+      return resolve(expr.left, response) !== resolve(expr.right, response);
+    case 'gt':
+      return cmp(expr.left, expr.right, response) > 0;
+    case 'gte':
+      return cmp(expr.left, expr.right, response) >= 0;
+    case 'lt':
+      return cmp(expr.left, expr.right, response) < 0;
+    case 'lte':
+      return cmp(expr.left, expr.right, response) <= 0;
+    case 'and':
+      return expr.operands.every((e) => Boolean(evaluate(e, response)));
+    case 'or':
+      return expr.operands.some((e) => Boolean(evaluate(e, response)));
+    case 'not':
+      return !evaluate(expr.operand, response);
+    case 'in': {
+      const haystack = resolve(expr.right, response);
+      const needle = resolve(expr.left, response);
+      if (Array.isArray(haystack)) return haystack.includes(needle);
+      if (typeof haystack === 'string' && typeof needle === 'string') {
+        return haystack.includes(needle);
+      }
+      return false;
+    }
+    case 'between': {
+      const v = numericResolve(expr.value, response);
+      const lo = numericResolve(expr.min, response);
+      const hi = numericResolve(expr.max, response);
+      if (v === null || lo === null || hi === null) return false;
+      return v >= lo && v <= hi;
+    }
+    case 'add':
+    case 'sub':
+    case 'mul':
+    case 'div': {
+      const a = numericResolve(expr.left, response);
+      const b = numericResolve(expr.right, response);
+      if (a === null || b === null) return null;
+      switch (expr.op) {
+        case 'add':
+          return a + b;
+        case 'sub':
+          return a - b;
+        case 'mul':
+          return a * b;
+        case 'div':
+          return b === 0 ? null : a / b;
+      }
+      return null;
+    }
+    case 'concat':
+      return expr.operands
+        .map((o) => {
+          const v = resolve(o, response);
+          return v === null || v === undefined ? '' : String(v);
+        })
+        .join('');
+    case 'if':
+      return evaluate(expr.condition, response)
+        ? resolve(expr.then, response)
+        : resolve(expr.else, response);
+  }
+}
+
+function resolve(operand: Operand, response: Response): unknown {
+  if ('value' in operand) return operand.value;
+  if ('ref' in operand) return response[operand.ref] ?? null;
+  // builtin call
+  return callBuiltin(operand.call, operand.args ?? [], response);
+}
+
+function numericResolve(operand: Operand, response: Response): number | null {
+  const v = resolve(operand, response);
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string' && v.trim() !== '') {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function cmp(left: Operand, right: Operand, response: Response): number {
+  const a = resolve(left, response);
+  const b = resolve(right, response);
+  if (typeof a === 'number' && typeof b === 'number') return a - b;
+  // String compare for everything else (dates compare correctly as
+  // ISO strings).
+  return String(a ?? '').localeCompare(String(b ?? ''));
+}
+
+function callBuiltin(
+  name: BuiltinName,
+  args: Operand[],
+  response: Response,
+): unknown {
+  switch (name) {
+    case 'today': {
+      const d = new Date();
+      const yyyy = d.getFullYear();
+      const mm = String(d.getMonth() + 1).padStart(2, '0');
+      const dd = String(d.getDate()).padStart(2, '0');
+      return `${yyyy}-${mm}-${dd}`;
+    }
+    case 'now':
+      return new Date().toISOString();
+    case 'len': {
+      const v = args[0] ? resolve(args[0], response) : null;
+      if (typeof v === 'string') return v.length;
+      if (Array.isArray(v)) return v.length;
+      return 0;
+    }
+    case 'sum': {
+      let total = 0;
+      for (const a of args) {
+        const v = numericResolve(a, response);
+        if (v !== null) total += v;
+      }
+      return total;
+    }
+    case 'count': {
+      const v = args[0] ? resolve(args[0], response) : null;
+      return Array.isArray(v) ? v.length : 0;
+    }
+    case 'coalesce': {
+      for (const a of args) {
+        const v = resolve(a, response);
+        if (v !== null && v !== undefined && v !== '') return v;
+      }
+      return null;
+    }
+    case 'lower': {
+      const v = args[0] ? resolve(args[0], response) : null;
+      return typeof v === 'string' ? v.toLowerCase() : v;
+    }
+    case 'upper': {
+      const v = args[0] ? resolve(args[0], response) : null;
+      return typeof v === 'string' ? v.toUpperCase() : v;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Walker / utilities
+// ---------------------------------------------------------------------------
+
+/**
+ * Iterate every question in the schema, walking into pages/groups.
+ * Used by the designer (palette dragdrop), the runtime (visibility
+ * resolution), and the validator.
+ */
+export function* walkQuestions(form: FormSchema): Iterable<Question> {
+  yield* walkList(form.questions);
+}
+
+function* walkList(qs: Question[]): Iterable<Question> {
+  for (const q of qs) {
+    yield q;
+    if (q.type === 'group') yield* walkList(q.children);
+  }
+}
+
+/** Lookup by id; O(n) but n is small in practice. */
+export function findQuestion(
+  form: FormSchema,
+  id: QuestionId,
+): Question | undefined {
+  for (const q of walkQuestions(form)) if (q.id === id) return q;
+  return undefined;
+}
+
+/**
+ * Compatible question types per data_layer column type. The Field
+ * runtime uses this to filter the palette when binding to an
+ * existing layer column. Returns the empty set if the column type
+ * is unknown to us.
+ */
+export function compatibleQuestionTypes(
+  columnType: string,
+): readonly QuestionType[] {
+  const t = columnType.toLowerCase();
+  if (/text|varchar|char/.test(t)) return ['text', 'multiline', 'select-one'];
+  if (/int|smallint|bigint/.test(t)) return ['integer', 'rating', 'slider', 'select-one'];
+  if (/numeric|float|double|real|decimal/.test(t)) {
+    return ['number', 'slider'];
+  }
+  if (/bool/.test(t)) return ['boolean'];
+  if (t.includes('date') && t.includes('time')) return ['datetime'];
+  if (t.includes('time')) return ['time'];
+  if (t.includes('date')) return ['date'];
+  if (/geometry|geography|point/.test(t)) {
+    if (/point/.test(t)) return ['geopoint'];
+    if (/line/.test(t)) return ['geotrace'];
+    if (/polygon/.test(t)) return ['geoshape'];
+    return ['geopoint', 'geotrace', 'geoshape'];
+  }
+  if (/json/.test(t)) return ['select-many', 'multiline'];
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Validator
+// ---------------------------------------------------------------------------
+
+export interface ValidationError {
+  questionId: QuestionId;
+  message: string;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: ValidationError[];
+}
+
+/**
+ * Validate a response against the schema. Honors visibility (hidden
+ * fields are not validated), required (incl. required-if), constraint
+ * expressions, and per-type bounds (min/max length, min/max value,
+ * min/max selected, etc).
+ */
+export function validate(form: FormSchema, response: Response): ValidationResult {
+  const errors: ValidationError[] = [];
+  for (const q of walkQuestions(form)) {
+    if (q.type === 'page' || q.type === 'note' || q.type === 'group') continue;
+    if (!isVisible(q, response)) continue;
+
+    const value = response[q.id];
+    if (isRequired(q, response) && isEmpty(value)) {
+      errors.push({ questionId: q.id, message: 'This field is required.' });
+      continue;
+    }
+    if (isEmpty(value)) continue; // nothing more to validate when blank + optional
+
+    const typeError = validateType(q, value);
+    if (typeError) {
+      errors.push({ questionId: q.id, message: typeError });
+      continue;
+    }
+
+    if (q.constraint) {
+      const ok = evaluate(q.constraint, response);
+      if (!ok) {
+        errors.push({
+          questionId: q.id,
+          message: q.message ?? 'Value is not valid.',
+        });
+      }
+    }
+  }
+  return { ok: errors.length === 0, errors };
+}
+
+export function isVisible(q: Question, response: Response): boolean {
+  if (q.visible === false) return false;
+  if (!q.visibleIf) return true;
+  return Boolean(evaluate(q.visibleIf, response));
+}
+
+export function isRequired(q: Question, response: Response): boolean {
+  if (q.required === undefined) return false;
+  if (typeof q.required === 'boolean') return q.required;
+  return Boolean(evaluate(q.required, response));
+}
+
+function isEmpty(value: unknown): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === 'string') return value.trim() === '';
+  if (Array.isArray(value)) return value.length === 0;
+  return false;
+}
+
+function validateType(q: Question, value: unknown): string | null {
+  switch (q.type) {
+    case 'text':
+    case 'multiline': {
+      if (typeof value !== 'string') return 'Expected text.';
+      if (q.maxLength && value.length > q.maxLength) {
+        return `Must be ${q.maxLength} characters or fewer.`;
+      }
+      if (q.type === 'text' && q.pattern) {
+        const re = new RegExp(`^(?:${q.pattern})$`);
+        if (!re.test(value)) return 'Does not match the required format.';
+      }
+      return null;
+    }
+    case 'number':
+    case 'integer': {
+      const n = typeof value === 'number' ? value : Number(value);
+      if (!Number.isFinite(n)) return 'Expected a number.';
+      if (q.type === 'integer' && !Number.isInteger(n)) {
+        return 'Expected a whole number.';
+      }
+      if (q.min !== undefined && n < q.min) return `Must be at least ${q.min}.`;
+      if (q.max !== undefined && n > q.max) return `Must be at most ${q.max}.`;
+      return null;
+    }
+    case 'boolean':
+      if (typeof value !== 'boolean') return 'Expected yes or no.';
+      return null;
+    case 'select-one':
+      if (typeof value !== 'string') return 'Pick one option.';
+      return null;
+    case 'select-many': {
+      if (!Array.isArray(value)) return 'Pick from the options.';
+      if (q.minSelected !== undefined && value.length < q.minSelected) {
+        return `Pick at least ${q.minSelected}.`;
+      }
+      if (q.maxSelected !== undefined && value.length > q.maxSelected) {
+        return `Pick at most ${q.maxSelected}.`;
+      }
+      return null;
+    }
+    case 'date':
+    case 'time':
+    case 'datetime':
+      if (typeof value !== 'string') return 'Expected a valid value.';
+      return null;
+    case 'photo':
+      if (!Array.isArray(value)) return 'Expected one or more attachments.';
+      if (q.maxCount !== undefined && value.length > q.maxCount) {
+        return `Up to ${q.maxCount} attachments allowed.`;
+      }
+      return null;
+    case 'signature':
+    case 'geopoint':
+    case 'geotrace':
+    case 'geoshape':
+    case 'rating':
+    case 'slider':
+    case 'calculated':
+      return null;
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers used by the runtime to compute derived values
+// ---------------------------------------------------------------------------
+
+/**
+ * For every `calculated` question whose dependencies have changed,
+ * recompute its value and write it into the response. Returns the
+ * mutated response (callers can rely on identity equality when
+ * nothing changed).
+ */
+export function applyCalculations(
+  form: FormSchema,
+  response: Response,
+): Response {
+  let next = response;
+  let changed = false;
+  for (const q of walkQuestions(form)) {
+    if (q.type !== 'calculated') continue;
+    const computed = evaluate(q.calculate, response);
+    if (next[q.id] !== computed) {
+      if (!changed) {
+        next = { ...response };
+        changed = true;
+      }
+      next[q.id] = computed;
+    }
+  }
+  return next;
+}
+
+/**
+ * Strip values for hidden fields so submissions don't leak data the
+ * respondent never confirmed. Called by the runtime before submit.
+ */
+export function pruneHidden(form: FormSchema, response: Response): Response {
+  const out: Response = {};
+  for (const q of walkQuestions(form)) {
+    if (q.type === 'page' || q.type === 'note' || q.type === 'group') continue;
+    if (!isVisible(q, response)) continue;
+    if (q.id in response) out[q.id] = response[q.id];
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Designer helpers (used by the form builder UI)
+// ---------------------------------------------------------------------------
+
+/** Generate a fresh, empty FormSchema bound to a given form item id. */
+export function emptyForm(id: string, title = 'Untitled form'): FormSchema {
+  return {
+    schemaVersion: CURRENT_FORM_SCHEMA_VERSION,
+    id,
+    title,
+    questions: [],
+  };
+}
+
+/** Default question shape per type. The designer drops one of these
+ *  into the canvas when the user drags a palette item. */
+export function defaultQuestion(type: QuestionType, id: QuestionId): Question {
+  const base = { id, label: defaultLabel(type) };
+  switch (type) {
+    case 'text':
+      return { ...base, type };
+    case 'multiline':
+      return { ...base, type, rows: 3 };
+    case 'number':
+      return { ...base, type };
+    case 'integer':
+      return { ...base, type };
+    case 'boolean':
+      return { ...base, type };
+    case 'select-one':
+      return {
+        ...base,
+        type,
+        appearance: 'radio',
+        choices: [
+          { value: 'option_1', label: 'Option 1' },
+          { value: 'option_2', label: 'Option 2' },
+        ],
+      };
+    case 'select-many':
+      return {
+        ...base,
+        type,
+        choices: [
+          { value: 'option_1', label: 'Option 1' },
+          { value: 'option_2', label: 'Option 2' },
+        ],
+      };
+    case 'date':
+      return { ...base, type };
+    case 'time':
+      return { ...base, type };
+    case 'datetime':
+      return { ...base, type };
+    case 'photo':
+      return { ...base, type, maxCount: 1 };
+    case 'signature':
+      return { ...base, type };
+    case 'geopoint':
+      return { ...base, type, capture: 'auto' };
+    case 'geotrace':
+      return { ...base, type };
+    case 'geoshape':
+      return { ...base, type };
+    case 'rating':
+      return { ...base, type, max: 5, shape: 'star' };
+    case 'slider':
+      return { ...base, type, min: 0, max: 100, step: 1, showValue: true };
+    case 'calculated':
+      // Trivial pass-through expression so the field has a valid
+      // calculate that never errors. The designer prompts the user
+      // to wire in real refs.
+      return {
+        ...base,
+        type,
+        calculate: { op: 'concat', operands: [{ value: '' }] },
+      };
+    case 'note':
+      return { ...base, type, appearance: 'plain' };
+    case 'page':
+      return { ...base, type, label: 'Page break' };
+    case 'group':
+      return { ...base, type, children: [] };
+  }
+}
+
+function defaultLabel(type: QuestionType): string {
+  return (
+    {
+      text: 'Short text',
+      multiline: 'Long text',
+      number: 'Number',
+      integer: 'Whole number',
+      boolean: 'Yes / No',
+      'select-one': 'Single choice',
+      'select-many': 'Multiple choice',
+      date: 'Date',
+      time: 'Time',
+      datetime: 'Date and time',
+      photo: 'Photo',
+      signature: 'Signature',
+      geopoint: 'Location (point)',
+      geotrace: 'Path (polyline)',
+      geoshape: 'Area (polygon)',
+      rating: 'Rating',
+      slider: 'Slider',
+      calculated: 'Calculated',
+      note: 'Note',
+      page: 'New page',
+      group: 'Group',
+    } satisfies Record<QuestionType, string>
+  )[type];
+}
+
+/**
+ * Generate a unique question id from a label. Lowercase, snake_case,
+ * truncated to 40 chars. Not a strict slugifier; the designer
+ * deduplicates on save.
+ */
+export function suggestQuestionId(label: string): string {
+  const base = label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_|_$/g, '')
+    .slice(0, 40);
+  return base || 'question';
+}
+
+/**
+ * Walk the schema and return a Set of all question ids in use, so
+ * the designer can avoid id collisions when adding new questions.
+ */
+export function collectIds(form: FormSchema): Set<string> {
+  const ids = new Set<string>();
+  for (const q of walkQuestions(form)) ids.add(q.id);
+  return ids;
+}
+
+/** Ensure a candidate id is unique; appends `_2`, `_3`, ... as needed. */
+export function uniqueQuestionId(form: FormSchema, candidate: string): string {
+  const existing = collectIds(form);
+  if (!existing.has(candidate)) return candidate;
+  let i = 2;
+  while (existing.has(`${candidate}_${i}`)) i += 1;
+  return `${candidate}_${i}`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
 
   apps/portal-web:
     dependencies:
+      '@gratis-gis/form-schema':
+        specifier: workspace:*
+        version: link:../../packages/form-schema
       '@gratis-gis/shared-types':
         specifier: workspace:*
         version: link:../../packages/shared-types


### PR DESCRIPTION
Phase 1 of the unified Data Collection workflow described in
[`docs/editing-and-collection.md`](docs/editing-and-collection.md). Lands the **shared form-schema kernel + designer + runtime** end-to-end, plus the **Survey-style entry point** (form-first, optional location). The **Field-style entry point** (map-first, layer-bound) reuses the same designer + runtime in a Phase 1b follow-up that adds the `data_collection` item type.

The thesis is the same as the design doc: "Survey vs Field Maps" is a **runtime entry point difference**, not two separate stacks. The schema, designer, validator, evaluator, and form runtime are **identical**; only how you reach them differs.

## What you can test tonight

1. **Add menu → Forms → Form** to create a form item.
2. The form item's detail page is the designer (replaces the coming-soon page). Drag types from the left palette onto the canvas; tap-to-add works on touch.
3. Bottom of the designer page shows the link `/forms/<id>/respond`. Open it from your phone, fill in, hit Submit.
4. **Toggle airplane mode mid-response**: the submit queues to IndexedDB, the Outbox card appears, and re-enabling network drains it.

## What landed

### Shared kernel — `@gratis-gis/form-schema`

- 21 question types matching Survey123's catalog: text, multiline, number, integer, boolean, single/multi choice, date/time/datetime, photo, signature, geopoint/geotrace/geoshape, rating, slider, calculated, note, page, group (incl. repeating).
- JSON-only expression DSL — **no eval, no Function constructor**. Same evaluator runs in browser + server. Comparisons, boolean ops, arithmetic, in/between, if/then, fixed builtin whitelist (`today`, `now`, `len`, `sum`, `count`, `coalesce`, `lower`, `upper`).
- Helpers: `walkQuestions`, `validate`, `applyCalculations`, `pruneHidden`, `isVisible`, `isRequired`, `compatibleQuestionTypes` (Field-mode column-type filtering).
- `CURRENT_FORM_SCHEMA_VERSION` stamped on every captured submission so forward-rolled forms never invalidate in-flight queues.

### Designer

`apps/portal-web/src/app/items/[id]/form/designer.tsx` — three-panel UX (palette / canvas / properties), HTML5 native drag-drop, tap-to-add for touch, live Preview tab that swaps the canvas for the real runtime against the in-memory schema. Per-type bounds (min/max, maxLength, choices) and a Phase 1 conditional-logic builder (single-`eq` `visibleIf` rule).

### Runtime

`apps/portal-web/src/components/form-runtime.tsx` — **mobile-first**. Single column, native input types so phone keyboards do the right thing, sticky bottom action bar, paged surveys, repeating groups, GPS capture for `geopoint`, photo capture via `<input type="file" capture="environment">`. The runtime is used **both** as the designer Preview pane and as the public respondent runtime, so they can never drift.

### Offline

`apps/portal-web/src/lib/form-offline.ts` — **zero-dep IndexedDB outbox**. Submissions queue with a client-generated UUID, drain on the `online` event, fail open with a visible Outbox card. Backend upserts on `(formId, clientId)` so a re-drained queue is a no-op.

### Backend

`apps/portal-api/src/forms/` — new `form_submission` table, idempotent `POST /forms/:id/submissions`, list + count endpoints. `schemaVersion` preserved.

## Phase 1b follow-ups (already documented in `docs/data-collection-phase1.md`)

- `data_collection` item type (Survey + Field deployment wrapper)
- Field runtime: map canvas + per-layer feature templates (mostly the existing Editor canvas + the FormRuntime opening on Add)
- Service worker pre-cache of the runtime + form schema + target layer schemas (the IndexedDB outbox is already in place)
- Touch drag-drop fallback (HTML5 native DnD is desktop-only on iOS)
- Full conditional logic builder UI (Expression DSL already supports the fuller shape; UI catches up next)

## Quality gate

- `pnpm typecheck` passes
- `pnpm lint` passes (existing import-type warnings only)
- `pnpm test` passes
- migration applied locally via `prisma migrate deploy`

Closes #131.
