### PR TITLE
feat(forms): ranking + matrix-dropdown + matrix-rating (#145)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -16,6 +16,7 @@ import {
   Grid3x3,
   GripVertical,
   Hash,
+  ListOrdered,
   ListChecks,
   Loader2,
   MapPin,
@@ -611,6 +612,9 @@ const PALETTE: PaletteEntry[] = [
   { type: 'select-many', label: 'Multiple choice', icon: CheckSquare, group: 'choice' },
   { type: 'matrix-single', label: 'Matrix (single)', icon: Grid3x3, group: 'matrix' },
   { type: 'matrix-multi', label: 'Matrix (multi)', icon: Grid3x3, group: 'matrix' },
+  { type: 'matrix-dropdown', label: 'Matrix (dropdown)', icon: Grid3x3, group: 'matrix' },
+  { type: 'matrix-rating', label: 'Matrix (rating)', icon: Grid3x3, group: 'matrix' },
+  { type: 'ranking', label: 'Ranking', icon: ListOrdered, group: 'choice' },
   { type: 'rating', label: 'Rating', icon: Star, group: 'scale' },
   { type: 'slider', label: 'Slider', icon: Sliders, group: 'scale' },
   { type: 'date', label: 'Date', icon: Calendar, group: 'time' },
@@ -1197,6 +1201,109 @@ function Properties({
         </div>
       ) : null}
 
+      {question.type === 'matrix-dropdown' ? (
+        <MatrixDropdownEditor
+          rows={question.rows}
+          columns={question.columns}
+          canEdit={canEdit}
+          onChange={(patch) => onChange(patch as Partial<Question>)}
+        />
+      ) : null}
+
+      {question.type === 'matrix-rating' ? (
+        <>
+          <MatrixRowsEditor
+            rows={question.rows}
+            canEdit={canEdit}
+            onChange={(rows) => onChange({ rows } as Partial<Question>)}
+          />
+          <div className="mb-2 grid grid-cols-2 gap-2">
+            <Field label="Max stars">
+              <input
+                type="number"
+                min={1}
+                max={10}
+                value={question.max ?? 5}
+                disabled={!canEdit}
+                onChange={(e) =>
+                  onChange({ max: Number(e.target.value) } as Partial<Question>)
+                }
+                className={inputCls}
+              />
+            </Field>
+            <Field label="Shape">
+              <select
+                value={question.shape ?? 'star'}
+                disabled={!canEdit}
+                onChange={(e) =>
+                  onChange({
+                    shape: e.target.value as 'star' | 'heart' | 'thumb',
+                  } as Partial<Question>)
+                }
+                className={inputCls}
+              >
+                <option value="star">Star</option>
+                <option value="heart">Heart</option>
+                <option value="thumb">Thumb</option>
+              </select>
+            </Field>
+          </div>
+          <label className="mb-2 inline-flex items-center gap-2 text-xs">
+            <input
+              type="checkbox"
+              checked={Boolean(question.perRowRequired)}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({ perRowRequired: e.target.checked } as Partial<Question>)
+              }
+            />
+            <span>Require an answer for every row</span>
+          </label>
+        </>
+      ) : null}
+
+      {question.type === 'ranking' ? (
+        <>
+          <ChoicesEditor
+            choices={question.choices}
+            canEdit={canEdit}
+            onChange={(choices) => onChange({ choices } as Partial<Question>)}
+          />
+          <div className="mb-2 grid grid-cols-2 gap-2">
+            <Field label="Min ranked">
+              <input
+                type="number"
+                min={0}
+                value={question.minRanked ?? ''}
+                disabled={!canEdit}
+                onChange={(e) =>
+                  onChange({
+                    minRanked:
+                      e.target.value === '' ? undefined : Number(e.target.value),
+                  } as Partial<Question>)
+                }
+                className={inputCls}
+              />
+            </Field>
+            <Field label="Max ranked">
+              <input
+                type="number"
+                min={0}
+                value={question.maxRanked ?? ''}
+                disabled={!canEdit}
+                onChange={(e) =>
+                  onChange({
+                    maxRanked:
+                      e.target.value === '' ? undefined : Number(e.target.value),
+                  } as Partial<Question>)
+                }
+                className={inputCls}
+              />
+            </Field>
+          </div>
+        </>
+      ) : null}
+
       {question.type === 'number' || question.type === 'integer' ? (
         <div className="grid grid-cols-2 gap-2">
           <Field label="Min">
@@ -1609,6 +1716,203 @@ function MatrixEditor({
                     {
                       value: `option_${columns.length + 1}`,
                       label: `Option ${columns.length + 1}`,
+                    },
+                  ],
+                })
+              }
+              className="inline-flex h-7 items-center gap-1 rounded-md border border-dashed border-border bg-surface-1 px-2 text-[11px] text-ink-1 hover:bg-surface-2"
+            >
+              <Plus className="h-3 w-3" />
+              Add column
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MatrixRowsEditor({
+  rows,
+  canEdit,
+  onChange,
+}: {
+  rows: { id: string; label: string }[];
+  canEdit: boolean;
+  onChange: (next: typeof rows) => void;
+}) {
+  return (
+    <div className="mb-3">
+      <p className="mb-1 text-[10px] uppercase tracking-wide text-muted">
+        Rows
+      </p>
+      <div className="space-y-1">
+        {rows.map((r, i) => (
+          <div key={i} className="flex items-center gap-1">
+            <input
+              type="text"
+              value={r.id}
+              placeholder="row id"
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange(
+                  rows.map((rr, ii) =>
+                    ii === i ? { ...rr, id: e.target.value } : rr,
+                  ),
+                )
+              }
+              className={`${inputCls} font-mono w-20`}
+            />
+            <input
+              type="text"
+              value={r.label}
+              placeholder="row label"
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange(
+                  rows.map((rr, ii) =>
+                    ii === i ? { ...rr, label: e.target.value } : rr,
+                  ),
+                )
+              }
+              className={`${inputCls} flex-1`}
+            />
+            {canEdit ? (
+              <button
+                type="button"
+                onClick={() => onChange(rows.filter((_, ii) => ii !== i))}
+                className="rounded p-1 text-muted hover:bg-surface-2 hover:text-danger"
+                aria-label="Remove row"
+              >
+                <Trash2 className="h-3 w-3" />
+              </button>
+            ) : null}
+          </div>
+        ))}
+        {canEdit ? (
+          <button
+            type="button"
+            onClick={() =>
+              onChange([
+                ...rows,
+                {
+                  id: `row_${rows.length + 1}`,
+                  label: `Item ${rows.length + 1}`,
+                },
+              ])
+            }
+            className="inline-flex h-7 items-center gap-1 rounded-md border border-dashed border-border bg-surface-1 px-2 text-[11px] text-ink-1 hover:bg-surface-2"
+          >
+            <Plus className="h-3 w-3" />
+            Add row
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Editor for `matrix-dropdown` columns. Each column has its own
+ * choices, so the component is a stack of {column header, column
+ * choices editor} blocks rather than the flat list MatrixEditor uses.
+ */
+function MatrixDropdownEditor({
+  rows,
+  columns,
+  canEdit,
+  onChange,
+}: {
+  rows: { id: string; label: string }[];
+  columns: { value: string; label: string; choices: Choice[] }[];
+  canEdit: boolean;
+  onChange: (
+    patch: { rows?: typeof rows; columns?: typeof columns },
+  ) => void;
+}) {
+  return (
+    <div className="mb-3 space-y-3">
+      <MatrixRowsEditor
+        rows={rows}
+        canEdit={canEdit}
+        onChange={(next) => onChange({ rows: next })}
+      />
+      <div>
+        <p className="mb-1 text-[10px] uppercase tracking-wide text-muted">
+          Columns (each with its own choices)
+        </p>
+        <div className="space-y-2">
+          {columns.map((c, i) => (
+            <div key={i} className="rounded-md border border-border bg-surface-1 p-2">
+              <div className="mb-1 flex items-center gap-1">
+                <input
+                  type="text"
+                  value={c.value}
+                  placeholder="value"
+                  disabled={!canEdit}
+                  onChange={(e) =>
+                    onChange({
+                      columns: columns.map((cc, ii) =>
+                        ii === i ? { ...cc, value: e.target.value } : cc,
+                      ),
+                    })
+                  }
+                  className={`${inputCls} font-mono w-20`}
+                />
+                <input
+                  type="text"
+                  value={c.label}
+                  placeholder="label"
+                  disabled={!canEdit}
+                  onChange={(e) =>
+                    onChange({
+                      columns: columns.map((cc, ii) =>
+                        ii === i ? { ...cc, label: e.target.value } : cc,
+                      ),
+                    })
+                  }
+                  className={`${inputCls} flex-1`}
+                />
+                {canEdit ? (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      onChange({ columns: columns.filter((_, ii) => ii !== i) })
+                    }
+                    className="rounded p-1 text-muted hover:bg-surface-2 hover:text-danger"
+                    aria-label="Remove column"
+                  >
+                    <Trash2 className="h-3 w-3" />
+                  </button>
+                ) : null}
+              </div>
+              <ChoicesEditor
+                choices={c.choices}
+                canEdit={canEdit}
+                onChange={(choices) =>
+                  onChange({
+                    columns: columns.map((cc, ii) =>
+                      ii === i ? { ...cc, choices } : cc,
+                    ),
+                  })
+                }
+              />
+            </div>
+          ))}
+          {canEdit ? (
+            <button
+              type="button"
+              onClick={() =>
+                onChange({
+                  columns: [
+                    ...columns,
+                    {
+                      value: `col_${columns.length + 1}`,
+                      label: `Column ${columns.length + 1}`,
+                      choices: [
+                        { value: 'option_1', label: 'Option 1' },
+                        { value: 'option_2', label: 'Option 2' },
+                      ],
                     },
                   ],
                 })

--- a/apps/portal-web/src/components/form-runtime.tsx
+++ b/apps/portal-web/src/components/form-runtime.tsx
@@ -4,12 +4,15 @@ import { Fragment, useEffect, useMemo, useState } from 'react';
 import {
   Camera,
   Check,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
+  ChevronUp,
   Loader2,
   MapPin,
   Plus,
   Trash2,
+  X,
 } from 'lucide-react';
 import {
   applyCalculations,
@@ -626,6 +629,33 @@ function Input({
           onChange={onChange}
         />
       );
+    case 'matrix-dropdown':
+      return (
+        <MatrixDropdownInput
+          q={q}
+          value={value}
+          readOnly={readOnly}
+          onChange={onChange}
+        />
+      );
+    case 'matrix-rating':
+      return (
+        <MatrixRatingInput
+          q={q}
+          value={value}
+          readOnly={readOnly}
+          onChange={onChange}
+        />
+      );
+    case 'ranking':
+      return (
+        <RankingInput
+          q={q}
+          value={value}
+          readOnly={readOnly}
+          onChange={onChange}
+        />
+      );
     case 'date':
       return (
         <input
@@ -1162,6 +1192,355 @@ function MatrixMultiInput({
   );
 }
 
+/**
+ * Matrix dropdown: each cell is a per-column dropdown. Renders as a
+ * grid on desktop and as one fieldset per row on mobile.
+ */
+function MatrixDropdownInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'matrix-dropdown' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  const map: Record<string, Record<string, string>> =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, Record<string, string>>)
+      : {};
+
+  function setCell(rowId: string, colValue: string, choice: string | null) {
+    const rowMap: Record<string, string> = { ...(map[rowId] ?? {}) };
+    if (choice === null || choice === '') delete rowMap[colValue];
+    else rowMap[colValue] = choice;
+    const out = { ...map };
+    if (Object.keys(rowMap).length === 0) delete out[rowId];
+    else out[rowId] = rowMap;
+    onChange(out);
+  }
+
+  return (
+    <div>
+      <div className="hidden sm:block">
+        <div
+          className="grid items-center gap-x-2 gap-y-1 overflow-x-auto rounded-md border border-border bg-surface-1 p-2 text-sm"
+          style={{
+            gridTemplateColumns: `minmax(8rem, 1.4fr) repeat(${q.columns.length}, minmax(7rem, 1fr))`,
+          }}
+        >
+          <div />
+          {q.columns.map((c) => (
+            <div
+              key={c.value}
+              className="px-1 text-center text-[11px] font-medium text-muted"
+            >
+              {c.label}
+            </div>
+          ))}
+          {q.rows.map((row, idx) => {
+            const odd = idx % 2 === 1;
+            const rowMap = map[row.id] ?? {};
+            return (
+              <Fragment key={row.id}>
+                <div
+                  className={`px-2 py-2 text-sm text-ink-1 ${odd ? 'bg-surface-2/40' : ''}`}
+                >
+                  {row.label}
+                </div>
+                {q.columns.map((c) => (
+                  <div
+                    key={c.value}
+                    className={`px-1 py-1 ${odd ? 'bg-surface-2/40' : ''}`}
+                  >
+                    <select
+                      value={rowMap[c.value] ?? ''}
+                      disabled={readOnly}
+                      onChange={(e) =>
+                        setCell(row.id, c.value, e.target.value || null)
+                      }
+                      className="block h-9 w-full rounded-md border border-border bg-surface-1 px-2 text-xs"
+                    >
+                      <option value="">--</option>
+                      {c.choices.map((ch) => (
+                        <option key={ch.value} value={ch.value}>
+                          {ch.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                ))}
+              </Fragment>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="space-y-3 sm:hidden">
+        {q.rows.map((row) => {
+          const rowMap = map[row.id] ?? {};
+          return (
+            <fieldset
+              key={row.id}
+              className="rounded-md border border-border bg-surface-1 p-2"
+            >
+              <legend className="px-1 text-sm font-medium text-ink-1">
+                {row.label}
+              </legend>
+              <div className="mt-1 space-y-2">
+                {q.columns.map((c) => (
+                  <label key={c.value} className="block text-xs">
+                    <span className="mb-0.5 block text-muted">{c.label}</span>
+                    <select
+                      value={rowMap[c.value] ?? ''}
+                      disabled={readOnly}
+                      onChange={(e) =>
+                        setCell(row.id, c.value, e.target.value || null)
+                      }
+                      className="block h-10 w-full rounded-md border border-border bg-surface-1 px-2 text-sm"
+                    >
+                      <option value="">--</option>
+                      {c.choices.map((ch) => (
+                        <option key={ch.value} value={ch.value}>
+                          {ch.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ))}
+              </div>
+            </fieldset>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Matrix rating: each row gets the same rating widget. Useful for
+ * scoring a list of items on a shared scale.
+ */
+function MatrixRatingInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'matrix-rating' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  const map: Record<string, number> =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, number>)
+      : {};
+  const max = q.max ?? 5;
+  const icon =
+    q.shape === 'heart' ? '♥' : q.shape === 'thumb' ? '\u{1F44D}' : '★';
+
+  function set(rowId: string, n: number) {
+    const out = { ...map };
+    out[rowId] = n;
+    onChange(out);
+  }
+
+  return (
+    <div className="space-y-2 rounded-md border border-border bg-surface-1 p-2">
+      {q.rows.map((row, idx) => {
+        const cur = map[row.id] ?? 0;
+        const odd = idx % 2 === 1;
+        return (
+          <div
+            key={row.id}
+            className={`flex flex-col items-start justify-between gap-1 rounded-sm px-2 py-2 sm:flex-row sm:items-center ${odd ? 'bg-surface-2/40' : ''}`}
+          >
+            <span className="text-sm text-ink-1">{row.label}</span>
+            <div className="flex gap-1">
+              {Array.from({ length: max }, (_, i) => i + 1).map((n) => (
+                <button
+                  type="button"
+                  key={n}
+                  disabled={readOnly}
+                  onClick={() => set(row.id, n)}
+                  className={`h-9 w-9 rounded-md border text-base ${
+                    n <= cur
+                      ? 'border-accent bg-accent/10 text-accent'
+                      : 'border-border bg-surface-1'
+                  }`}
+                  aria-label={`${row.label}: ${n} of ${max}`}
+                >
+                  {icon}
+                </button>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Ranking: drag-to-reorder on desktop with a fallback up / down
+ * arrow per item. Mobile users tap the arrows; the grip is a hint
+ * but not strictly required. Choices not yet ranked appear in a
+ * second list and can be promoted into the ordered set.
+ */
+function RankingInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'ranking' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  const ranked: string[] = Array.isArray(value)
+    ? (value as string[]).filter(
+        (v): v is string =>
+          typeof v === 'string' && q.choices.some((c) => c.value === v),
+      )
+    : [];
+  const rankedSet = new Set(ranked);
+  const unranked = q.choices.filter((c) => !rankedSet.has(c.value));
+
+  function move(idx: number, delta: -1 | 1) {
+    const next = ranked.slice();
+    const target = idx + delta;
+    if (target < 0 || target >= next.length) return;
+    const a = next[idx];
+    const b = next[target];
+    if (a === undefined || b === undefined) return;
+    next[idx] = b;
+    next[target] = a;
+    onChange(next);
+  }
+
+  function rank(value: string) {
+    if (rankedSet.has(value)) return;
+    const max = q.maxRanked ?? q.choices.length;
+    if (ranked.length >= max) return;
+    onChange([...ranked, value]);
+  }
+
+  function unrank(value: string) {
+    onChange(ranked.filter((v) => v !== value));
+  }
+
+  function onDragStart(e: React.DragEvent<HTMLLIElement>, idx: number) {
+    if (readOnly) return;
+    e.dataTransfer.setData('text/x-rank-index', String(idx));
+    e.dataTransfer.effectAllowed = 'move';
+  }
+
+  function onDrop(e: React.DragEvent<HTMLLIElement>, dropIdx: number) {
+    if (readOnly) return;
+    const raw = e.dataTransfer.getData('text/x-rank-index');
+    if (!raw) return;
+    const fromIdx = Number(raw);
+    if (Number.isNaN(fromIdx) || fromIdx === dropIdx) return;
+    const next = ranked.slice();
+    const [moved] = next.splice(fromIdx, 1);
+    if (moved === undefined) return;
+    const insertAt = dropIdx > fromIdx ? dropIdx - 1 : dropIdx;
+    next.splice(insertAt, 0, moved);
+    onChange(next);
+    e.preventDefault();
+  }
+
+  function labelFor(v: string): string {
+    return q.choices.find((c) => c.value === v)?.label ?? v;
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="rounded-md border border-border bg-surface-1 p-2">
+        <p className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted">
+          Ranked
+        </p>
+        {ranked.length === 0 ? (
+          <p className="px-2 py-2 text-xs text-muted">
+            No items ranked yet. Tap an item below to add it.
+          </p>
+        ) : (
+          <ol className="space-y-1">
+            {ranked.map((v, i) => (
+              <li
+                key={v}
+                draggable={!readOnly}
+                onDragStart={(e) => onDragStart(e, i)}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={(e) => onDrop(e, i)}
+                className="flex items-center gap-2 rounded-md border border-border bg-surface-2/30 px-2 py-1.5 text-sm"
+              >
+                <span className="w-5 text-xs tabular-nums text-muted">{i + 1}.</span>
+                <span className="flex-1 truncate">{labelFor(v)}</span>
+                {!readOnly ? (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => move(i, -1)}
+                      disabled={i === 0}
+                      className="rounded p-1 text-muted hover:bg-surface-2 disabled:opacity-30"
+                      aria-label="Move up"
+                    >
+                      <ChevronUp className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => move(i, 1)}
+                      disabled={i === ranked.length - 1}
+                      className="rounded p-1 text-muted hover:bg-surface-2 disabled:opacity-30"
+                      aria-label="Move down"
+                    >
+                      <ChevronDown className="h-3.5 w-3.5" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => unrank(v)}
+                      className="rounded p-1 text-muted hover:bg-surface-2 hover:text-danger"
+                      aria-label="Remove from ranking"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  </>
+                ) : null}
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+      {unranked.length > 0 ? (
+        <div className="rounded-md border border-dashed border-border bg-surface-2/30 p-2">
+          <p className="mb-1 text-[11px] font-medium uppercase tracking-wide text-muted">
+            Available
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {unranked.map((c) => (
+              <button
+                type="button"
+                key={c.value}
+                disabled={readOnly}
+                onClick={() => rank(c.value)}
+                className="inline-flex h-8 items-center gap-1 rounded-md border border-border bg-surface-1 px-2 text-xs hover:bg-surface-2"
+              >
+                <Plus className="h-3 w-3 text-muted" />
+                {c.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 // ---- helpers ----------------------------------------------------
 
 function fileToDataUrl(file: File): Promise<string> {
@@ -1232,7 +1611,10 @@ function packIntoRows(qs: Question[]): Question[][] {
       q.type === 'group' ||
       q.type === 'note' ||
       q.type === 'matrix-single' ||
-      q.type === 'matrix-multi';
+      q.type === 'matrix-multi' ||
+      q.type === 'matrix-dropdown' ||
+      q.type === 'matrix-rating' ||
+      q.type === 'ranking';
     const w = widthFraction(q.layout?.width);
     if (isStandalone || w === 1) {
       flush();

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -59,6 +59,9 @@ export const QUESTION_TYPES = [
   'select-many', // checkboxes
   'matrix-single', // grid: rows of statements, one choice per row
   'matrix-multi', // grid: rows of statements, multi choice per row
+  'matrix-dropdown', // grid: per-column dropdown choices
+  'matrix-rating', // grid: rating-per-row (stars / hearts / thumbs)
+  'ranking', // ordered list (drag or arrows to reorder)
   'date', // calendar date
   'time', // wall-clock time
   'datetime', // calendar + clock
@@ -306,6 +309,71 @@ interface MatrixMultiQuestion extends QuestionBase {
   perRowMaxSelected?: number;
 }
 
+/**
+ * A column in a `matrix-dropdown` question -- carries its own
+ * `choices` list, so each column can be a different dropdown
+ * (e.g. "Current state" with one choice set, "Target state" with
+ * another).
+ */
+export interface MatrixDropdownColumn {
+  value: string;
+  label: string;
+  choices: Choice[];
+}
+
+/**
+ * Matrix where each cell is a per-column dropdown. Useful when the
+ * columns aren't parallel choices (the matrix-single / matrix-multi
+ * case) but instead are different facets of each row that the
+ * respondent answers from different lists.
+ *
+ * Response shape:
+ *   Record<rowId, Record<columnValue, choiceValue | null>>
+ */
+interface MatrixDropdownQuestion extends QuestionBase {
+  type: 'matrix-dropdown';
+  rows: MatrixRow[];
+  columns: MatrixDropdownColumn[];
+  rowsPickListId?: string;
+}
+
+/**
+ * Matrix where each row gets the same rating widget (stars / hearts
+ * / thumbs). Quick way to score a list of items on a shared scale.
+ *
+ * Response shape: Record<rowId, number> (1..max).
+ */
+interface MatrixRatingQuestion extends QuestionBase {
+  type: 'matrix-rating';
+  rows: MatrixRow[];
+  rowsPickListId?: string;
+  /** Number of icons. Default 5. */
+  max?: number;
+  /** Icon shape. */
+  shape?: 'star' | 'heart' | 'thumb';
+  /** When true, every row counts toward `required`. */
+  perRowRequired?: boolean;
+}
+
+/**
+ * Ranking: the respondent orders the choices into a preferred
+ * sequence by dragging or by tapping up / down. The Response is an
+ * ordered array of choice values.
+ *
+ * Response shape: string[] -- the values of the choices in the
+ * order the respondent placed them.
+ */
+interface RankingQuestion extends QuestionBase {
+  type: 'ranking';
+  choices: Choice[];
+  pickListId?: string;
+  /** Minimum number of choices that must be ranked. Default: all. */
+  minRanked?: number;
+  /** Maximum number of choices the respondent can rank. Useful for
+   *  "rank your top 3" prompts -- defaults to all. */
+  maxRanked?: number;
+}
+
 interface DateQuestion extends QuestionBase {
   type: 'date';
   /** ISO 8601 date or `today`. */
@@ -422,6 +490,9 @@ export type Question =
   | SelectManyQuestion
   | MatrixSingleQuestion
   | MatrixMultiQuestion
+  | MatrixDropdownQuestion
+  | MatrixRatingQuestion
+  | RankingQuestion
   | DateQuestion
   | TimeQuestion
   | DateTimeQuestion
@@ -781,7 +852,8 @@ export function validate(form: FormSchema, response: Response): ValidationResult
     // even when nothing is filled, so we let validateType run.
     const skipIfEmpty =
       !(q.type === 'matrix-single' && q.perRowRequired) &&
-      !(q.type === 'matrix-multi' && q.perRowMinSelected);
+      !(q.type === 'matrix-multi' && q.perRowMinSelected) &&
+      !(q.type === 'matrix-rating' && q.perRowRequired);
     if (isEmpty(value) && skipIfEmpty) continue;
 
     const typeError = validateType(q, value);
@@ -924,6 +996,77 @@ function validateType(q: Question, value: unknown): string | null {
           return `Row "${row.label}": pick at most ${q.perRowMaxSelected}.`;
         }
       }
+      return null;
+    }
+    case 'matrix-dropdown': {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return 'Expected selections per row.';
+      }
+      const map = value as Record<string, unknown>;
+      const colMap = new Map(q.columns.map((c) => [c.value, c]));
+      for (const row of q.rows) {
+        const cells = map[row.id];
+        if (cells === undefined || cells === null) continue;
+        if (
+          typeof cells !== 'object' ||
+          Array.isArray(cells)
+        ) {
+          return `Row "${row.label}" has an unexpected value.`;
+        }
+        for (const [colValue, choice] of Object.entries(
+          cells as Record<string, unknown>,
+        )) {
+          if (choice === null || choice === undefined || choice === '') continue;
+          const col = colMap.get(colValue);
+          if (!col) {
+            return `Row "${row.label}": unknown column "${colValue}".`;
+          }
+          const validChoices = new Set(col.choices.map((c) => c.value));
+          if (typeof choice !== 'string' || !validChoices.has(choice)) {
+            return `Row "${row.label}", column "${col.label}" has an unrecognized choice.`;
+          }
+        }
+      }
+      return null;
+    }
+    case 'matrix-rating': {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return 'Expected a rating per row.';
+      }
+      const map = value as Record<string, unknown>;
+      const max = q.max ?? 5;
+      for (const row of q.rows) {
+        const v = map[row.id];
+        if (v === undefined || v === null || v === '') continue;
+        if (typeof v !== 'number' || !Number.isInteger(v) || v < 1 || v > max) {
+          return `Row "${row.label}" has an unexpected rating.`;
+        }
+      }
+      if (q.perRowRequired) {
+        for (const row of q.rows) {
+          const v = map[row.id];
+          if (v === undefined || v === null || v === '') {
+            return `Row "${row.label}" is required.`;
+          }
+        }
+      }
+      return null;
+    }
+    case 'ranking': {
+      if (!Array.isArray(value)) return 'Expected an ordered list.';
+      const validValues = new Set(q.choices.map((c) => c.value));
+      const seen = new Set<string>();
+      for (const v of value) {
+        if (typeof v !== 'string' || !validValues.has(v)) {
+          return 'List contains an unrecognized choice.';
+        }
+        if (seen.has(v)) return 'List contains a duplicate choice.';
+        seen.add(v);
+      }
+      const min = q.minRanked ?? 0;
+      const max = q.maxRanked ?? q.choices.length;
+      if (value.length < min) return `Rank at least ${min}.`;
+      if (value.length > max) return `Rank at most ${max}.`;
       return null;
     }
     case 'date':
@@ -1074,6 +1217,57 @@ export function defaultQuestion(type: QuestionType, id: QuestionId): Question {
           { value: 'option_c', label: 'Option C' },
         ],
       };
+    case 'matrix-dropdown':
+      return {
+        ...base,
+        type,
+        rows: [
+          { id: 'row_1', label: 'Item 1' },
+          { id: 'row_2', label: 'Item 2' },
+        ],
+        columns: [
+          {
+            value: 'current',
+            label: 'Current',
+            choices: [
+              { value: 'low', label: 'Low' },
+              { value: 'medium', label: 'Medium' },
+              { value: 'high', label: 'High' },
+            ],
+          },
+          {
+            value: 'target',
+            label: 'Target',
+            choices: [
+              { value: 'low', label: 'Low' },
+              { value: 'medium', label: 'Medium' },
+              { value: 'high', label: 'High' },
+            ],
+          },
+        ],
+      };
+    case 'matrix-rating':
+      return {
+        ...base,
+        type,
+        rows: [
+          { id: 'row_1', label: 'Item 1' },
+          { id: 'row_2', label: 'Item 2' },
+          { id: 'row_3', label: 'Item 3' },
+        ],
+        max: 5,
+        shape: 'star',
+      };
+    case 'ranking':
+      return {
+        ...base,
+        type,
+        choices: [
+          { value: 'option_1', label: 'Option 1' },
+          { value: 'option_2', label: 'Option 2' },
+          { value: 'option_3', label: 'Option 3' },
+        ],
+      };
     case 'date':
       return { ...base, type };
     case 'time':
@@ -1124,6 +1318,9 @@ function defaultLabel(type: QuestionType): string {
       'select-many': 'Multiple choice',
       'matrix-single': 'Matrix (single)',
       'matrix-multi': 'Matrix (multi)',
+      'matrix-dropdown': 'Matrix (dropdown)',
+      'matrix-rating': 'Matrix (rating)',
+      ranking: 'Ranking',
       date: 'Date',
       time: 'Time',
       datetime: 'Date and time',


### PR DESCRIPTION
## Summary

Slice 2 of the question-type expansion (#145). Lands the rest of
the matrix family plus the standalone ranking type that paid
products ship.

## What ships

### Schema (`packages/form-schema`)

- `matrix-dropdown`: per-cell dropdown grid where each column carries
  its own `choices` list (e.g. one column for "current", another for
  "target").
- `matrix-rating`: rating-per-row grid (stars / hearts / thumbs)
  with shared scale.
- `ranking`: ordered list of choices. Response is `string[]`.
- Validators reject unknown columns / choices, ranking duplicates,
  out-of-range ratings, and respect per-row required + min / max.

### Runtime (`form-runtime.tsx`)

- `MatrixDropdownInput`, `MatrixRatingInput`, `RankingInput`
  components. All collapse to mobile-friendly stacks below `sm:`.
- Ranking has both drag-to-reorder (desktop) and per-row up / down
  arrows (universal). Available choices live in a separate "tap to
  promote" tray.
- `packIntoRows` treats the new types as standalone rows.

### Designer (`designer.tsx`)

- Palette: matrix-dropdown and matrix-rating in the Matrix group,
  ranking in the Choice group.
- New `MatrixRowsEditor` (rows-only) for `matrix-rating`.
- New `MatrixDropdownEditor`: rows + per-column blocks, each block
  has its own embedded `ChoicesEditor`.
- Per-type Properties: max + shape + perRowRequired for
  matrix-rating, min / max ranked for ranking.

## Quality gate

- `pnpm typecheck`, `pnpm lint`, `pnpm test` clean.

Stacked on top of #15 (slice 1). Rebased onto main after that
merged.
