### PR TITLE
feat(forms): per-question width for side-by-side / grid layout (#144)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -1049,6 +1049,35 @@ function Properties({
         <span>Required</span>
       </label>
 
+      {question.type !== 'page' && question.type !== 'group' ? (
+        <Field label="Width" hint="Width on desktop. Mobile collapses to full.">
+          <select
+            value={question.layout?.width ?? 'full'}
+            disabled={!canEdit}
+            onChange={(e) => {
+              const v = e.target.value as
+                | 'full'
+                | 'half'
+                | 'third'
+                | 'two-thirds'
+                | 'quarter'
+                | 'three-quarters';
+              onChange({
+                layout: v === 'full' ? undefined : { width: v },
+              });
+            }}
+            className={inputCls}
+          >
+            <option value="full">Full</option>
+            <option value="half">1 / 2</option>
+            <option value="third">1 / 3</option>
+            <option value="two-thirds">2 / 3</option>
+            <option value="quarter">1 / 4</option>
+            <option value="three-quarters">3 / 4</option>
+          </select>
+        </Field>
+      ) : null}
+
       {question.type === 'select-one' || question.type === 'select-many' ? (
         <ChoicesEditor
           choices={question.choices}

--- a/apps/portal-web/src/components/form-runtime.tsx
+++ b/apps/portal-web/src/components/form-runtime.tsx
@@ -199,15 +199,31 @@ export function FormRuntime({
           }
         }}
       >
-        {currentPage.questions.map((q) => (
-          <QuestionField
-            key={q.id}
-            q={q}
-            response={response}
-            error={errorByQuestion.get(q.id) ?? null}
-            readOnly={readOnly || isReadOnly(q, response)}
-            onChange={(v) => setValue(q.id, v)}
-          />
+        {/* Sequential questions are packed into rows by their declared
+            width so authors can place "first name | last name" or a
+            three-up grid on a single line. Mobile collapses everything
+            to full-width below 640px (sm: breakpoint) so phone users
+            never operate cramped half-width inputs. */}
+        {packIntoRows(currentPage.questions).map((row, rowIdx) => (
+          <div
+            key={`row-${rowIdx}`}
+            className="flex flex-col gap-5 sm:flex-row sm:flex-wrap sm:gap-4"
+          >
+            {row.map((q) => (
+              <div
+                key={q.id}
+                className={`min-w-0 ${widthToClass(q.layout?.width)}`}
+              >
+                <QuestionField
+                  q={q}
+                  response={response}
+                  error={errorByQuestion.get(q.id) ?? null}
+                  readOnly={readOnly || isReadOnly(q, response)}
+                  onChange={(v) => setValue(q.id, v)}
+                />
+              </div>
+            ))}
+          </div>
         ))}
 
         {submitError ? (
@@ -903,6 +919,79 @@ function isReadOnly(q: Question, response: Response): boolean {
   if (q.readOnly === undefined || q.readOnly === false) return false;
   if (q.readOnly === true) return true;
   return Boolean(evaluate(q.readOnly as Expression, response));
+}
+
+/**
+ * Pack a list of questions into visual rows based on their declared
+ * widths. A `full` (or unspecified) width starts a new row by itself.
+ * Otherwise sequential questions are accumulated until their summed
+ * widths exceed 1, then the row breaks. Note rows are flat -- no
+ * recursive nesting -- so a row never contains a group; groups are
+ * always on their own row at full width.
+ */
+function packIntoRows(qs: Question[]): Question[][] {
+  const rows: Question[][] = [];
+  let current: Question[] = [];
+  let used = 0;
+  function flush() {
+    if (current.length > 0) rows.push(current);
+    current = [];
+    used = 0;
+  }
+  for (const q of qs) {
+    const isStandalone =
+      q.type === 'page' || q.type === 'group' || q.type === 'note';
+    const w = widthFraction(q.layout?.width);
+    if (isStandalone || w === 1) {
+      flush();
+      rows.push([q]);
+      continue;
+    }
+    if (used + w > 1) flush();
+    current.push(q);
+    used += w;
+  }
+  flush();
+  return rows;
+}
+
+function widthFraction(width: string | undefined): number {
+  switch (width) {
+    case 'half':
+      return 1 / 2;
+    case 'third':
+      return 1 / 3;
+    case 'two-thirds':
+      return 2 / 3;
+    case 'quarter':
+      return 1 / 4;
+    case 'three-quarters':
+      return 3 / 4;
+    case 'full':
+    default:
+      return 1;
+  }
+}
+
+function widthToClass(width: string | undefined): string {
+  // Tailwind: mobile collapses to w-full; sm: applies the fractional
+  // basis. We use `basis-` so flexbox does the wrapping inside the
+  // `flex-wrap` parent.
+  switch (width) {
+    case 'half':
+      return 'w-full sm:basis-[calc(50%-0.5rem)]';
+    case 'third':
+      return 'w-full sm:basis-[calc(33.333%-0.667rem)]';
+    case 'two-thirds':
+      return 'w-full sm:basis-[calc(66.666%-0.333rem)]';
+    case 'quarter':
+      return 'w-full sm:basis-[calc(25%-0.75rem)]';
+    case 'three-quarters':
+      return 'w-full sm:basis-[calc(75%-0.25rem)]';
+    case 'full':
+    default:
+      return 'w-full';
+  }
 }
 
 // Re-export for designer / runtime consumers.

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -119,6 +119,28 @@ export interface BindTo {
 // Per-question shapes
 // ---------------------------------------------------------------------------
 
+/**
+ * Per-question layout hint. The runtime uses this to flow questions
+ * side-by-side instead of one-per-row. Sequential questions whose
+ * widths sum to <= 1 sit on the same visual row; the next question
+ * past 1 wraps to a new row. `full` always starts a new row.
+ *
+ * Mobile collapses everything to full-width below ~640px so users
+ * never have to operate cramped half-width inputs on a phone.
+ */
+export type QuestionWidth =
+  | 'full'
+  | 'half'
+  | 'third'
+  | 'two-thirds'
+  | 'quarter'
+  | 'three-quarters';
+
+export interface QuestionLayout {
+  /** Width within the form column. Default: 'full'. */
+  width?: QuestionWidth | undefined;
+}
+
 interface QuestionBase {
   id: QuestionId;
   /** User-facing label. Shown above the input. */
@@ -141,9 +163,22 @@ interface QuestionBase {
   readOnly?: boolean | Expression | undefined;
   /** Layer binding (Field runtime only). */
   bindTo?: BindTo | undefined;
+  /** Per-question layout (width within the form column). */
+  layout?: QuestionLayout | undefined;
   /** Free-form per-question metadata. */
   meta?: Record<string, unknown> | undefined;
 }
+
+/** Numeric fraction (0-1) for a width. Used by the runtime to
+ *  pack questions and by helpers that compute row breaks. */
+export const WIDTH_FRACTION: Record<QuestionWidth, number> = {
+  full: 1,
+  half: 1 / 2,
+  third: 1 / 3,
+  'two-thirds': 2 / 3,
+  quarter: 1 / 4,
+  'three-quarters': 3 / 4,
+};
 
 interface TextQuestion extends QuestionBase {
   type: 'text';


### PR DESCRIPTION
## Summary

Closes #144. The form designer was strictly vertical: every question rendered on its own row, even when two short fields obviously belonged side by side. This adds a per-question width hint so authors can pack a row.

## Schema (`packages/form-schema`)

- `QuestionWidth` string union: `full`, `half`, `third`, `two-thirds`, `quarter`, `three-quarters`.
- `QuestionLayout { width? }` interface; new optional `layout` field on `QuestionBase`.
- `WIDTH_FRACTION` map exports the 0..1 fraction for each width so callers don't have to re-derive it.

The export envelope from #142 picks this up for free; round-trips preserve `layout`.

## Runtime (`form-runtime.tsx`)

- `packIntoRows()` walks each page's questions and groups consecutive fractional widths into a single row. Full widths, groups, page breaks, and notes always start their own row. When the running sum would exceed 1, the row wraps.
- Each row renders as a responsive flex container: column on mobile (`flex-col gap-5`), row-with-wrap on `sm+` (`sm:flex-row sm:flex-wrap sm:gap-4`).
- Cells use `basis-[calc(50%-0.5rem)]`-style classes so the gap is accounted for and two halves sit flush.
- Mobile collapses every cell to `w-full` so phone users never operate cramped half-width inputs.

## Designer (`designer.tsx`)

- Properties panel gains a Width selector (Full / 1/2 / 1/3 / 2/3 / 1/4 / 3/4).
- Selecting Full clears `layout` entirely so the schema stays canonical (no `{ width: 'full' }` noise).
- Pages and groups don't expose the selector; their width is always the column they live in.

## Quality gate

- `pnpm typecheck` clean across all 5 workspaces.
- `pnpm lint` clean.
- `pnpm test` clean.
