### PR TITLE
feat(forms): export / import form designs as portable JSON (#142)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AlignLeft,
   Calculator,
@@ -11,6 +11,7 @@ import {
   Circle,
   Clock,
   Database,
+  Download,
   Eye,
   GripVertical,
   Hash,
@@ -27,6 +28,7 @@ import {
   ToggleLeft,
   Trash2,
   Type,
+  Upload,
   Workflow,
   X,
 } from 'lucide-react';
@@ -35,8 +37,12 @@ import {
   CURRENT_FORM_SCHEMA_VERSION,
   defaultQuestion,
   emptyForm,
+  fromImportEnvelope,
+  parseExportEnvelope,
   QUESTION_TYPES,
+  suggestExportFilename,
   suggestQuestionId,
+  toExportEnvelope,
   uniqueQuestionId,
   type Choice,
   type Expression,
@@ -45,6 +51,7 @@ import {
   type QuestionId,
   type QuestionType,
 } from '@gratis-gis/form-schema';
+import { useConfirm } from '@/components/dialog-provider';
 import { FormRuntime } from '@/components/form-runtime';
 
 interface Props {
@@ -80,6 +87,7 @@ interface Props {
  * automatically.
  */
 export function FormDesigner({ itemId, initial, canEdit }: Props) {
+  const confirmDialog = useConfirm();
   const [form, setForm] = useState<FormSchema>(
     () => initial ?? emptyForm(itemId, 'Untitled form'),
   );
@@ -89,6 +97,7 @@ export function FormDesigner({ itemId, initial, canEdit }: Props) {
   const [savedAt, setSavedAt] = useState<Date | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [importOpen, setImportOpen] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [layerColumns, setLayerColumns] = useState<LayerColumn[] | null>(null);
 
   // Whenever the linked layer changes (initial load + import + unlink),
@@ -191,6 +200,50 @@ export function FormDesigner({ itemId, initial, canEdit }: Props) {
     }
   }
 
+  function exportForm() {
+    const env = toExportEnvelope(form);
+    const blob = new Blob([JSON.stringify(env, null, 2)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = suggestExportFilename(form);
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  async function importFormFile(file: File) {
+    setError(null);
+    let raw: unknown;
+    try {
+      raw = JSON.parse(await file.text());
+    } catch {
+      setError('That file is not valid JSON.');
+      return;
+    }
+    const result = parseExportEnvelope(raw);
+    if ('error' in result) {
+      setError(result.error);
+      return;
+    }
+    // Confirm before clobbering existing work.
+    const hasContent = form.questions.length > 0;
+    if (hasContent) {
+      const ok = await confirmDialog({
+        title: 'Replace this form?',
+        message: `Importing "${result.form.title}" will replace the current form (${form.questions.length} question${form.questions.length === 1 ? '' : 's'}). This can't be undone.`,
+        confirmLabel: 'Replace',
+        variant: 'danger',
+      });
+      if (!ok) return;
+    }
+    setForm(fromImportEnvelope(result, itemId));
+    setSelectedId(null);
+  }
+
   function applyImported(
     qs: Question[],
     layer: { id: string; title: string; layerKey?: string },
@@ -262,6 +315,40 @@ export function FormDesigner({ itemId, initial, canEdit }: Props) {
               Preview
             </button>
           </div>
+          <button
+            type="button"
+            onClick={exportForm}
+            title="Download this form as a portable JSON file"
+            className="inline-flex h-8 items-center gap-1 rounded-md border border-border bg-surface-1 px-2 text-xs font-medium text-ink-1 hover:bg-surface-2"
+          >
+            <Download className="h-3.5 w-3.5" />
+            Export
+          </button>
+          {canEdit ? (
+            <>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                title="Replace this form with one from a .gratisgis-form.json file"
+                className="inline-flex h-8 items-center gap-1 rounded-md border border-border bg-surface-1 px-2 text-xs font-medium text-ink-1 hover:bg-surface-2"
+              >
+                <Upload className="h-3.5 w-3.5" />
+                Import
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="application/json,.json"
+                className="hidden"
+                onChange={(e) => {
+                  const f = e.target.files?.[0];
+                  if (f) void importFormFile(f);
+                  // Reset so picking the same file twice still fires.
+                  e.target.value = '';
+                }}
+              />
+            </>
+          ) : null}
           {canEdit ? (
             <button
               type="button"

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -975,3 +975,177 @@ export function uniqueQuestionId(form: FormSchema, candidate: string): string {
   while (existing.has(`${candidate}_${i}`)) i += 1;
   return `${candidate}_${i}`;
 }
+
+// ---------------------------------------------------------------------------
+// Portable export / import
+// ---------------------------------------------------------------------------
+
+/**
+ * Envelope used for native GratisGIS form export (#142). Wraps a
+ * FormSchema with a small bit of provenance metadata so a future
+ * GratisGIS knows the file came from us, what version, and where
+ * (informational; for cross-portal migration audits).
+ *
+ * `schemaVersion` mirrors the inner FormSchema's so you can pick the
+ * right migrator if we ever bump it without opening the inner schema.
+ */
+export interface FormExportEnvelope {
+  /** Magic header so importers can sniff before parsing further. */
+  kind: 'gratisgis-form';
+  /** The form-schema version the inner form is on. */
+  schemaVersion: FormSchemaVersion;
+  /** ISO timestamp of the export. */
+  exportedAt: string;
+  /** Optional: free-form note about where the form came from. */
+  source?: {
+    /** Human-friendly origin (org name, portal URL). */
+    portal?: string;
+    /** The original form item id at the source portal -- not used
+     *  on import, just for trail-of-breadcrumbs. */
+    formId?: string;
+  };
+  /** The portable form. Local-only fields (linkedLayerId, the
+   *  linkedLayerTitle in meta) are stripped before this is written;
+   *  see `toExportEnvelope`. */
+  form: FormSchema;
+}
+
+/** Magic kind string we sniff for on import. */
+export const FORM_EXPORT_KIND = 'gratisgis-form' as const;
+
+/**
+ * Strip everything that's local to one GratisGIS portal so the file
+ * is portable. We keep:
+ *
+ *   - Form title, description, and the question tree (with bindTo
+ *     metadata: column names are useful even when the layer doesn't
+ *     exist at the destination -- a re-link will line them up by
+ *     name).
+ *   - Question id, label, hint, validation, expressions, choices.
+ *
+ * We strip:
+ *
+ *   - `id` on the FormSchema (this matches the source form item's
+ *     id; the destination's form item has a different id).
+ *   - `linkedLayerId` / `linkedLayerKey` (refer to a remote item).
+ *   - `meta.linkedLayerTitle` (display name of a remote item).
+ *
+ * We do NOT strip per-question `bindTo`. The destination importer
+ * decides whether to clear bindings (if the target layer differs)
+ * or keep them (if a layer with the same column names is being
+ * relinked).
+ */
+export function toExportEnvelope(
+  form: FormSchema,
+  opts: { portal?: string } = {},
+): FormExportEnvelope {
+  const portable: FormSchema = {
+    schemaVersion: form.schemaVersion,
+    id: '', // destination assigns
+    title: form.title,
+    questions: form.questions,
+  };
+  if (form.description !== undefined) portable.description = form.description;
+  if (form.geometryQuestionId !== undefined) {
+    portable.geometryQuestionId = form.geometryQuestionId;
+  }
+  // Drop linkedLayerTitle from meta; keep anything else.
+  if (form.meta) {
+    const { linkedLayerTitle: _drop, ...rest } = form.meta as Record<
+      string,
+      unknown
+    >;
+    void _drop;
+    if (Object.keys(rest).length > 0) portable.meta = rest;
+  }
+  const env: FormExportEnvelope = {
+    kind: FORM_EXPORT_KIND,
+    schemaVersion: form.schemaVersion,
+    exportedAt: new Date().toISOString(),
+    form: portable,
+  };
+  if (opts.portal) {
+    env.source = { portal: opts.portal, formId: form.id };
+  } else if (form.id) {
+    env.source = { formId: form.id };
+  }
+  return env;
+}
+
+/**
+ * Apply a portable envelope onto a destination form. Keeps the
+ * destination's `id` (the local form item id stays the source of
+ * truth), copies title / description / questions / geometry binding
+ * from the import. Does NOT carry the source's `linkedLayerId` (the
+ * remote layer doesn't exist locally; the user re-links explicitly).
+ *
+ * Returns the new FormSchema. Caller drives state.
+ */
+export function fromImportEnvelope(
+  env: FormExportEnvelope,
+  destinationId: string,
+): FormSchema {
+  const next: FormSchema = {
+    schemaVersion: env.form.schemaVersion,
+    id: destinationId,
+    title: env.form.title,
+    questions: env.form.questions,
+  };
+  if (env.form.description !== undefined) next.description = env.form.description;
+  if (env.form.geometryQuestionId !== undefined) {
+    next.geometryQuestionId = env.form.geometryQuestionId;
+  }
+  if (env.form.meta) next.meta = { ...env.form.meta };
+  return next;
+}
+
+/**
+ * Validate that an unknown blob is a well-formed export envelope.
+ * Returns the typed envelope on success or a string error suitable
+ * for showing in a dialog.
+ */
+export function parseExportEnvelope(
+  raw: unknown,
+): FormExportEnvelope | { error: string } {
+  if (!raw || typeof raw !== 'object') {
+    return { error: 'Not a valid form export file (expected JSON object).' };
+  }
+  const r = raw as Record<string, unknown>;
+  if (r.kind !== FORM_EXPORT_KIND) {
+    return {
+      error: `Not a GratisGIS form export. Expected kind="${FORM_EXPORT_KIND}", got "${String(r.kind)}".`,
+    };
+  }
+  if (typeof r.schemaVersion !== 'number') {
+    return { error: 'Export is missing a schemaVersion.' };
+  }
+  if (r.schemaVersion > CURRENT_FORM_SCHEMA_VERSION) {
+    return {
+      error: `This form was exported from a newer GratisGIS (schema v${r.schemaVersion}). Update this portal to import it.`,
+    };
+  }
+  const form = r.form as Record<string, unknown> | undefined;
+  if (!form || typeof form !== 'object') {
+    return { error: 'Export is missing the form payload.' };
+  }
+  if (typeof form.title !== 'string') {
+    return { error: 'Form is missing a title.' };
+  }
+  if (!Array.isArray(form.questions)) {
+    return { error: 'Form is missing the questions array.' };
+  }
+  return raw as FormExportEnvelope;
+}
+
+/**
+ * Suggest a download filename based on the form title.
+ * "Nest Inspections" -> "nest-inspections.gratisgis-form.json"
+ */
+export function suggestExportFilename(form: FormSchema): string {
+  const slug = form.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60) || 'form';
+  return `${slug}.gratisgis-form.json`;
+}


### PR DESCRIPTION
Two buttons in the designer header — **Export** and **Import** — for sharing form designs (not data) between GratisGIS users / portals.

## What changes

- **Export** downloads the current form as `<title>.gratisgis-form.json`. The file is a versioned envelope (`kind: "gratisgis-form"`, `schemaVersion`, `exportedAt`, optional source breadcrumbs) wrapping a portable `FormSchema`. Local-only fields (`id`, `linkedLayerId`, `linkedLayerKey`, `meta.linkedLayerTitle`) are stripped so the file is safe to share. Per-question `bindTo.column` is preserved — a destination form re-linked to a layer with matching column names picks the bindings up automatically.
- **Import** file picker + JSON parse + envelope validation. If the current form has questions, prompts with a styled confirm before clobbering. On success the destination's form item id is preserved; everything else (title, description, questions, geometry binding, meta minus the local linked-layer title) comes from the file.
- Forward-version safety: an export from a newer schema version is refused so a forward-rolled export doesn't silently corrupt an older portal.

## What's still missing

OSS interop with the rest of the field-data-collection world. XForms (XLSForm authoring layer) is the de-facto spec — KoboToolbox, ODK Collect, Enketo, Survey123, SurveyCTO all read it. A round-trip on the common 80% would let users migrate forms in/out of GratisGIS without rebuilding. It's real work (XPath translation, "secondary instances" for choices in XML, appearance taxonomy) — captured as task **#143** for Phase 2.

## How to test

1. Create or open a form. Build something.
2. Hit **Export** — get a `*.gratisgis-form.json` file.
3. Open another (or the same) form, hit **Import**, pick that file. Confirm the replace prompt. The form populates.

## Quality gate

- `pnpm typecheck` passes
- `pnpm lint` passes (existing import-type warnings only)
- `pnpm test` passes
