### PR TITLE
feat(forms): email + url + phone + regex (#145)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -16,11 +16,15 @@ import {
   Grid3x3,
   GripVertical,
   Hash,
+  Link,
   ListOrdered,
   ListChecks,
   Loader2,
+  Mail,
   MapPin,
+  Phone,
   Plus,
+  Regex,
   Save,
   Sliders,
   SplitSquareHorizontal,
@@ -605,6 +609,10 @@ const PALETTE_GROUPS: { id: PaletteGroup; label: string }[] = [
 const PALETTE: PaletteEntry[] = [
   { type: 'text', label: 'Short text', icon: Type, group: 'text' },
   { type: 'multiline', label: 'Long text', icon: AlignLeft, group: 'text' },
+  { type: 'email', label: 'Email', icon: Mail, group: 'text' },
+  { type: 'url', label: 'URL', icon: Link, group: 'text' },
+  { type: 'phone', label: 'Phone', icon: Phone, group: 'text' },
+  { type: 'regex', label: 'Pattern', icon: Regex, group: 'text' },
   { type: 'number', label: 'Number', icon: Hash, group: 'numeric' },
   { type: 'integer', label: 'Whole number', icon: Hash, group: 'numeric' },
   { type: 'boolean', label: 'Yes / No', icon: ToggleLeft, group: 'choice' },
@@ -1335,7 +1343,11 @@ function Properties({
         </div>
       ) : null}
 
-      {question.type === 'text' || question.type === 'multiline' ? (
+      {question.type === 'text' ||
+      question.type === 'multiline' ||
+      question.type === 'email' ||
+      question.type === 'url' ||
+      question.type === 'regex' ? (
         <Field label="Max length">
           <input
             type="number"
@@ -1349,6 +1361,45 @@ function Properties({
             className={inputCls}
           />
         </Field>
+      ) : null}
+
+      {question.type === 'regex' ? (
+        <>
+          <Field label="Pattern" hint="Regex applied with implicit ^...$ anchors.">
+            <input
+              type="text"
+              value={question.pattern}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({ pattern: e.target.value } as Partial<Question>)
+              }
+              className={`${inputCls} font-mono`}
+            />
+          </Field>
+          <Field label="Flags" hint='e.g. "i" for case-insensitive.'>
+            <input
+              type="text"
+              value={question.flags ?? ''}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({ flags: e.target.value || undefined } as Partial<Question>)
+              }
+              className={`${inputCls} font-mono`}
+              maxLength={6}
+            />
+          </Field>
+          <Field label="Error message">
+            <input
+              type="text"
+              value={question.message ?? ''}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({ message: e.target.value || undefined } as Partial<Question>)
+              }
+              className={inputCls}
+            />
+          </Field>
+        </>
       ) : null}
 
       {question.type === 'group' ? (

--- a/apps/portal-web/src/components/form-runtime.tsx
+++ b/apps/portal-web/src/components/form-runtime.tsx
@@ -477,6 +477,63 @@ function Input({
           className={baseClass}
         />
       );
+    case 'email':
+      return (
+        <input
+          id={q.id}
+          type="email"
+          inputMode="email"
+          autoComplete="email"
+          value={(value as string) ?? ''}
+          maxLength={q.maxLength}
+          placeholder={q.placeholder}
+          disabled={readOnly}
+          onChange={(e) => onChange(e.target.value)}
+          className={baseClass}
+        />
+      );
+    case 'url':
+      return (
+        <input
+          id={q.id}
+          type="url"
+          inputMode="url"
+          autoComplete="url"
+          value={(value as string) ?? ''}
+          maxLength={q.maxLength}
+          placeholder={q.placeholder}
+          disabled={readOnly}
+          onChange={(e) => onChange(e.target.value)}
+          className={baseClass}
+        />
+      );
+    case 'phone':
+      return (
+        <input
+          id={q.id}
+          type="tel"
+          inputMode="tel"
+          autoComplete="tel"
+          value={(value as string) ?? ''}
+          placeholder={q.placeholder}
+          disabled={readOnly}
+          onChange={(e) => onChange(e.target.value)}
+          className={baseClass}
+        />
+      );
+    case 'regex':
+      return (
+        <input
+          id={q.id}
+          type="text"
+          value={(value as string) ?? ''}
+          maxLength={q.maxLength}
+          placeholder={q.placeholder}
+          disabled={readOnly}
+          onChange={(e) => onChange(e.target.value)}
+          className={baseClass}
+        />
+      );
     case 'number':
       return (
         <input

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -52,6 +52,10 @@ export const CURRENT_FORM_SCHEMA_VERSION: FormSchemaVersion = 1;
 export const QUESTION_TYPES = [
   'text', // single-line free text
   'multiline', // multi-line free text (textarea)
+  'email', // text + email validation + email keyboard
+  'url', // text + URL validation + URL keyboard
+  'phone', // text + tel keyboard + light phone validation
+  'regex', // text + author-supplied regex pattern
   'number', // free decimal
   'integer', // whole number
   'boolean', // yes/no toggle
@@ -203,6 +207,42 @@ interface MultilineQuestion extends QuestionBase {
   maxLength?: number;
   /** Suggested rows. UI may grow as the user types. */
   rows?: number;
+}
+
+interface EmailQuestion extends QuestionBase {
+  type: 'email';
+  placeholder?: string;
+  maxLength?: number;
+}
+
+interface UrlQuestion extends QuestionBase {
+  type: 'url';
+  placeholder?: string;
+  maxLength?: number;
+  /** Restrict to specific protocols, e.g. ['http', 'https']. When
+   *  omitted any URL.parse-able value is accepted. */
+  allowedProtocols?: string[];
+}
+
+interface PhoneQuestion extends QuestionBase {
+  type: 'phone';
+  placeholder?: string;
+  /** ISO 3166 country hint for the renderer (used to default the
+   *  country code prefix). Validation stays light: digits + a few
+   *  punctuation chars + length sanity check. */
+  defaultCountry?: string;
+}
+
+interface RegexQuestion extends QuestionBase {
+  type: 'regex';
+  placeholder?: string;
+  /** Author-supplied regex pattern. The runtime anchors it when
+   *  validating (^...$). Required for a useful regex question. */
+  pattern: string;
+  /** Optional flags ("i", "u", etc.). The runtime defaults to no
+   *  flags. */
+  flags?: string;
+  maxLength?: number;
 }
 
 interface NumberQuestion extends QuestionBase {
@@ -483,6 +523,10 @@ interface GroupQuestion extends QuestionBase {
 export type Question =
   | TextQuestion
   | MultilineQuestion
+  | EmailQuestion
+  | UrlQuestion
+  | PhoneQuestion
+  | RegexQuestion
   | NumberQuestion
   | IntegerQuestion
   | BooleanQuestion
@@ -915,6 +959,66 @@ function validateType(q: Question, value: unknown): string | null {
       }
       return null;
     }
+    case 'email': {
+      if (typeof value !== 'string') return 'Expected text.';
+      if (q.maxLength && value.length > q.maxLength) {
+        return `Must be ${q.maxLength} characters or fewer.`;
+      }
+      // Pragmatic email check (RFC 5322 lite). We accept anything
+      // with one @, a non-empty local part, and a domain that has at
+      // least one dot. The full RFC grammar is famously over-broad
+      // and rejects almost no real addresses; this catches typos.
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+        return 'Enter a valid email address.';
+      }
+      return null;
+    }
+    case 'url': {
+      if (typeof value !== 'string') return 'Expected text.';
+      if (q.maxLength && value.length > q.maxLength) {
+        return `Must be ${q.maxLength} characters or fewer.`;
+      }
+      let parsed: URL | null = null;
+      try {
+        parsed = new URL(value);
+      } catch {
+        return 'Enter a valid URL.';
+      }
+      if (q.allowedProtocols && q.allowedProtocols.length > 0) {
+        const proto = parsed.protocol.replace(/:$/, '');
+        if (!q.allowedProtocols.includes(proto)) {
+          return `URL must use ${q.allowedProtocols.join(' or ')}.`;
+        }
+      }
+      return null;
+    }
+    case 'phone': {
+      if (typeof value !== 'string') return 'Expected text.';
+      // Strip allowed punctuation; what's left should be digits with
+      // optional leading +. Length sanity: 7..16 digits is the
+      // ITU-T E.164 envelope minus a small slack for short codes.
+      const cleaned = value.replace(/[\s().-]/g, '');
+      if (!/^\+?\d{7,16}$/.test(cleaned)) {
+        return 'Enter a valid phone number.';
+      }
+      return null;
+    }
+    case 'regex': {
+      if (typeof value !== 'string') return 'Expected text.';
+      if (q.maxLength && value.length > q.maxLength) {
+        return `Must be ${q.maxLength} characters or fewer.`;
+      }
+      let re: RegExp;
+      try {
+        re = new RegExp(`^(?:${q.pattern})$`, q.flags ?? '');
+      } catch {
+        // A bad pattern is a designer error; pass validation rather
+        // than block the respondent on something they can't fix.
+        return null;
+      }
+      if (!re.test(value)) return q.message ?? 'Does not match the required format.';
+      return null;
+    }
     case 'number':
     case 'integer': {
       const n = typeof value === 'number' ? value : Number(value);
@@ -1160,6 +1264,14 @@ export function defaultQuestion(type: QuestionType, id: QuestionId): Question {
       return { ...base, type };
     case 'multiline':
       return { ...base, type, rows: 3 };
+    case 'email':
+      return { ...base, type };
+    case 'url':
+      return { ...base, type };
+    case 'phone':
+      return { ...base, type };
+    case 'regex':
+      return { ...base, type, pattern: '.+' };
     case 'number':
       return { ...base, type };
     case 'integer':
@@ -1311,6 +1423,10 @@ function defaultLabel(type: QuestionType): string {
     {
       text: 'Short text',
       multiline: 'Long text',
+      email: 'Email',
+      url: 'URL',
+      phone: 'Phone',
+      regex: 'Pattern',
       number: 'Number',
       integer: 'Whole number',
       boolean: 'Yes / No',


### PR DESCRIPTION
## Summary

Slice 3 of the question-type expansion (#145). Specialized text inputs:
email, url, phone, regex. Trivial schema-wise but very visible -- they
unlock the right mobile keyboard and look professional.

## What ships

### Schema (`packages/form-schema`)

- `email`: pragmatic RFC-5322-lite check (one @, dotted domain).
- `url`: parsed via `URL`; optional `allowedProtocols` list.
- `phone`: light validation -- strips space / parens / dot / dash,
  asserts `+? digits{7..16}` (E.164 envelope plus a small slack).
- `regex`: author supplies pattern + optional flags + custom error
  message. Implicitly anchored. Bad pattern is a designer error and
  passes (we don't block respondents on something they can't fix).

### Runtime (`form-runtime.tsx`)

Each type renders an `<input>` with the correct `type`, `inputMode`,
and `autoComplete`. Mobile pops the @-key keyboard for email, the
URL keyboard for URL, the dial pad for phone.

### Designer (`designer.tsx`)

- Palette: email / url / phone / regex in the Text group with
  Mail / Link / Phone / Regex icons.
- Properties: max length surfaces for email / url / regex; regex gets
  pattern + flags + error message inputs.

## Quality gate

- `pnpm typecheck`, `pnpm lint`, `pnpm test` clean.

Stacked on top of #16 (slice 2). Rebased onto main after that merged.
