### PR TITLE
feat(forms): matrix-single + matrix-multi + palette categories (#145)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -13,6 +13,7 @@ import {
   Database,
   Download,
   Eye,
+  Grid3x3,
   GripVertical,
   Hash,
   ListChecks,
@@ -565,21 +566,53 @@ function isDescendant(node: Question, candidateId: QuestionId): boolean {
 
 // ---- Palette ----------------------------------------------------
 
+type PaletteGroup =
+  | 'text'
+  | 'numeric'
+  | 'choice'
+  | 'matrix'
+  | 'scale'
+  | 'time'
+  | 'media'
+  | 'spatial'
+  | 'logic'
+  | 'layout';
+
 interface PaletteEntry {
   type: QuestionType;
   label: string;
   icon: typeof Type;
-  group: 'basic' | 'choice' | 'time' | 'media' | 'spatial' | 'logic' | 'layout';
+  group: PaletteGroup;
 }
 
+/** Display order + label for each palette group. The list order is
+ *  intentional: text and choice (the bread-and-butter types) come
+ *  first; specialized groups follow. */
+const PALETTE_GROUPS: { id: PaletteGroup; label: string }[] = [
+  { id: 'text', label: 'Text' },
+  { id: 'numeric', label: 'Numeric' },
+  { id: 'choice', label: 'Choice' },
+  { id: 'matrix', label: 'Matrix' },
+  { id: 'scale', label: 'Scale' },
+  { id: 'time', label: 'Date & time' },
+  { id: 'media', label: 'Media' },
+  { id: 'spatial', label: 'Geometry' },
+  { id: 'logic', label: 'Logic' },
+  { id: 'layout', label: 'Layout' },
+];
+
 const PALETTE: PaletteEntry[] = [
-  { type: 'text', label: 'Short text', icon: Type, group: 'basic' },
-  { type: 'multiline', label: 'Long text', icon: AlignLeft, group: 'basic' },
-  { type: 'number', label: 'Number', icon: Hash, group: 'basic' },
-  { type: 'integer', label: 'Whole number', icon: Hash, group: 'basic' },
-  { type: 'boolean', label: 'Yes / No', icon: ToggleLeft, group: 'basic' },
+  { type: 'text', label: 'Short text', icon: Type, group: 'text' },
+  { type: 'multiline', label: 'Long text', icon: AlignLeft, group: 'text' },
+  { type: 'number', label: 'Number', icon: Hash, group: 'numeric' },
+  { type: 'integer', label: 'Whole number', icon: Hash, group: 'numeric' },
+  { type: 'boolean', label: 'Yes / No', icon: ToggleLeft, group: 'choice' },
   { type: 'select-one', label: 'Single choice', icon: Circle, group: 'choice' },
   { type: 'select-many', label: 'Multiple choice', icon: CheckSquare, group: 'choice' },
+  { type: 'matrix-single', label: 'Matrix (single)', icon: Grid3x3, group: 'matrix' },
+  { type: 'matrix-multi', label: 'Matrix (multi)', icon: Grid3x3, group: 'matrix' },
+  { type: 'rating', label: 'Rating', icon: Star, group: 'scale' },
+  { type: 'slider', label: 'Slider', icon: Sliders, group: 'scale' },
   { type: 'date', label: 'Date', icon: Calendar, group: 'time' },
   { type: 'time', label: 'Time', icon: Clock, group: 'time' },
   { type: 'datetime', label: 'Date + time', icon: CalendarClock, group: 'time' },
@@ -588,8 +621,6 @@ const PALETTE: PaletteEntry[] = [
   { type: 'geopoint', label: 'Location', icon: MapPin, group: 'spatial' },
   { type: 'geotrace', label: 'Path', icon: SplitSquareHorizontal, group: 'spatial' },
   { type: 'geoshape', label: 'Area', icon: Square, group: 'spatial' },
-  { type: 'rating', label: 'Rating', icon: Star, group: 'basic' },
-  { type: 'slider', label: 'Slider', icon: Sliders, group: 'basic' },
   { type: 'calculated', label: 'Calculated', icon: Calculator, group: 'logic' },
   { type: 'note', label: 'Note', icon: TextIcon, group: 'layout' },
   { type: 'page', label: 'Page break', icon: Workflow, group: 'layout' },
@@ -603,32 +634,54 @@ function Palette({
   canEdit: boolean;
   onAdd: (type: QuestionType) => void;
 }) {
+  // Bucket entries by group, preserving the QUESTION_TYPES order
+  // within each bucket so any new schema type slots in cleanly.
+  const buckets = new Map<PaletteGroup, PaletteEntry[]>();
+  for (const t of QUESTION_TYPES) {
+    const entry = PALETTE.find((e) => e.type === t);
+    if (!entry) continue;
+    const list = buckets.get(entry.group) ?? [];
+    list.push(entry);
+    buckets.set(entry.group, list);
+  }
+
   return (
     <aside className="border-b border-border bg-surface-2/40 p-3 lg:border-b-0 lg:border-r">
       <p className="mb-2 text-[10px] font-medium uppercase tracking-wide text-muted">
         Add a question
       </p>
-      <div className="flex flex-wrap gap-1.5 lg:flex-col">
-        {QUESTION_TYPES.map((t) => {
-          const entry = PALETTE.find((e) => e.type === t);
-          if (!entry) return null;
-          const Icon = entry.icon;
+      <div className="space-y-3">
+        {PALETTE_GROUPS.map((g) => {
+          const entries = buckets.get(g.id);
+          if (!entries || entries.length === 0) return null;
           return (
-            <button
-              type="button"
-              key={t}
-              draggable={canEdit}
-              onDragStart={(e) => {
-                e.dataTransfer.setData('text/x-question-type', t);
-                e.dataTransfer.effectAllowed = 'copy';
-              }}
-              onClick={() => canEdit && onAdd(t)}
-              disabled={!canEdit}
-              className="inline-flex w-full items-center gap-1.5 rounded-md border border-border bg-surface-1 px-2 py-1.5 text-xs text-ink-1 hover:bg-surface-2 disabled:opacity-50"
-            >
-              <Icon className="h-3.5 w-3.5 text-muted" />
-              <span className="truncate text-left">{entry.label}</span>
-            </button>
+            <div key={g.id}>
+              <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted/70">
+                {g.label}
+              </p>
+              <div className="flex flex-wrap gap-1.5 lg:flex-col">
+                {entries.map((entry) => {
+                  const Icon = entry.icon;
+                  return (
+                    <button
+                      type="button"
+                      key={entry.type}
+                      draggable={canEdit}
+                      onDragStart={(e) => {
+                        e.dataTransfer.setData('text/x-question-type', entry.type);
+                        e.dataTransfer.effectAllowed = 'copy';
+                      }}
+                      onClick={() => canEdit && onAdd(entry.type)}
+                      disabled={!canEdit}
+                      className="inline-flex w-full items-center gap-1.5 rounded-md border border-border bg-surface-1 px-2 py-1.5 text-xs text-ink-1 hover:bg-surface-2 disabled:opacity-50"
+                    >
+                      <Icon className="h-3.5 w-3.5 text-muted" />
+                      <span className="truncate text-left">{entry.label}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
           );
         })}
       </div>
@@ -1086,6 +1139,64 @@ function Properties({
         />
       ) : null}
 
+      {question.type === 'matrix-single' || question.type === 'matrix-multi' ? (
+        <MatrixEditor
+          rows={question.rows}
+          columns={question.columns}
+          canEdit={canEdit}
+          onChange={(patch) => onChange(patch as Partial<Question>)}
+        />
+      ) : null}
+
+      {question.type === 'matrix-single' ? (
+        <label className="mb-2 inline-flex items-center gap-2 text-xs">
+          <input
+            type="checkbox"
+            checked={Boolean(question.perRowRequired)}
+            disabled={!canEdit}
+            onChange={(e) =>
+              onChange({ perRowRequired: e.target.checked } as Partial<Question>)
+            }
+          />
+          <span>Require an answer for every row</span>
+        </label>
+      ) : null}
+
+      {question.type === 'matrix-multi' ? (
+        <div className="mb-2 grid grid-cols-2 gap-2">
+          <Field label="Min per row">
+            <input
+              type="number"
+              min={0}
+              value={question.perRowMinSelected ?? ''}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({
+                  perRowMinSelected:
+                    e.target.value === '' ? undefined : Number(e.target.value),
+                } as Partial<Question>)
+              }
+              className={inputCls}
+            />
+          </Field>
+          <Field label="Max per row">
+            <input
+              type="number"
+              min={0}
+              value={question.perRowMaxSelected ?? ''}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({
+                  perRowMaxSelected:
+                    e.target.value === '' ? undefined : Number(e.target.value),
+                } as Partial<Question>)
+              }
+              className={inputCls}
+            />
+          </Field>
+        </div>
+      ) : null}
+
       {question.type === 'number' || question.type === 'integer' ? (
         <div className="grid grid-cols-2 gap-2">
           <Field label="Min">
@@ -1345,6 +1456,170 @@ function ChoicesEditor({
             Add choice
           </button>
         ) : null}
+      </div>
+    </div>
+  );
+}
+
+function MatrixEditor({
+  rows,
+  columns,
+  canEdit,
+  onChange,
+}: {
+  rows: { id: string; label: string }[];
+  columns: { value: string; label: string }[];
+  canEdit: boolean;
+  onChange: (
+    patch: { rows?: typeof rows; columns?: typeof columns },
+  ) => void;
+}) {
+  return (
+    <div className="mb-3 space-y-3">
+      <div>
+        <p className="mb-1 text-[10px] uppercase tracking-wide text-muted">
+          Rows
+        </p>
+        <div className="space-y-1">
+          {rows.map((r, i) => (
+            <div key={i} className="flex items-center gap-1">
+              <input
+                type="text"
+                value={r.id}
+                placeholder="row id"
+                disabled={!canEdit}
+                onChange={(e) =>
+                  onChange({
+                    rows: rows.map((rr, ii) =>
+                      ii === i ? { ...rr, id: e.target.value } : rr,
+                    ),
+                  })
+                }
+                className={`${inputCls} font-mono w-20`}
+              />
+              <input
+                type="text"
+                value={r.label}
+                placeholder="row label"
+                disabled={!canEdit}
+                onChange={(e) =>
+                  onChange({
+                    rows: rows.map((rr, ii) =>
+                      ii === i ? { ...rr, label: e.target.value } : rr,
+                    ),
+                  })
+                }
+                className={`${inputCls} flex-1`}
+              />
+              {canEdit ? (
+                <button
+                  type="button"
+                  onClick={() =>
+                    onChange({ rows: rows.filter((_, ii) => ii !== i) })
+                  }
+                  className="rounded p-1 text-muted hover:bg-surface-2 hover:text-danger"
+                  aria-label="Remove row"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </button>
+              ) : null}
+            </div>
+          ))}
+          {canEdit ? (
+            <button
+              type="button"
+              onClick={() =>
+                onChange({
+                  rows: [
+                    ...rows,
+                    {
+                      id: `row_${rows.length + 1}`,
+                      label: `Statement ${rows.length + 1}`,
+                    },
+                  ],
+                })
+              }
+              className="inline-flex h-7 items-center gap-1 rounded-md border border-dashed border-border bg-surface-1 px-2 text-[11px] text-ink-1 hover:bg-surface-2"
+            >
+              <Plus className="h-3 w-3" />
+              Add row
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div>
+        <p className="mb-1 text-[10px] uppercase tracking-wide text-muted">
+          Columns
+        </p>
+        <div className="space-y-1">
+          {columns.map((c, i) => (
+            <div key={i} className="flex items-center gap-1">
+              <input
+                type="text"
+                value={c.value}
+                placeholder="value"
+                disabled={!canEdit}
+                onChange={(e) =>
+                  onChange({
+                    columns: columns.map((cc, ii) =>
+                      ii === i ? { ...cc, value: e.target.value } : cc,
+                    ),
+                  })
+                }
+                className={`${inputCls} font-mono w-20`}
+              />
+              <input
+                type="text"
+                value={c.label}
+                placeholder="label"
+                disabled={!canEdit}
+                onChange={(e) =>
+                  onChange({
+                    columns: columns.map((cc, ii) =>
+                      ii === i ? { ...cc, label: e.target.value } : cc,
+                    ),
+                  })
+                }
+                className={`${inputCls} flex-1`}
+              />
+              {canEdit ? (
+                <button
+                  type="button"
+                  onClick={() =>
+                    onChange({
+                      columns: columns.filter((_, ii) => ii !== i),
+                    })
+                  }
+                  className="rounded p-1 text-muted hover:bg-surface-2 hover:text-danger"
+                  aria-label="Remove column"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </button>
+              ) : null}
+            </div>
+          ))}
+          {canEdit ? (
+            <button
+              type="button"
+              onClick={() =>
+                onChange({
+                  columns: [
+                    ...columns,
+                    {
+                      value: `option_${columns.length + 1}`,
+                      label: `Option ${columns.length + 1}`,
+                    },
+                  ],
+                })
+              }
+              className="inline-flex h-7 items-center gap-1 rounded-md border border-dashed border-border bg-surface-1 px-2 text-[11px] text-ink-1 hover:bg-surface-2"
+            >
+              <Plus className="h-3 w-3" />
+              Add column
+            </button>
+          ) : null}
+        </div>
       </div>
     </div>
   );

--- a/apps/portal-web/src/components/form-runtime.tsx
+++ b/apps/portal-web/src/components/form-runtime.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 import {
   Camera,
   Check,
@@ -608,6 +608,24 @@ function Input({
         </div>
       );
     }
+    case 'matrix-single':
+      return (
+        <MatrixSingleInput
+          q={q}
+          value={value}
+          readOnly={readOnly}
+          onChange={onChange}
+        />
+      );
+    case 'matrix-multi':
+      return (
+        <MatrixMultiInput
+          q={q}
+          value={value}
+          readOnly={readOnly}
+          onChange={onChange}
+        />
+      );
     case 'date':
       return (
         <input
@@ -874,6 +892,276 @@ function GeoPointInput({
   );
 }
 
+/**
+ * Matrix (single choice per row). On desktop renders as a CSS grid
+ * with column headers across the top and row labels down the left.
+ * On mobile (< sm breakpoint) collapses to a stack: each row shows
+ * its label, then the choices below as full-width radio buttons --
+ * cramped grid cells are unusable on a phone.
+ */
+function MatrixSingleInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'matrix-single' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  const map: Record<string, string> =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, string>)
+      : {};
+
+  function set(rowId: string, col: string | null) {
+    const next = { ...map };
+    if (col === null) delete next[rowId];
+    else next[rowId] = col;
+    onChange(next);
+  }
+
+  return (
+    <div>
+      {/* Desktop: grid */}
+      <div className="hidden sm:block">
+        <div
+          className="grid items-center gap-x-2 gap-y-1 overflow-x-auto rounded-md border border-border bg-surface-1 p-2 text-sm"
+          style={{
+            gridTemplateColumns: `minmax(8rem, 1.4fr) repeat(${q.columns.length}, minmax(5rem, 1fr))`,
+          }}
+        >
+          <div />
+          {q.columns.map((c) => (
+            <div
+              key={c.value}
+              className="px-1 text-center text-[11px] font-medium text-muted"
+            >
+              {c.label}
+            </div>
+          ))}
+          {q.rows.map((row, idx) => (
+            <MatrixSingleRow
+              key={row.id}
+              row={row}
+              columns={q.columns}
+              selected={map[row.id] ?? null}
+              odd={idx % 2 === 1}
+              readOnly={readOnly}
+              onChange={(col) => set(row.id, col)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Mobile: stacked rows */}
+      <div className="space-y-3 sm:hidden">
+        {q.rows.map((row) => (
+          <fieldset key={row.id} className="rounded-md border border-border bg-surface-1 p-2">
+            <legend className="px-1 text-sm font-medium text-ink-1">
+              {row.label}
+            </legend>
+            <div className="mt-1 space-y-1">
+              {q.columns.map((c) => {
+                const selected = map[row.id] === c.value;
+                return (
+                  <label
+                    key={c.value}
+                    className={`flex h-10 items-center gap-2 rounded-md border px-3 text-sm ${
+                      selected
+                        ? 'border-accent bg-accent/5'
+                        : 'border-border bg-surface-1'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name={`${q.id}__${row.id}`}
+                      value={c.value}
+                      checked={selected}
+                      disabled={readOnly}
+                      onChange={() => set(row.id, c.value)}
+                    />
+                    <span>{c.label}</span>
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MatrixSingleRow({
+  row,
+  columns,
+  selected,
+  odd,
+  readOnly,
+  onChange,
+}: {
+  row: { id: string; label: string };
+  columns: { value: string; label: string }[];
+  selected: string | null;
+  odd: boolean;
+  readOnly: boolean;
+  onChange: (col: string) => void;
+}) {
+  return (
+    <>
+      <div
+        className={`px-2 py-2 text-sm text-ink-1 ${odd ? 'bg-surface-2/40' : ''}`}
+      >
+        {row.label}
+      </div>
+      {columns.map((c) => (
+        <div
+          key={c.value}
+          className={`flex items-center justify-center py-2 ${odd ? 'bg-surface-2/40' : ''}`}
+        >
+          <input
+            type="radio"
+            name={`__matrix_${row.id}`}
+            value={c.value}
+            checked={selected === c.value}
+            disabled={readOnly}
+            onChange={() => onChange(c.value)}
+            aria-label={c.label}
+          />
+        </div>
+      ))}
+    </>
+  );
+}
+
+/**
+ * Matrix (multi choice per row). Same layout as MatrixSingleInput
+ * but each cell is a checkbox and the per-row response is an array.
+ */
+function MatrixMultiInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'matrix-multi' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  const map: Record<string, string[]> =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, string[]>)
+      : {};
+
+  function toggle(rowId: string, col: string) {
+    const raw = map[rowId];
+    const arr: string[] = Array.isArray(raw) ? raw : [];
+    const next = arr.includes(col)
+      ? arr.filter((v) => v !== col)
+      : [...arr, col];
+    const out = { ...map };
+    if (next.length === 0) delete out[rowId];
+    else out[rowId] = next;
+    onChange(out);
+  }
+
+  return (
+    <div>
+      {/* Desktop: grid */}
+      <div className="hidden sm:block">
+        <div
+          className="grid items-center gap-x-2 gap-y-1 overflow-x-auto rounded-md border border-border bg-surface-1 p-2 text-sm"
+          style={{
+            gridTemplateColumns: `minmax(8rem, 1.4fr) repeat(${q.columns.length}, minmax(5rem, 1fr))`,
+          }}
+        >
+          <div />
+          {q.columns.map((c) => (
+            <div
+              key={c.value}
+              className="px-1 text-center text-[11px] font-medium text-muted"
+            >
+              {c.label}
+            </div>
+          ))}
+          {q.rows.map((row, idx) => {
+            const odd = idx % 2 === 1;
+            const raw = map[row.id];
+            const arr: string[] = Array.isArray(raw) ? raw : [];
+            return (
+              <Fragment key={row.id}>
+                <div
+                  className={`px-2 py-2 text-sm text-ink-1 ${odd ? 'bg-surface-2/40' : ''}`}
+                >
+                  {row.label}
+                </div>
+                {q.columns.map((c) => (
+                  <div
+                    key={c.value}
+                    className={`flex items-center justify-center py-2 ${odd ? 'bg-surface-2/40' : ''}`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={arr.includes(c.value)}
+                      disabled={readOnly}
+                      onChange={() => toggle(row.id, c.value)}
+                      aria-label={`${row.label}: ${c.label}`}
+                    />
+                  </div>
+                ))}
+              </Fragment>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Mobile: stacked rows */}
+      <div className="space-y-3 sm:hidden">
+        {q.rows.map((row) => {
+          const raw = map[row.id];
+          const arr: string[] = Array.isArray(raw) ? raw : [];
+          return (
+            <fieldset
+              key={row.id}
+              className="rounded-md border border-border bg-surface-1 p-2"
+            >
+              <legend className="px-1 text-sm font-medium text-ink-1">
+                {row.label}
+              </legend>
+              <div className="mt-1 space-y-1">
+                {q.columns.map((c) => {
+                  const checked = arr.includes(c.value);
+                  return (
+                    <label
+                      key={c.value}
+                      className={`flex h-10 items-center gap-2 rounded-md border px-3 text-sm ${
+                        checked
+                          ? 'border-accent bg-accent/5'
+                          : 'border-border bg-surface-1'
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        disabled={readOnly}
+                        onChange={() => toggle(row.id, c.value)}
+                      />
+                      <span>{c.label}</span>
+                    </label>
+                  );
+                })}
+              </div>
+            </fieldset>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 // ---- helpers ----------------------------------------------------
 
 function fileToDataUrl(file: File): Promise<string> {
@@ -940,7 +1228,11 @@ function packIntoRows(qs: Question[]): Question[][] {
   }
   for (const q of qs) {
     const isStandalone =
-      q.type === 'page' || q.type === 'group' || q.type === 'note';
+      q.type === 'page' ||
+      q.type === 'group' ||
+      q.type === 'note' ||
+      q.type === 'matrix-single' ||
+      q.type === 'matrix-multi';
     const w = widthFraction(q.layout?.width);
     if (isStandalone || w === 1) {
       flush();

--- a/docs/forms-question-types.md
+++ b/docs/forms-question-types.md
@@ -1,0 +1,379 @@
+# Form question types
+
+## Why this exists
+
+The form designer ships with 21 question types today. That covers the
+basics for field data collection but leaves us short of what a respondent
+expects from a paid survey product. The most visible gap is the matrix
+question (a grid of rows-by-columns, one or many choices per row), which
+is table stakes on every general-purpose survey platform and is the kind
+of question the respondent sees on the very first survey they take.
+
+This doc surveys what the leading paid products offer, marks where we
+are vs. where we want to be, and proposes a phased plan to land the rest
+without thrashing the schema. The intent is not to ship every type below;
+it is to know, when a customer says "we use matrix questions in our
+audit form," that we have a clear answer for them.
+
+## Source comparison
+
+The ten products we benchmark against, grouped by their natural audience:
+
+  - General survey: Typeform, SurveyMonkey, Qualtrics, Google Forms,
+    Microsoft Forms
+  - Forms with workflow: Jotform, Formstack
+  - Open / GIS-adjacent: KoBoToolbox (ODK), Survey123 (Esri)
+
+Qualtrics is the gold standard for question type breadth. Typeform is
+the leader on per-question UX polish. SurveyMonkey is the volume
+leader. Survey123 and KoBo are the closest analogs to what GratisGIS
+needs because they share the geometry, offline, and Field-mode story.
+
+## What we have today (schema v1)
+
+Twenty-one types in `packages/form-schema/src/index.ts`:
+
+  - Text: `text`, `multiline`
+  - Numeric: `number`, `integer`
+  - Boolean: `boolean`
+  - Choice: `select-one` (radio or dropdown), `select-many`
+  - Date / time: `date`, `time`, `datetime`
+  - Capture: `photo`, `signature`
+  - Geometry: `geopoint`, `geotrace`, `geoshape`
+  - Scales: `rating` (1-N stars), `slider`
+  - Computation: `calculated`
+  - Layout: `note`, `page`, `group` (with optional repeat)
+
+Strengths: the JSON-only expression DSL, the `bindTo` link to data
+layer columns, and the offline outbox give us a foundation that the
+paid products generally do not have a direct equivalent for. The
+geometry types and the repeating-group-as-related-table mapping are
+ahead of every general-purpose survey product.
+
+Gaps: no matrix family at all, no native ranking, no specialized text
+types (email, URL, phone), no identity components (full-name parts,
+address parts), no audio/video capture, no barcode scan, no NPS or
+Likert as first-class, no image-choice. Those last two together are
+what makes a survey feel "professional" out of the box.
+
+## Comparison matrix
+
+The presence-check below uses these glyphs:
+
+  - "yes" the product ships this as a first-class question type
+  - "lib" the product treats it as a library / form template, not a
+    distinct question type, but the user can build it
+  - no entry: not natively supported
+
+|                              | Typeform | SurveyMonkey | Qualtrics | Google Forms | MS Forms | Jotform | Formstack | KoBo | Survey123 | GratisGIS |
+| ---------------------------- | :------: | :----------: | :-------: | :----------: | :------: | :-----: | :-------: | :--: | :-------: | :-------: |
+| Short text                   |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    |    yes    |
+| Long text                    |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    |    yes    |
+| Email                        |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    |      |    yes    |           |
+| URL                          |   yes    |     yes      |    yes    |              |          |   yes   |    yes    |      |    yes    |           |
+| Phone                        |   yes    |     yes      |    yes    |              |          |   yes   |    yes    |      |    yes    |           |
+| Number                       |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    |    yes    |
+| Integer                      |          |              |    yes    |              |          |         |           | yes  |    yes    |    yes    |
+| Currency                     |   yes    |     yes      |    yes    |              |          |   yes   |    yes    |      |    yes    | (number)  |
+| Percentage                   |          |     yes      |    yes    |              |          |         |           |      |           |           |
+| Yes / No                     |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    |    yes    |
+| Single choice (radio)        |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    |    yes    |
+| Multiple choice              |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    |    yes    |
+| Dropdown                     |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    | (select)  |
+| Image choice                 |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |           | yes  |           |           |
+| Ranking (drag to reorder)    |   yes    |     yes      |    yes    |              |   yes    |   yes   |    yes    |      |    yes    |           |
+| Likert                       |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    | (rating)  |
+| Net Promoter Score (NPS)     |   yes    |     yes      |    yes    |              |   yes    |   yes   |           |      |    yes    |           |
+| Slider                       |   yes    |     yes      |    yes    |     yes      |          |   yes   |    yes    | yes  |    yes    |    yes    |
+| Star rating                  |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    |    yes    |
+| Semantic differential        |          |     yes      |    yes    |              |          |         |           |      |           |           |
+| Matrix single (radio grid)   |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    |           |
+| Matrix multi (checkbox grid) |   yes    |     yes      |    yes    |              |   yes    |   yes   |    yes    | yes  |    yes    |           |
+| Matrix dropdown              |          |     yes      |    yes    |              |          |   yes   |    yes    | yes  |    yes    |           |
+| Matrix ranking               |          |     yes      |    yes    |              |          |   yes   |    yes    |      |           |           |
+| Side-by-side matrix          |          |     yes      |    yes    |              |          |         |           |      |           |           |
+| Constant sum                 |          |     yes      |    yes    |              |          |         |           |      |           |           |
+| Heat map / hotspot           |          |     yes      |    yes    |              |          |   yes   |           |      |           |           |
+| Date                         |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    |    yes    |
+| Time                         |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    |    yes    |
+| Date + time                  |          |     yes      |    yes    |              |   yes    |   yes   |    yes    | yes  |    yes    |    yes    |
+| Date range                   |          |     yes      |    yes    |              |          |   yes   |    yes    |      |           |           |
+| Duration                     |          |              |    yes    |              |          |         |           | yes  |           |           |
+| Full name (multipart)        |   yes    |     yes      |    yes    |              |          |   yes   |    yes    |      |           |           |
+| Full address (multipart)     |   yes    |     yes      |    yes    |              |          |   yes   |    yes    |      |    yes    |           |
+| Photo                        |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    |    yes    |
+| Audio capture                |          |              |    yes    |              |          |   yes   |           | yes  |           |           |
+| Video capture                |          |              |    yes    |              |          |   yes   |           | yes  |           |           |
+| Generic file upload          |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    | (photo)   |
+| Drawing / sketch             |          |              |    yes    |              |          |   yes   |    yes    |      |           |           |
+| Signature                    |   yes    |     yes      |    yes    |              |          |   yes   |    yes    |      |    yes    |    yes    |
+| Barcode / QR                 |          |              |           |              |          |         |           | yes  |    yes    |           |
+| Geopoint                     |          |              |           |              |          |         |           | yes  |    yes    |    yes    |
+| Geotrace (line)              |          |              |           |              |          |         |           | yes  |    yes    |    yes    |
+| Geoshape (polygon)           |          |              |           |              |          |         |           | yes  |    yes    |    yes    |
+| Pick from map / feature      |          |              |           |              |          |         |           |      |    yes    |           |
+| Calculated                   |          |     yes      |    yes    |              |          |   yes   |    yes    | yes  |    yes    |    yes    |
+| Hidden / pre-fill            |          |     yes      |    yes    |              |          |   yes   |    yes    | yes  |    yes    |           |
+| Acknowledge / consent        |          |              |    yes    |              |          |   yes   |    yes    | yes  |    yes    |           |
+| Color picker                 |          |              |           |              |          |   yes   |           |      |           |           |
+| CAPTCHA                      |          |              |           |              |          |   yes   |    yes    |      |           |           |
+| Page break                   |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    |    yes    |
+| Section header / image       |   yes    |     yes      |    yes    |     yes      |   yes    |   yes   |    yes    | yes  |    yes    |  (note)   |
+| Repeating group              |          |              |   (lib)   |              |          |  (lib)  |   (lib)   | yes  |    yes    |    yes    |
+
+The matrix family alone is six rows we are zero-for. That is the
+single biggest credibility gap if a customer is comparing GratisGIS
+side by side with a paid product.
+
+## Proposed additions, by phase
+
+The phases are sized so each one is a self-contained PR or two and
+respects the schema's invariants (JSON-only, no eval, runtime parity
+between server and browser).
+
+### Phase 2a: Matrix family (the headline)
+
+This is the biggest visible win and the closest thing to "you can't
+take us seriously without this."
+
+  1. `matrix-single` — rows of statements, columns of choices, one
+     radio per row. The screenshot you pasted is exactly this.
+  2. `matrix-multi` — same layout, checkboxes per row, multiple
+     choices allowed.
+  3. `matrix-dropdown` — same layout, but each cell is a per-row
+     dropdown. Useful when columns are not parallel categories
+     (e.g. a "current value" column and a "target value" column).
+  4. `matrix-rating` — same layout, each cell is a star or numeric
+     rating. Quick way to score a list of items on the same scale.
+
+Schema sketch:
+
+```ts
+interface MatrixSingleQuestion extends QuestionBase {
+  type: 'matrix-single';
+  rows: { id: string; label: string }[];
+  columns: { value: string; label: string }[];
+  /** When set, the row source is dynamic (pick_list of row labels). */
+  rowsPickListId?: string;
+  /** Per-row required override; defaults to question-level required. */
+  perRowRequired?: boolean;
+}
+
+// Response shape:  { [rowId]: 'columnValue' }
+```
+
+`matrix-multi` mirrors this with `Record<rowId, string[]>`.
+`matrix-dropdown` lets each column carry its own `choices`.
+`matrix-rating` borrows the existing `rating` config (max + shape).
+
+Mobile: every matrix collapses to a stack of "row label, then the
+options as a normal radio/checkbox/rating below it" on narrow
+viewports. The desktop grid is a `display: grid` with `grid-template-columns`.
+
+Layer mapping: a matrix can either flatten to one column per row
+(`audit_q1`, `audit_q2`, ...) when bound to a flat layer, or to a
+related child table when the layer has a `matrix_responses` related
+table. Both are useful; the designer picks.
+
+Validation: row-level required. The constraint expression DSL can
+reference a row by `matrix.rowId.column` paths.
+
+### Phase 2b: Ranking and side-by-side
+
+  5. `ranking` — a list of items the respondent drags into preferred
+     order. Captured as an ordered array of choice values.
+  6. `matrix-rank` — a row-by-column matrix where each cell is a rank
+     dropdown (1, 2, 3...) and each column can be used at most once
+     per row. Less common; punt to 2c if implementation is fiddly.
+  7. `matrix-side-by-side` — two matrices that share the row labels.
+     Useful for "rate importance" + "rate satisfaction" in one block.
+
+### Phase 2c: First-class scales
+
+  8. `likert` — a single-row Likert (Strongly disagree → Strongly
+     agree). Today this is achievable with `select-one` plus careful
+     choice labeling, but having it as a type lets the runtime render
+     the canonical horizontal scale and lets analytics treat it as
+     ordinal. Default 5-point with optional 7-point and "neutral"
+     middle option toggle.
+  9. `nps` — Net Promoter Score, 0-10 buttons with the standard
+     "Detractor / Passive / Promoter" coloring. Captured as integer.
+ 10. `semantic-differential` — bipolar adjective scale ("Cold ←→ Warm")
+     across N points. Less common; safe to defer if Phase 2c is
+     getting heavy.
+
+### Phase 2d: Specialized text
+
+These are all `text` today with a `pattern`, but giving them their
+own type unlocks better mobile keyboards (`inputmode=email/tel/url`),
+better validation messages, and better integration with the
+calculated DSL (a future `is_email(...)` builtin).
+
+ 11. `email` — RFC 5322 lite validation; `inputmode=email`.
+ 12. `url` — must parse as a URL.
+ 13. `phone` — E.164 with country picker; `inputmode=tel`.
+ 14. `regex` — author supplies a custom pattern + error message. We
+     already support `pattern` on `text`; the wrapper makes it more
+     discoverable.
+
+### Phase 2e: Identity components
+
+These are technically composite types, but every general-purpose form
+product treats them as one question because users always need them.
+
+ 15. `name` — first / middle / last / suffix in one block, captured as
+     `{ first, middle?, last, suffix? }`. Required-on-each toggleable.
+ 16. `address` — street1 / street2 / city / region / postal / country
+     in one block, captured as the same shape. The renderer can hide
+     fields per-locale. When `bindTo` points at a layer with discrete
+     address columns we map straight in; otherwise we land on a
+     single `address_json` JSONB column or a denormalized set.
+
+### Phase 2f: Capture (audio, video, drawing, barcode)
+
+ 17. `audio` — capture or upload, stored as `audio/*` attachment.
+ 18. `video` — capture or upload, stored as `video/*` attachment.
+ 19. `drawing` — freehand canvas. The output is an SVG + a PNG raster.
+     Useful on Field forms for damage diagrams over a vehicle
+     silhouette.
+ 20. `file` — generic file upload (today we conflate with `photo`).
+ 21. `barcode` — scans a 1D / 2D code via the device camera. KoBo and
+     Survey123 both support this and it is a real differentiator for
+     field workflows (asset tags, sample IDs).
+
+Capacity, accept-types, and per-file-bytes mirror `photo`.
+
+### Phase 2g: Specialized numeric / time
+
+ 22. `currency` — integer minor units + ISO 4217 code, rendered with
+     locale-correct prefix and grouping. Today `number.currency`
+     papers over this; making it a type catches sloppy bindings.
+ 23. `percentage` — number constrained 0..100 with a `%` suffix.
+ 24. `date-range` — pair of dates with a min-spread / max-spread
+     constraint. Captured as `{ start, end }`.
+ 25. `duration` — hours / minutes captured as a single integer
+     (seconds) for storage, rendered as a friendly hh:mm input.
+
+### Phase 2h: Image-based questions
+
+ 26. `image-choice` — same semantics as `select-one` / `select-many`
+     but each option is an image with a caption. Big mobile UX win.
+ 27. `image-hotspot` — the respondent clicks one or more points on a
+     reference image. Captured as an array of `{ x, y }` (0..1).
+     Common in "where does it hurt?" or "which part of the building?"
+     type forms.
+
+### Phase 2i: Display-only / utility
+
+ 28. `image-display` — embed an image as instructional content (no
+     value captured). Today `note` only handles text.
+ 29. `divider` — a thin separator with optional caption.
+ 30. `acknowledge` — display long-form text with a required checkbox
+     ("I have read and agree"). Captures the timestamp at which the
+     user checked.
+ 31. `hidden` — value source via URL prefill or calculated; never
+     rendered. Useful for campaign IDs, submitter UUIDs, signed
+     tokens.
+ 32. `color` — color picker. Niche but trivial; mention for
+     completeness.
+
+### Phase 2j: GIS-specific extras
+
+These are wins where we will out-feature any general-purpose product.
+
+ 33. `pick-feature` — respondent selects an existing feature from a
+     bound layer (think "select the asset this incident is about").
+     Captures the feature id; the runtime can then auto-fill any
+     question whose `bindTo` references that feature's columns.
+ 34. `route` — between two pinned endpoints, capture a routed path
+     (when a routing service is wired in). Otherwise falls back to
+     `geotrace`.
+ 35. `area-buffer` — captures a center point + radius and stores the
+     resulting circle as a polygon. Easier on field users than
+     drawing a freehand polygon.
+
+## Implementation considerations
+
+**Wire format.** Every new type ships with three things: the schema
+shape (above), a Postgres column-type mapping (`compatibleQuestionTypes`
+for the Field runtime), and a JSON value shape for `Response[questionId]`.
+The matrix family is the riskiest because the natural Response shape is
+nested. We absorb that with `Record<rowId, value>` and treat each row
+as a logical sub-question for the constraint DSL.
+
+**Schema versioning.** Any change to a question's persisted shape bumps
+`CURRENT_FORM_SCHEMA_VERSION`. Adding new question types in
+`QUESTION_TYPES` is technically additive and could stay on v1, but I
+would rather bump to v2 once we have the matrix family + identity
+components landed and write a one-shot migrator that is ready for
+when we add anything genuinely breaking.
+
+**Expression DSL impact.** New `BUILTINS` we will want:
+
+  - `is_email`, `is_url`, `is_phone`
+  - `length` (alias of `len`)
+  - `now_minus(days)`, `today_minus(days)` (date math)
+  - `matrix_count_selected(refToMatrix)` (for cross-row required-if)
+  - `pick_field(refToFeature, 'columnName')` (for `pick-feature`
+    auto-fill)
+
+These ship in both browser and server. Add them in the same PR that
+adds the question type that needs them.
+
+**Mobile + offline.** Every new type must render reasonably on a 320
+px-wide viewport and persist to the IndexedDB outbox without extra
+plumbing. The matrix collapse-to-stack rule, the `image-hotspot`
+zoom-to-fit, and `audio/video` blob handling are the three that need
+explicit attention.
+
+**Export envelope.** The portable JSON envelope from #142 is structural,
+not exhaustive. Every new question type rides through it for free as
+long as the type discriminator is in `QUESTION_TYPES`. A future
+GratisGIS that does not know about a newer type should refuse the
+import with a clear error rather than silently dropping questions; we
+already do this on schema-version mismatch.
+
+**Designer palette.** With ~50 types post-Phase-2 the flat palette
+becomes unusable. Group the palette into the categories above (Text,
+Choice, Matrix, Scale, Date / time, Capture, Identity, Geometry,
+Display, Advanced) and add a search box.
+
+## Suggested rollout order
+
+  - Slice 1 (1 PR): `matrix-single` and `matrix-multi`. The headline
+    asks. Start the palette categorization at the same time so the
+    new types have a home.
+  - Slice 2 (1 PR): `ranking`, `matrix-dropdown`, `matrix-rating`.
+    Same row-by-column rendering machinery.
+  - Slice 3 (1 PR): `email`, `url`, `phone`, `regex`. Trivial but
+    very visible.
+  - Slice 4 (1 PR): `likert`, `nps`. Adds first-class scale UX without
+    changing the response shape much.
+  - Slice 5 (1 PR): `name`, `address`. Composite types; introduces the
+    pattern we will reuse for `date-range`.
+  - Slice 6 (1 PR): `image-choice`, `image-hotspot`, `image-display`.
+    Image asset handling shared.
+  - Slice 7 (1 PR): `audio`, `video`, `barcode`, `file`, `drawing`.
+    Capture types share the attachment plumbing.
+  - Slice 8 (1 PR): `acknowledge`, `hidden`, `divider`, `consent`.
+    Utility types.
+  - Slice 9 (1 PR): `pick-feature`, `area-buffer`, `route`. GIS-only,
+    differentiator.
+  - Slice 10 (1 PR): designer palette polish + search + categories.
+
+That puts the matrix family in front of users in the first PR, which
+is the right priority given the visible gap.
+
+## Open questions
+
+  - Do we want a "form template gallery" (NPS template, employee
+    feedback template, audit checklist) the way SurveyMonkey does?
+    Probably yes once the catalog is broad enough that "build it
+    from scratch" is more work than "tweak a template."
+  - Where do AI question authoring + AI answer summarization land
+    relative to question-type breadth? My instinct: question types
+    first (table stakes), then the AI on top of a richer schema.
+  - For matrix questions specifically, do we want to support the
+    Qualtrics "carry forward" pattern (rows of matrix B come from
+    selected choices in select-many A)? That is a deep rabbit hole;
+    not for the first slice.

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -57,6 +57,8 @@ export const QUESTION_TYPES = [
   'boolean', // yes/no toggle
   'select-one', // radio buttons or dropdown (controlled by `appearance`)
   'select-many', // checkboxes
+  'matrix-single', // grid: rows of statements, one choice per row
+  'matrix-multi', // grid: rows of statements, multi choice per row
   'date', // calendar date
   'time', // wall-clock time
   'datetime', // calendar + clock
@@ -246,6 +248,64 @@ interface SelectManyQuestion extends QuestionBase {
   pickListId?: string;
 }
 
+/**
+ * A row in a matrix question. Rows are stable: the row `id` is the
+ * key used in the Response, so renaming a row label is safe but
+ * deleting and re-adding a row loses any captured value.
+ */
+export interface MatrixRow {
+  id: string;
+  label: string;
+}
+
+/**
+ * A column in a matrix question. For `matrix-single` and `matrix-multi`
+ * every column shares the same set of choices (the columns ARE the
+ * choices). The `value` is what's stored in the Response.
+ */
+export interface MatrixColumn {
+  value: string;
+  label: string;
+}
+
+/**
+ * Matrix with one selectable column per row (radio grid).
+ *
+ * Response shape: `Record<rowId, columnValue | null>` -- a flat object
+ * keyed by row id, with the chosen column's `value` as the value.
+ * Rows the respondent never touched are simply absent.
+ */
+interface MatrixSingleQuestion extends QuestionBase {
+  type: 'matrix-single';
+  rows: MatrixRow[];
+  columns: MatrixColumn[];
+  /** When set, rows are sourced from a pick list at runtime; the
+   *  inline `rows` may still be used as a designer-time preview. */
+  rowsPickListId?: string;
+  /** When true, every row counts toward `required`. When false (the
+   *  default), the question's `required` flag means "at least one
+   *  row has a value". */
+  perRowRequired?: boolean;
+}
+
+/**
+ * Matrix with one or many selectable columns per row (checkbox grid).
+ *
+ * Response shape: `Record<rowId, columnValue[]>` -- a flat object
+ * keyed by row id, with the array of chosen column values. Rows the
+ * respondent never touched are absent.
+ */
+interface MatrixMultiQuestion extends QuestionBase {
+  type: 'matrix-multi';
+  rows: MatrixRow[];
+  columns: MatrixColumn[];
+  rowsPickListId?: string;
+  /** Minimum selected columns per row. */
+  perRowMinSelected?: number;
+  /** Maximum selected columns per row. */
+  perRowMaxSelected?: number;
+}
+
 interface DateQuestion extends QuestionBase {
   type: 'date';
   /** ISO 8601 date or `today`. */
@@ -360,6 +420,8 @@ export type Question =
   | BooleanQuestion
   | SelectOneQuestion
   | SelectManyQuestion
+  | MatrixSingleQuestion
+  | MatrixMultiQuestion
   | DateQuestion
   | TimeQuestion
   | DateTimeQuestion
@@ -715,7 +777,12 @@ export function validate(form: FormSchema, response: Response): ValidationResult
       errors.push({ questionId: q.id, message: 'This field is required.' });
       continue;
     }
-    if (isEmpty(value)) continue; // nothing more to validate when blank + optional
+    // Matrix questions with perRowRequired enforce row-level checks
+    // even when nothing is filled, so we let validateType run.
+    const skipIfEmpty =
+      !(q.type === 'matrix-single' && q.perRowRequired) &&
+      !(q.type === 'matrix-multi' && q.perRowMinSelected);
+    if (isEmpty(value) && skipIfEmpty) continue;
 
     const typeError = validateType(q, value);
     if (typeError) {
@@ -752,6 +819,13 @@ function isEmpty(value: unknown): boolean {
   if (value === null || value === undefined) return true;
   if (typeof value === 'string') return value.trim() === '';
   if (Array.isArray(value)) return value.length === 0;
+  // Plain objects (matrix responses) are empty when no row has any
+  // value. We treat null / '' / [] as "no value" recursively.
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) return true;
+    return entries.every(([, v]) => isEmpty(v));
+  }
   return false;
 }
 
@@ -793,6 +867,62 @@ function validateType(q: Question, value: unknown): string | null {
       }
       if (q.maxSelected !== undefined && value.length > q.maxSelected) {
         return `Pick at most ${q.maxSelected}.`;
+      }
+      return null;
+    }
+    case 'matrix-single': {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return 'Expected one choice per row.';
+      }
+      const map = value as Record<string, unknown>;
+      const validValues = new Set(q.columns.map((c) => c.value));
+      for (const row of q.rows) {
+        const v = map[row.id];
+        if (v === undefined || v === null || v === '') continue;
+        if (typeof v !== 'string' || !validValues.has(v)) {
+          return `Row "${row.label}" has an unrecognized value.`;
+        }
+      }
+      // Per-row required: every row must have a non-empty selection.
+      if (q.perRowRequired) {
+        for (const row of q.rows) {
+          const v = map[row.id];
+          if (v === undefined || v === null || v === '') {
+            return `Row "${row.label}" is required.`;
+          }
+        }
+      }
+      return null;
+    }
+    case 'matrix-multi': {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return 'Expected selections per row.';
+      }
+      const map = value as Record<string, unknown>;
+      const validValues = new Set(q.columns.map((c) => c.value));
+      for (const row of q.rows) {
+        const v = map[row.id];
+        if (v === undefined || v === null) continue;
+        if (!Array.isArray(v)) {
+          return `Row "${row.label}" has an unexpected value.`;
+        }
+        for (const x of v) {
+          if (typeof x !== 'string' || !validValues.has(x)) {
+            return `Row "${row.label}" has an unrecognized value.`;
+          }
+        }
+        if (
+          q.perRowMinSelected !== undefined &&
+          v.length < q.perRowMinSelected
+        ) {
+          return `Row "${row.label}": pick at least ${q.perRowMinSelected}.`;
+        }
+        if (
+          q.perRowMaxSelected !== undefined &&
+          v.length > q.perRowMaxSelected
+        ) {
+          return `Row "${row.label}": pick at most ${q.perRowMaxSelected}.`;
+        }
       }
       return null;
     }
@@ -912,6 +1042,38 @@ export function defaultQuestion(type: QuestionType, id: QuestionId): Question {
           { value: 'option_2', label: 'Option 2' },
         ],
       };
+    case 'matrix-single':
+      return {
+        ...base,
+        type,
+        rows: [
+          { id: 'row_1', label: 'Statement 1' },
+          { id: 'row_2', label: 'Statement 2' },
+          { id: 'row_3', label: 'Statement 3' },
+        ],
+        columns: [
+          { value: 'strongly_disagree', label: 'Strongly disagree' },
+          { value: 'disagree', label: 'Disagree' },
+          { value: 'neutral', label: 'Neutral' },
+          { value: 'agree', label: 'Agree' },
+          { value: 'strongly_agree', label: 'Strongly agree' },
+        ],
+      };
+    case 'matrix-multi':
+      return {
+        ...base,
+        type,
+        rows: [
+          { id: 'row_1', label: 'Item 1' },
+          { id: 'row_2', label: 'Item 2' },
+          { id: 'row_3', label: 'Item 3' },
+        ],
+        columns: [
+          { value: 'option_a', label: 'Option A' },
+          { value: 'option_b', label: 'Option B' },
+          { value: 'option_c', label: 'Option C' },
+        ],
+      };
     case 'date':
       return { ...base, type };
     case 'time':
@@ -960,6 +1122,8 @@ function defaultLabel(type: QuestionType): string {
       boolean: 'Yes / No',
       'select-one': 'Single choice',
       'select-many': 'Multiple choice',
+      'matrix-single': 'Matrix (single)',
+      'matrix-multi': 'Matrix (multi)',
       date: 'Date',
       time: 'Time',
       datetime: 'Date and time',


### PR DESCRIPTION
## Summary

First slice of the question-type expansion (#145). Adds the matrix
family that every paid survey product ships and that we have been
zero-for. Headline ask: a row-by-column grid of statements where the
respondent picks one (or many) choices per row, like the screenshot
in the design conversation.

Also categorizes the now-23-type designer palette so it stops being
a flat scroll.

## What ships

### Schema (`packages/form-schema/src/index.ts`)

- New types `matrix-single` and `matrix-multi` in `QUESTION_TYPES`.
- Exported `MatrixRow` and `MatrixColumn` shapes.
- Validator handles per-row required, per-row min / max, and
  rejects unknown column values.
- `isEmpty` now treats a plain object whose values are all empty
  as empty too, so a fresh matrix counts as empty for the
  question-level required check.

### Runtime (`form-runtime.tsx`)

- `MatrixSingleInput` and `MatrixMultiInput` render a CSS grid on
  desktop and collapse to a stack of fieldsets on mobile (< 640px).
  Each row gets a fresh fieldset / legend so screen readers read it
  as a discrete sub-question.
- `packIntoRows` treats matrix questions as standalone rows so they
  always render full-width regardless of `layout.width`.

### Designer (`designer.tsx`)

- Palette grouped into Text / Numeric / Choice / Matrix / Scale /
  Date & time / Media / Geometry / Logic / Layout with named
  headers.
- New `MatrixEditor` component for the Properties panel: row list +
  column list, each with id / label and add / remove.
- Per-type Properties: `perRowRequired` checkbox for matrix-single,
  Min / Max per row inputs for matrix-multi.

### Docs

Adds `docs/forms-question-types.md`, the comparison-matrix audit
against ten paid survey products and the phased plan this slice
opens.

## Quality gate

- `pnpm typecheck` clean across all 5 workspaces
- `pnpm lint` clean (no new warnings)
- `pnpm test` clean (no new test failures)
