### PR TITLE
fix(forms): nested groups + repeating + import from data layer (#131 followup)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   AlignLeft,
   Calculator,
@@ -10,6 +10,7 @@ import {
   CheckSquare,
   Circle,
   Clock,
+  Database,
   Eye,
   GripVertical,
   Hash,
@@ -27,6 +28,7 @@ import {
   Trash2,
   Type,
   Workflow,
+  X,
 } from 'lucide-react';
 import {
   collectIds,
@@ -52,19 +54,30 @@ interface Props {
 }
 
 /**
- * Three-panel form designer (#131). Survey123-style layout: palette on
- * the left, canvas in the middle, properties on the right; a Preview
- * tab swaps the canvas with the live runtime so authors can sanity-
- * check what respondents will see.
+ * Three-panel form designer (#131 / #141). Survey123-style layout:
+ * palette / canvas / properties; a Preview tab swaps the canvas with
+ * the live runtime so authors can sanity-check what respondents see.
  *
- * Persistence: the schema lives on the form item's `data_json`. Save
- * does a PUT to /api/portal/items/<id> with the full data field.
+ * Tree model: questions live in a tree -- top-level array on the
+ * form, plus `children` arrays on `group` questions. Every state
+ * mutation (add / update / remove / move) takes a "container path":
+ * `null` for the top level, or a group's question id. The Canvas is
+ * a recursive component that renders the tree with proper drop
+ * zones at each level so users can drop into a group, not just on
+ * the top-level list.
  *
- * Drag-drop: HTML5 native (no extra deps). Drag from palette into the
- * canvas to add; drag a canvas row by its grip to reorder. Touch
- * drag-drop is awkward on phones, so the palette + canvas also
- * support tap-to-add (selecting a palette tile inserts at the end of
- * the canvas).
+ * Drag-drop: HTML5 native (no extra deps). Drop targets stop event
+ * propagation so a drop on a row doesn't double-fire on the parent
+ * container. Tap-to-add is preserved for touch devices where DnD is
+ * unreliable.
+ *
+ * Layer import: a "Start from a data layer" entry point on the
+ * empty canvas (and a button always available in the form-level
+ * properties panel) opens a picker, fetches the layer's columns,
+ * and seeds the form with one question per column at compatible
+ * types. Each generated question has `bindTo.column` set so the
+ * Field-mode runtime can map submissions back to the layer
+ * automatically.
  */
 export function FormDesigner({ itemId, initial, canEdit }: Props) {
   const [form, setForm] = useState<FormSchema>(
@@ -75,51 +88,65 @@ export function FormDesigner({ itemId, initial, canEdit }: Props) {
   const [saving, setSaving] = useState(false);
   const [savedAt, setSavedAt] = useState<Date | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [importOpen, setImportOpen] = useState(false);
 
   const selected = useMemo(
-    () => (selectedId ? form.questions.find((q) => q.id === selectedId) ?? null : null),
+    () => (selectedId ? findById(form.questions, selectedId) : null),
     [form.questions, selectedId],
   );
 
+  /**
+   * Add a fresh question. `containerId === null` puts it at the end
+   * of the top-level questions; a non-null id puts it at the end of
+   * that group's children.
+   */
   const addQuestion = useCallback(
-    (type: QuestionType) => {
+    (type: QuestionType, containerId: QuestionId | null = null) => {
       const baseId = suggestQuestionId(type);
-      const id = uniqueQuestionId(form, baseId);
-      const q = defaultQuestion(type, id);
-      setForm((f) => ({ ...f, questions: [...f.questions, q] }));
-      setSelectedId(id);
+      setForm((f) => {
+        const id = uniqueQuestionId(f, baseId);
+        const q = defaultQuestion(type, id);
+        const next = mutateContainer(f, containerId, (list) => [...list, q]);
+        // schedule selection on the next tick so the freshly-added
+        // question is selectable immediately
+        queueMicrotask(() => setSelectedId(id));
+        return next;
+      });
     },
-    [form],
+    [],
   );
 
   const updateQuestion = useCallback(
     (id: QuestionId, patch: Partial<Question>) => {
-      setForm((f) => ({
-        ...f,
-        questions: f.questions.map((q) =>
-          q.id === id ? ({ ...q, ...patch } as Question) : q,
-        ),
-      }));
+      setForm((f) => updateInTree(f, id, (q) => ({ ...q, ...patch } as Question)));
     },
     [],
   );
 
   const removeQuestion = useCallback((id: QuestionId) => {
-    setForm((f) => ({
-      ...f,
-      questions: f.questions.filter((q) => q.id !== id),
-    }));
+    setForm((f) => removeFromTree(f, id));
     setSelectedId(null);
   }, []);
 
-  const reorder = useCallback((from: number, to: number) => {
-    setForm((f) => {
-      const next = f.questions.slice();
-      const [moved] = next.splice(from, 1);
-      if (moved) next.splice(to, 0, moved);
-      return { ...f, questions: next };
-    });
-  }, []);
+  /**
+   * Move an existing question. Supports the three transitions:
+   *
+   *   - reorder within the same container
+   *   - move from top-level into a group's children
+   *   - move from a group's children to top-level (drop on a top-
+   *     level question or the empty footer)
+   *
+   * Drops on the dragged question itself are no-ops.
+   */
+  const moveQuestion = useCallback(
+    (
+      sourceId: QuestionId,
+      target: { containerId: QuestionId | null; index: number },
+    ) => {
+      setForm((f) => moveInTree(f, sourceId, target));
+    },
+    [],
+  );
 
   async function save() {
     if (!canEdit) return;
@@ -138,6 +165,11 @@ export function FormDesigner({ itemId, initial, canEdit }: Props) {
     } finally {
       setSaving(false);
     }
+  }
+
+  function applyImported(qs: Question[]) {
+    setForm((f) => ({ ...f, questions: [...f.questions, ...qs] }));
+    setImportOpen(false);
   }
 
   return (
@@ -212,15 +244,16 @@ export function FormDesigner({ itemId, initial, canEdit }: Props) {
 
       {tab === 'design' ? (
         <div className="grid grid-cols-1 lg:grid-cols-[200px_1fr_280px]">
-          <Palette canEdit={canEdit} onAdd={addQuestion} />
+          <Palette canEdit={canEdit} onAdd={(t) => addQuestion(t, null)} />
           <Canvas
             form={form}
             selectedId={selectedId}
             canEdit={canEdit}
             onSelect={setSelectedId}
             onRemove={removeQuestion}
-            onReorder={reorder}
-            onAdd={addQuestion}
+            onAddInto={addQuestion}
+            onMove={moveQuestion}
+            onOpenImport={() => setImportOpen(true)}
           />
           <Properties
             form={form}
@@ -239,15 +272,13 @@ export function FormDesigner({ itemId, initial, canEdit }: Props) {
                 return;
               }
               setError(null);
-              setForm((f) => ({
-                ...f,
-                questions: f.questions.map((q) =>
-                  q.id === selected.id ? ({ ...q, id: newId } as Question) : q,
-                ),
-              }));
+              setForm((f) =>
+                updateInTree(f, selected.id, (q) => ({ ...q, id: newId } as Question)),
+              );
               setSelectedId(newId);
             }}
             onUpdateForm={(patch) => setForm({ ...form, ...patch })}
+            onOpenImport={() => setImportOpen(true)}
           />
         </div>
       ) : (
@@ -261,8 +292,135 @@ export function FormDesigner({ itemId, initial, canEdit }: Props) {
           />
         </div>
       )}
+
+      {importOpen ? (
+        <LayerImportDialog onClose={() => setImportOpen(false)} onApply={applyImported} />
+      ) : null}
     </div>
   );
+}
+
+// ---- Tree mutation helpers --------------------------------------
+
+function findById(qs: Question[], id: QuestionId): Question | null {
+  for (const q of qs) {
+    if (q.id === id) return q;
+    if (q.type === 'group') {
+      const inner = findById(q.children, id);
+      if (inner) return inner;
+    }
+  }
+  return null;
+}
+
+function mutateContainer(
+  form: FormSchema,
+  containerId: QuestionId | null,
+  fn: (list: Question[]) => Question[],
+): FormSchema {
+  if (containerId === null) {
+    return { ...form, questions: fn(form.questions) };
+  }
+  return {
+    ...form,
+    questions: mapTree(form.questions, (q) => {
+      if (q.type === 'group' && q.id === containerId) {
+        return { ...q, children: fn(q.children) };
+      }
+      return q;
+    }),
+  };
+}
+
+function mapTree(
+  qs: Question[],
+  fn: (q: Question) => Question,
+): Question[] {
+  return qs.map((q) => {
+    const mapped = fn(q);
+    if (mapped.type === 'group') {
+      return { ...mapped, children: mapTree(mapped.children, fn) };
+    }
+    return mapped;
+  });
+}
+
+function updateInTree(
+  form: FormSchema,
+  id: QuestionId,
+  fn: (q: Question) => Question,
+): FormSchema {
+  return {
+    ...form,
+    questions: mapTree(form.questions, (q) => (q.id === id ? fn(q) : q)),
+  };
+}
+
+function removeFromTree(form: FormSchema, id: QuestionId): FormSchema {
+  function rec(list: Question[]): Question[] {
+    return list
+      .filter((q) => q.id !== id)
+      .map((q) => (q.type === 'group' ? { ...q, children: rec(q.children) } : q));
+  }
+  return { ...form, questions: rec(form.questions) };
+}
+
+/** Locate the parent container + index for a given question id. */
+function locate(
+  qs: Question[],
+  id: QuestionId,
+  parent: QuestionId | null = null,
+): { containerId: QuestionId | null; index: number } | null {
+  for (let i = 0; i < qs.length; i += 1) {
+    const q = qs[i]!;
+    if (q.id === id) return { containerId: parent, index: i };
+    if (q.type === 'group') {
+      const inner = locate(q.children, id, q.id);
+      if (inner) return inner;
+    }
+  }
+  return null;
+}
+
+function moveInTree(
+  form: FormSchema,
+  sourceId: QuestionId,
+  target: { containerId: QuestionId | null; index: number },
+): FormSchema {
+  // Reject moving a group into itself or any of its descendants.
+  const moved = findById(form.questions, sourceId);
+  if (!moved) return form;
+  if (target.containerId !== null && isDescendant(moved, target.containerId)) {
+    return form;
+  }
+  // Detach the source first so subsequent index math is consistent
+  // with the post-detach tree.
+  const src = locate(form.questions, sourceId);
+  if (!src) return form;
+
+  // Detach
+  let next = removeFromTree(form, sourceId);
+
+  // Adjust the target index if we removed an item before it from the
+  // same container.
+  let insertIndex = target.index;
+  if (src.containerId === target.containerId && src.index < target.index) {
+    insertIndex -= 1;
+  }
+  insertIndex = Math.max(0, insertIndex);
+
+  next = mutateContainer(next, target.containerId, (list) => {
+    const out = list.slice();
+    out.splice(insertIndex, 0, moved);
+    return out;
+  });
+  return next;
+}
+
+function isDescendant(node: Question, candidateId: QuestionId): boolean {
+  if (node.id === candidateId) return true;
+  if (node.type !== 'group') return false;
+  return node.children.some((c) => isDescendant(c, candidateId));
 }
 
 // ---- Palette ----------------------------------------------------
@@ -295,7 +453,7 @@ const PALETTE: PaletteEntry[] = [
   { type: 'calculated', label: 'Calculated', icon: Calculator, group: 'logic' },
   { type: 'note', label: 'Note', icon: TextIcon, group: 'layout' },
   { type: 'page', label: 'Page break', icon: Workflow, group: 'layout' },
-  { type: 'group', label: 'Group', icon: ListChecks, group: 'layout' },
+  { type: 'group', label: 'Group / Repeat', icon: ListChecks, group: 'layout' },
 ];
 
 function Palette({
@@ -338,133 +496,302 @@ function Palette({
   );
 }
 
-// ---- Canvas -----------------------------------------------------
+// ---- Canvas (recursive) -----------------------------------------
 
-function Canvas({
-  form,
-  selectedId,
-  canEdit,
-  onSelect,
-  onRemove,
-  onReorder,
-  onAdd,
-}: {
-  form: FormSchema;
+interface CanvasCallbacks {
   selectedId: QuestionId | null;
   canEdit: boolean;
   onSelect: (id: QuestionId) => void;
   onRemove: (id: QuestionId) => void;
-  onReorder: (from: number, to: number) => void;
-  onAdd: (type: QuestionType) => void;
-}) {
-  const [dragIndex, setDragIndex] = useState<number | null>(null);
-  const [overIndex, setOverIndex] = useState<number | null>(null);
+  onAddInto: (type: QuestionType, containerId: QuestionId | null) => void;
+  onMove: (
+    sourceId: QuestionId,
+    target: { containerId: QuestionId | null; index: number },
+  ) => void;
+}
 
-  function onDropTarget(toIndex: number, e: React.DragEvent) {
-    e.preventDefault();
-    const newType = e.dataTransfer.getData('text/x-question-type');
-    if (newType) {
-      // adding from palette
-      onAdd(newType as QuestionType);
-      return;
-    }
-    if (dragIndex !== null) {
-      onReorder(dragIndex, toIndex);
-    }
-    setDragIndex(null);
-    setOverIndex(null);
-  }
-
+function Canvas({
+  form,
+  onOpenImport,
+  ...cb
+}: { form: FormSchema; onOpenImport: () => void } & CanvasCallbacks) {
   return (
-    <main
-      className="min-h-[420px] border-b border-border bg-surface-0 p-4 lg:border-b-0"
+    <main className="min-h-[420px] border-b border-border bg-surface-0 p-4 lg:border-b-0">
+      {form.questions.length === 0 ? (
+        <EmptyCanvas
+          canEdit={cb.canEdit}
+          onAddType={(t) => cb.onAddInto(t, null)}
+          onMoveTop={(id) => cb.onMove(id, { containerId: null, index: 0 })}
+          onOpenImport={onOpenImport}
+        />
+      ) : (
+        <QuestionList list={form.questions} containerId={null} {...cb} />
+      )}
+    </main>
+  );
+}
+
+function EmptyCanvas({
+  canEdit,
+  onAddType,
+  onMoveTop,
+  onOpenImport,
+}: {
+  canEdit: boolean;
+  onAddType: (t: QuestionType) => void;
+  onMoveTop: (id: QuestionId) => void;
+  onOpenImport: () => void;
+}) {
+  return (
+    <div
+      className="flex h-64 flex-col items-center justify-center gap-2 rounded-md border border-dashed border-border bg-surface-1 text-center text-sm text-muted"
       onDragOver={(e) => {
         if (canEdit) e.preventDefault();
       }}
       onDrop={(e) => {
         if (!canEdit) return;
+        e.preventDefault();
         const newType = e.dataTransfer.getData('text/x-question-type');
-        if (newType) onAdd(newType as QuestionType);
+        const sourceId = e.dataTransfer.getData('text/x-reorder-id');
+        if (newType) onAddType(newType as QuestionType);
+        else if (sourceId) onMoveTop(sourceId);
       }}
     >
-      {form.questions.length === 0 ? (
-        <div className="flex h-64 flex-col items-center justify-center rounded-md border border-dashed border-border bg-surface-1 text-center text-sm text-muted">
-          <Plus className="mb-2 h-5 w-5" />
-          Drag a question type from the left, or tap one to add it.
+      <Plus className="h-5 w-5" />
+      <span>Drag a question type from the left, or tap one to add it.</span>
+      {canEdit ? (
+        <button
+          type="button"
+          onClick={onOpenImport}
+          className="mt-1 inline-flex h-8 items-center gap-1 rounded-md border border-border bg-surface-1 px-3 text-xs font-medium text-ink-1 hover:bg-surface-2"
+        >
+          <Database className="h-3.5 w-3.5" />
+          Or start from a data layer
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function QuestionList({
+  list,
+  containerId,
+  ...cb
+}: { list: Question[]; containerId: QuestionId | null } & CanvasCallbacks) {
+  return (
+    <ul className="space-y-2">
+      {list.map((q, i) => (
+        <QuestionRow
+          key={q.id}
+          q={q}
+          index={i}
+          containerId={containerId}
+          {...cb}
+        />
+      ))}
+      {/* Trailing drop zone for "drop at the end". Without this you
+          can't drop into an empty group, and you can't append-via-
+          drop on the top-level list either. */}
+      <li>
+        <DropSlot
+          containerId={containerId}
+          index={list.length}
+          canEdit={cb.canEdit}
+          onAddType={(t) => cb.onAddInto(t, containerId)}
+          onMove={(id) => cb.onMove(id, { containerId, index: list.length })}
+        />
+      </li>
+    </ul>
+  );
+}
+
+function DropSlot({
+  containerId: _containerId,
+  index: _index,
+  canEdit,
+  onAddType,
+  onMove,
+}: {
+  containerId: QuestionId | null;
+  index: number;
+  canEdit: boolean;
+  onAddType: (t: QuestionType) => void;
+  onMove: (sourceId: QuestionId) => void;
+}) {
+  const [over, setOver] = useState(false);
+  if (!canEdit) return null;
+  return (
+    <div
+      className={`h-3 rounded transition ${
+        over ? 'bg-accent/30' : 'bg-transparent'
+      }`}
+      onDragOver={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setOver(true);
+      }}
+      onDragLeave={() => setOver(false)}
+      onDrop={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        setOver(false);
+        const newType = e.dataTransfer.getData('text/x-question-type');
+        const sourceId = e.dataTransfer.getData('text/x-reorder-id');
+        if (newType) onAddType(newType as QuestionType);
+        else if (sourceId) onMove(sourceId);
+      }}
+    />
+  );
+}
+
+function QuestionRow({
+  q,
+  index,
+  containerId,
+  selectedId,
+  canEdit,
+  onSelect,
+  onRemove,
+  onAddInto,
+  onMove,
+}: {
+  q: Question;
+  index: number;
+  containerId: QuestionId | null;
+} & CanvasCallbacks) {
+  const [overTop, setOverTop] = useState(false);
+
+  function onTopDrop(e: React.DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    setOverTop(false);
+    const newType = e.dataTransfer.getData('text/x-question-type');
+    const sourceId = e.dataTransfer.getData('text/x-reorder-id');
+    if (newType) onAddInto(newType as QuestionType, containerId);
+    else if (sourceId && sourceId !== q.id) {
+      onMove(sourceId, { containerId, index });
+    }
+  }
+
+  return (
+    <li>
+      {/* Insert-before drop zone. Sits above the row card so the user
+          gets a target *between* questions, distinct from "drop on
+          the row" (which would be ambiguous). */}
+      <DropSlot
+        containerId={containerId}
+        index={index}
+        canEdit={canEdit}
+        onAddType={(t) => onAddInto(t, containerId)}
+        onMove={(id) => {
+          if (id !== q.id) onMove(id, { containerId, index });
+        }}
+      />
+
+      <div
+        className={`relative rounded-md border ${
+          q.id === selectedId
+            ? 'border-accent ring-2 ring-accent/30'
+            : 'border-border'
+        } bg-surface-1 p-3 ${overTop ? 'border-accent' : ''}`}
+        onClick={(e) => {
+          e.stopPropagation();
+          onSelect(q.id);
+        }}
+        onDragOver={(e) => {
+          if (!canEdit) return;
+          e.preventDefault();
+          e.stopPropagation();
+          setOverTop(true);
+        }}
+        onDragLeave={() => setOverTop(false)}
+        onDrop={onTopDrop}
+      >
+        <div className="flex items-start gap-2">
+          {canEdit ? (
+            <button
+              type="button"
+              draggable
+              onDragStart={(e) => {
+                e.dataTransfer.setData('text/x-reorder-id', q.id);
+                e.dataTransfer.effectAllowed = 'move';
+              }}
+              className="cursor-grab text-muted hover:text-ink-0"
+              aria-label="Drag to reorder"
+            >
+              <GripVertical className="h-4 w-4" />
+            </button>
+          ) : null}
+          <div className="flex-1">
+            <p className="text-xs uppercase tracking-wide text-muted">
+              {q.type} · <span className="font-mono">{q.id}</span>
+              {q.type === 'group' && q.repeat ? (
+                <span className="ml-1.5 inline-flex rounded-full bg-accent/10 px-1.5 py-0.5 text-[9px] uppercase tracking-wide text-accent">
+                  repeat
+                </span>
+              ) : null}
+            </p>
+            <p className="text-sm font-medium text-ink-0">{q.label}</p>
+            {q.hint ? <p className="text-xs text-muted">{q.hint}</p> : null}
+          </div>
+          {canEdit ? (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRemove(q.id);
+              }}
+              className="rounded p-1 text-muted hover:bg-surface-2 hover:text-danger"
+              aria-label="Remove question"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          ) : null}
         </div>
-      ) : (
-        <ul className="space-y-2">
-          {form.questions.map((q, i) => (
-            <li key={q.id}>
-              <div
-                className={`relative rounded-md border ${
-                  q.id === selectedId
-                    ? 'border-accent ring-2 ring-accent/30'
-                    : 'border-border'
-                } bg-surface-1 p-3 ${
-                  overIndex === i ? 'border-t-2 border-t-accent' : ''
-                }`}
-                onClick={() => onSelect(q.id)}
-                onDragOver={(e) => {
-                  if (!canEdit) return;
-                  e.preventDefault();
-                  setOverIndex(i);
-                }}
-                onDrop={(e) => {
-                  if (!canEdit) return;
-                  onDropTarget(i, e);
-                }}
-                onDragLeave={() => setOverIndex(null)}
-              >
-                <div className="flex items-start gap-2">
-                  {canEdit ? (
-                    <button
-                      type="button"
-                      draggable
-                      onDragStart={(e) => {
-                        e.dataTransfer.setData('text/x-reorder', String(i));
-                        e.dataTransfer.effectAllowed = 'move';
-                        setDragIndex(i);
-                      }}
-                      onDragEnd={() => {
-                        setDragIndex(null);
-                        setOverIndex(null);
-                      }}
-                      className="cursor-grab text-muted hover:text-ink-0"
-                      aria-label="Drag to reorder"
-                    >
-                      <GripVertical className="h-4 w-4" />
-                    </button>
-                  ) : null}
-                  <div className="flex-1">
-                    <p className="text-xs uppercase tracking-wide text-muted">
-                      {q.type} · <span className="font-mono">{q.id}</span>
-                    </p>
-                    <p className="text-sm font-medium text-ink-0">{q.label}</p>
-                    {q.hint ? (
-                      <p className="text-xs text-muted">{q.hint}</p>
-                    ) : null}
-                  </div>
-                  {canEdit ? (
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onRemove(q.id);
-                      }}
-                      className="rounded p-1 text-muted hover:bg-surface-2 hover:text-danger"
-                      aria-label="Remove question"
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </button>
-                  ) : null}
-                </div>
-              </div>
-            </li>
-          ))}
-        </ul>
-      )}
-    </main>
+
+        {/* Group children rendered inside the row, so dropping on
+            the group adds to its children, not to the parent. */}
+        {q.type === 'group' ? (
+          <div
+            className="mt-3 rounded border border-dashed border-border bg-surface-2/30 p-2"
+            onClick={(e) => e.stopPropagation()}
+            onDragOver={(e) => {
+              if (!canEdit) return;
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            onDrop={(e) => {
+              if (!canEdit) return;
+              e.preventDefault();
+              e.stopPropagation();
+              const newType = e.dataTransfer.getData('text/x-question-type');
+              const sourceId = e.dataTransfer.getData('text/x-reorder-id');
+              if (newType) onAddInto(newType as QuestionType, q.id);
+              else if (sourceId && sourceId !== q.id) {
+                onMove(sourceId, { containerId: q.id, index: q.children.length });
+              }
+            }}
+          >
+            {q.children.length === 0 ? (
+              <p className="px-2 py-3 text-center text-[11px] text-muted">
+                Drop questions here.
+              </p>
+            ) : (
+              <QuestionList
+                list={q.children}
+                containerId={q.id}
+                selectedId={selectedId}
+                canEdit={canEdit}
+                onSelect={onSelect}
+                onRemove={onRemove}
+                onAddInto={onAddInto}
+                onMove={onMove}
+              />
+            )}
+          </div>
+        ) : null}
+      </div>
+    </li>
   );
 }
 
@@ -477,6 +804,7 @@ function Properties({
   onChange,
   onRename,
   onUpdateForm,
+  onOpenImport,
 }: {
   form: FormSchema;
   question: Question | null;
@@ -484,6 +812,7 @@ function Properties({
   onChange: (patch: Partial<Question>) => void;
   onRename: (newId: string) => void;
   onUpdateForm: (patch: Partial<FormSchema>) => void;
+  onOpenImport: () => void;
 }) {
   if (!question) {
     return (
@@ -500,7 +829,17 @@ function Properties({
             className={inputCls}
           />
         </Field>
-        <p className="mt-3 text-[11px] text-muted">
+        {canEdit ? (
+          <button
+            type="button"
+            onClick={onOpenImport}
+            className="mb-3 inline-flex h-8 w-full items-center justify-center gap-1 rounded-md border border-border bg-surface-1 px-2 text-xs font-medium text-ink-1 hover:bg-surface-2"
+          >
+            <Database className="h-3.5 w-3.5" />
+            Import questions from a data layer
+          </button>
+        ) : null}
+        <p className="mt-1 text-[11px] text-muted">
           Select a question on the left to edit it.
         </p>
       </aside>
@@ -552,7 +891,6 @@ function Properties({
         <span>Required</span>
       </label>
 
-      {/* Type-specific bits */}
       {question.type === 'select-one' || question.type === 'select-many' ? (
         <ChoicesEditor
           choices={question.choices}
@@ -608,19 +946,122 @@ function Properties({
         </Field>
       ) : null}
 
+      {question.type === 'group' ? (
+        <GroupRepeatEditor
+          q={question}
+          canEdit={canEdit}
+          onChange={(repeat) => onChange({ repeat } as Partial<Question>)}
+        />
+      ) : null}
+
       <details className="mt-3 rounded-md border border-border bg-surface-1 p-2 text-xs">
         <summary className="cursor-pointer text-muted">Conditional logic</summary>
         <div className="mt-2 space-y-2">
           <ExpressionEditor
             label="Visible if"
             value={question.visibleIf}
-            allFields={form.questions.map((q) => ({ id: q.id, label: q.label }))}
+            allFields={collectIdLabelPairs(form)}
             disabled={!canEdit}
             onChange={(visibleIf) => onChange({ visibleIf })}
           />
         </div>
       </details>
     </aside>
+  );
+}
+
+function collectIdLabelPairs(form: FormSchema): Array<{ id: string; label: string }> {
+  const out: Array<{ id: string; label: string }> = [];
+  function walk(qs: Question[]) {
+    for (const q of qs) {
+      out.push({ id: q.id, label: q.label });
+      if (q.type === 'group') walk(q.children);
+    }
+  }
+  walk(form.questions);
+  return out;
+}
+
+function GroupRepeatEditor({
+  q,
+  canEdit,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'group' }>;
+  canEdit: boolean;
+  onChange: (repeat: Extract<Question, { type: 'group' }>['repeat']) => void;
+}) {
+  const enabled = Boolean(q.repeat);
+  return (
+    <div className="mt-2 rounded-md border border-border bg-surface-1 p-2 text-xs">
+      <label className="inline-flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={enabled}
+          disabled={!canEdit}
+          onChange={(e) =>
+            onChange(e.target.checked ? { min: 0, addLabel: 'Add another' } : undefined)
+          }
+        />
+        <span>Repeat (capture multiple instances)</span>
+      </label>
+      {enabled && q.repeat ? (
+        <div className="mt-2 grid grid-cols-2 gap-2">
+          <Field label="Min instances">
+            <input
+              type="number"
+              min={0}
+              value={q.repeat.min ?? ''}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({
+                  ...q.repeat,
+                  min: e.target.value === '' ? undefined : Number(e.target.value),
+                })
+              }
+              className={inputCls}
+            />
+          </Field>
+          <Field label="Max instances">
+            <input
+              type="number"
+              min={0}
+              value={q.repeat.max ?? ''}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({
+                  ...q.repeat,
+                  max: e.target.value === '' ? undefined : Number(e.target.value),
+                })
+              }
+              className={inputCls}
+            />
+          </Field>
+          <div className="col-span-2">
+            <Field label='"Add another" button label'>
+              <input
+                type="text"
+                value={q.repeat.addLabel ?? ''}
+                disabled={!canEdit}
+                placeholder="Add another"
+                onChange={(e) =>
+                  onChange({
+                    ...q.repeat,
+                    addLabel: e.target.value || undefined,
+                  })
+                }
+                className={inputCls}
+              />
+            </Field>
+          </div>
+        </div>
+      ) : (
+        <p className="mt-1 text-[11px] text-muted">
+          Off: questions inside the group capture once. On: respondents can add
+          multiple instances (a "child rows" pattern).
+        </p>
+      )}
+    </div>
   );
 }
 
@@ -735,9 +1176,6 @@ function ExpressionEditor({
   disabled: boolean;
   onChange: (next: Expression | undefined) => void;
 }) {
-  // Phase 1 minimal builder: a single `eq` between a question ref
-  // and a literal. The Expression type already supports the fuller
-  // shape; the builder UI catches up in Phase 2.
   const eq =
     value && value.op === 'eq' && 'ref' in value.left && 'value' in value.right
       ? { ref: value.left.ref, val: value.right.value as string | number | boolean | null }
@@ -788,4 +1226,227 @@ function ExpressionEditor({
       </div>
     </div>
   );
+}
+
+// ---- Layer import dialog ----------------------------------------
+
+interface LayerListItem {
+  id: string;
+  title: string;
+}
+
+function LayerImportDialog({
+  onClose,
+  onApply,
+}: {
+  onClose: () => void;
+  onApply: (qs: Question[]) => void;
+}) {
+  const [layers, setLayers] = useState<LayerListItem[] | null>(null);
+  const [pickedId, setPickedId] = useState<string | null>(null);
+  const [columns, setColumns] = useState<Array<{
+    name: string;
+    type: string;
+    nullable?: boolean;
+  }> | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const res = await fetch(
+          '/api/portal/items?lite=1&type=data_layer',
+        );
+        if (!res.ok) throw new Error(`${res.status}`);
+        const items = (await res.json()) as Array<{ id: string; title: string }>;
+        setLayers(items);
+      } catch (e) {
+        setErr(e instanceof Error ? e.message : 'Could not load layers.');
+      }
+    })();
+  }, []);
+
+  async function loadColumns(layerId: string) {
+    setBusy(true);
+    setErr(null);
+    setColumns(null);
+    try {
+      const res = await fetch(`/api/portal/items/${layerId}`);
+      if (!res.ok) throw new Error(`${res.status}`);
+      const layer = (await res.json()) as {
+        data?: {
+          layers?: Array<{
+            schema?: { columns?: Array<{ name: string; type: string; nullable?: boolean }> };
+          }>;
+          schema?: { columns?: Array<{ name: string; type: string; nullable?: boolean }> };
+        };
+      };
+      const cols =
+        layer.data?.layers?.[0]?.schema?.columns ??
+        layer.data?.schema?.columns ??
+        [];
+      setColumns(cols);
+      setPickedId(layerId);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Could not load layer schema.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function generate() {
+    if (!columns) return;
+    // Skip system columns (created_*, edited_*, geometry-internal,
+    // primary keys) -- the form designer sees them as noise.
+    const skipPrefix = /^_/;
+    const skipExact = new Set([
+      'global_id',
+      'object_id',
+      'objectid',
+      'fid',
+      'gid',
+      'shape',
+      'geom',
+      'geometry',
+    ]);
+    const qs: Question[] = [];
+    for (const col of columns) {
+      if (skipPrefix.test(col.name)) continue;
+      if (skipExact.has(col.name.toLowerCase())) continue;
+      const t = col.type.toLowerCase();
+      const id = col.name;
+      const label = humanise(col.name);
+      const required = col.nullable === false;
+      const base = { id, label, required, bindTo: { column: col.name } };
+      if (/text|varchar|char/.test(t)) {
+        qs.push({ ...base, type: 'text' });
+      } else if (/int|smallint|bigint/.test(t)) {
+        qs.push({ ...base, type: 'integer' });
+      } else if (/numeric|float|double|real|decimal/.test(t)) {
+        qs.push({ ...base, type: 'number' });
+      } else if (/bool/.test(t)) {
+        qs.push({ ...base, type: 'boolean' });
+      } else if (t.includes('time') && t.includes('date')) {
+        qs.push({ ...base, type: 'datetime' });
+      } else if (t.includes('time')) {
+        qs.push({ ...base, type: 'time' });
+      } else if (t.includes('date')) {
+        qs.push({ ...base, type: 'date' });
+      } else if (/point/.test(t)) {
+        qs.push({ ...base, type: 'geopoint', capture: 'auto' });
+      } else if (/line/.test(t)) {
+        qs.push({ ...base, type: 'geotrace' });
+      } else if (/polygon/.test(t)) {
+        qs.push({ ...base, type: 'geoshape' });
+      } else {
+        qs.push({ ...base, type: 'text' });
+      }
+    }
+    onApply(qs);
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-30 flex items-center justify-center bg-black/40 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg rounded-lg border border-border bg-surface-1 shadow-raised"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <h2 className="text-sm font-semibold tracking-tight text-ink-0">
+            Start from a data layer
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 hover:bg-surface-2"
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="space-y-3 px-4 py-3 text-sm">
+          {err ? (
+            <p className="rounded-md border border-danger/40 bg-danger/5 px-2 py-1 text-xs text-danger">
+              {err}
+            </p>
+          ) : null}
+          {!pickedId ? (
+            <div>
+              <p className="mb-2 text-xs text-muted">
+                Pick a data layer; we&apos;ll generate one question per column at the
+                most compatible question type. You can edit before saving.
+              </p>
+              {layers === null ? (
+                <p className="text-xs text-muted">Loading layers...</p>
+              ) : layers.length === 0 ? (
+                <p className="text-xs text-muted">No data layers in this org yet.</p>
+              ) : (
+                <ul className="max-h-72 space-y-1 overflow-y-auto">
+                  {layers.map((l) => (
+                    <li key={l.id}>
+                      <button
+                        type="button"
+                        onClick={() => void loadColumns(l.id)}
+                        disabled={busy}
+                        className="flex w-full items-center justify-between rounded-md border border-border bg-surface-1 px-3 py-2 text-left hover:bg-surface-2 disabled:opacity-50"
+                      >
+                        <span className="truncate">{l.title}</span>
+                        <span className="text-[10px] uppercase tracking-wide text-muted">
+                          data layer
+                        </span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          ) : (
+            <div>
+              <p className="mb-2 text-xs text-muted">
+                Will generate {columns?.length ?? 0} questions:
+              </p>
+              <ul className="max-h-60 space-y-1 overflow-y-auto rounded border border-border bg-surface-2/40 p-2 text-xs">
+                {(columns ?? []).map((c) => (
+                  <li key={c.name} className="flex justify-between">
+                    <span className="font-mono text-ink-1">{c.name}</span>
+                    <span className="text-muted">{c.type}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+        <div className="flex items-center justify-end gap-2 border-t border-border px-4 py-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-8 items-center rounded-md border border-border bg-surface-1 px-3 text-xs font-medium text-ink-1 hover:bg-surface-2"
+          >
+            Cancel
+          </button>
+          {pickedId ? (
+            <button
+              type="button"
+              onClick={generate}
+              disabled={!columns}
+              className="inline-flex h-8 items-center rounded-md bg-accent px-3 text-xs font-medium text-accent-foreground hover:opacity-90 disabled:opacity-50"
+            >
+              Generate questions
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function humanise(name: string): string {
+  return name
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+    .trim();
 }

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -304,13 +304,15 @@ interface GroupQuestion extends QuestionBase {
   /** When `repeat` is set, this is a repeating group: the user
    *  captures multiple instances of the inner questions. The Field
    *  runtime maps repeating groups to a related child layer. */
-  repeat?: {
-    /** Min / max instance count. */
-    min?: number;
-    max?: number;
-    /** UI label per added instance ("Add another inspection"). */
-    addLabel?: string;
-  };
+  repeat?:
+    | {
+        /** Min / max instance count. */
+        min?: number | undefined;
+        max?: number | undefined;
+        /** UI label per added instance ("Add another inspection"). */
+        addLabel?: string | undefined;
+      }
+    | undefined;
   /** Child questions. Pages/groups can nest. */
   children: Question[];
 }


### PR DESCRIPTION
Three designer bugs / gaps reported after Phase 1 testing, plus the "how do I start from a data layer" question that was unanswered.

## What changes

### 1. Groups are now real drop targets

Canvas is now recursive. Each group renders its `children` inside a dashed inner panel that's its own drop target. Drops on the group's interior add to its children; reorder-drops of an existing question into a group's interior move it inside.

### 2. No more double-add

Cause: the inner row's `onDrop` and the parent container's `onDrop` both fired with no propagation stop. Fix: every drop target now `stopPropagation`s, and the canvas no longer has a top-level drop handler. Drops route through per-row "insert before" slots + a trailing slot at the end of each list (so you can append-via-drop).

### 3. Repeats have a UI

The schema already supported `repeat: { min, max, addLabel }` on group questions; the properties panel now surfaces:

- **Repeat (capture multiple instances)** checkbox
- min / max instance count
- "Add another" button label

The canvas tags repeating groups with a small `REPEAT` badge so it's obvious at a glance.

### 4. Start a form from an existing data layer

New entry point on the empty-canvas state AND always available in the form-level properties panel. Opens a picker → lists the org's data layers → fetches the layer's schema → generates one question per column at the most compatible type (text / integer / number / boolean / date / datetime / geopoint / geotrace / geoshape). Each generated question gets `bindTo.column` set so the Field-mode runtime (Phase 1b) can map submissions straight back to the layer.

System columns (`global_id`, `geometry`, `_created_*`, etc.) are skipped.

## Other cleanups

Tree mutations factored into pure helpers (`mapTree`, `updateInTree`, `removeFromTree`, `moveInTree`, `mutateContainer`, `locate`, `isDescendant`) so the same recursion isn't reimplemented across handlers and future work (move-into-page, undo/redo) has clean primitives.

## Quality gate

- `pnpm typecheck` passes
- `pnpm lint` passes (existing import-type warnings only)
- `pnpm test` passes
