### PR TITLE
feat(forms): likert + nps first-class scales (#145)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AlignLeft,
+  BarChart3,
   Calculator,
   Calendar,
   CalendarClock,
@@ -624,6 +625,8 @@ const PALETTE: PaletteEntry[] = [
   { type: 'matrix-rating', label: 'Matrix (rating)', icon: Grid3x3, group: 'matrix' },
   { type: 'ranking', label: 'Ranking', icon: ListOrdered, group: 'choice' },
   { type: 'rating', label: 'Rating', icon: Star, group: 'scale' },
+  { type: 'likert', label: 'Likert', icon: Sliders, group: 'scale' },
+  { type: 'nps', label: 'NPS (0-10)', icon: BarChart3, group: 'scale' },
   { type: 'slider', label: 'Slider', icon: Sliders, group: 'scale' },
   { type: 'date', label: 'Date', icon: Calendar, group: 'time' },
   { type: 'time', label: 'Time', icon: Clock, group: 'time' },
@@ -1408,6 +1411,73 @@ function Properties({
           canEdit={canEdit}
           onChange={(repeat) => onChange({ repeat } as Partial<Question>)}
         />
+      ) : null}
+
+      {question.type === 'likert' ? (
+        <>
+          <Field label="Number of points" hint="Common: 5 (default) or 7.">
+            <input
+              type="number"
+              min={2}
+              max={10}
+              value={question.points ?? 5}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({ points: Number(e.target.value) } as Partial<Question>)
+              }
+              className={inputCls}
+            />
+          </Field>
+          <div className="mb-2 grid grid-cols-2 gap-2">
+            <Field label="Left label">
+              <input
+                type="text"
+                value={question.leftLabel ?? ''}
+                disabled={!canEdit}
+                onChange={(e) =>
+                  onChange({ leftLabel: e.target.value || undefined } as Partial<Question>)
+                }
+                className={inputCls}
+              />
+            </Field>
+            <Field label="Right label">
+              <input
+                type="text"
+                value={question.rightLabel ?? ''}
+                disabled={!canEdit}
+                onChange={(e) =>
+                  onChange({ rightLabel: e.target.value || undefined } as Partial<Question>)
+                }
+                className={inputCls}
+              />
+            </Field>
+          </div>
+          <Field label="Center label" hint="Optional middle anchor (e.g. Neutral).">
+            <input
+              type="text"
+              value={question.centerLabel ?? ''}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({ centerLabel: e.target.value || undefined } as Partial<Question>)
+              }
+              className={inputCls}
+            />
+          </Field>
+        </>
+      ) : null}
+
+      {question.type === 'nps' ? (
+        <Field label="Caption" hint='e.g. "How likely are you to recommend us?"'>
+          <input
+            type="text"
+            value={question.caption ?? ''}
+            disabled={!canEdit}
+            onChange={(e) =>
+              onChange({ caption: e.target.value || undefined } as Partial<Question>)
+            }
+            className={inputCls}
+          />
+        </Field>
       ) : null}
 
       <details className="mt-3 rounded-md border border-border bg-surface-1 p-2 text-xs">

--- a/apps/portal-web/src/components/form-runtime.tsx
+++ b/apps/portal-web/src/components/form-runtime.tsx
@@ -790,6 +790,80 @@ function Input({
         </div>
       );
     }
+    case 'likert': {
+      const points = q.points ?? 5;
+      const cur = typeof value === 'number' ? value : 0;
+      return (
+        <div>
+          <div
+            className="grid items-center gap-1 rounded-md border border-border bg-surface-1 p-2"
+            style={{ gridTemplateColumns: `repeat(${points}, 1fr)` }}
+          >
+            {Array.from({ length: points }, (_, i) => i + 1).map((n) => (
+              <button
+                type="button"
+                key={n}
+                disabled={readOnly}
+                onClick={() => onChange(n)}
+                className={`flex h-11 items-center justify-center rounded-md border text-sm tabular-nums ${
+                  cur === n
+                    ? 'border-accent bg-accent/10 text-accent font-medium'
+                    : 'border-border bg-surface-1 hover:bg-surface-2'
+                }`}
+                aria-label={`Point ${n} of ${points}`}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+          <div className="mt-1 flex items-center justify-between text-[11px] text-muted">
+            <span>{q.leftLabel ?? ''}</span>
+            {q.centerLabel ? <span>{q.centerLabel}</span> : null}
+            <span>{q.rightLabel ?? ''}</span>
+          </div>
+        </div>
+      );
+    }
+    case 'nps': {
+      const cur = typeof value === 'number' ? value : -1;
+      // NPS scoring: 0..6 detractor (red), 7..8 passive (amber),
+      // 9..10 promoter (green). The fill colors track those bands so
+      // the respondent's choice maps visually to the score they're
+      // giving.
+      function bandClass(n: number, selected: boolean): string {
+        if (!selected) {
+          return 'border-border bg-surface-1 hover:bg-surface-2 text-ink-1';
+        }
+        if (n <= 6) return 'border-danger bg-danger/15 text-danger font-medium';
+        if (n <= 8) return 'border-warning bg-warning/15 text-warning font-medium';
+        return 'border-success bg-success/15 text-success font-medium';
+      }
+      return (
+        <div>
+          {q.caption ? (
+            <p className="mb-1 text-xs text-muted">{q.caption}</p>
+          ) : null}
+          <div className="grid grid-cols-11 gap-1">
+            {Array.from({ length: 11 }, (_, n) => (
+              <button
+                type="button"
+                key={n}
+                disabled={readOnly}
+                onClick={() => onChange(n)}
+                className={`flex h-10 items-center justify-center rounded-md border text-sm tabular-nums ${bandClass(n, cur === n)}`}
+                aria-label={`${n}`}
+              >
+                {n}
+              </button>
+            ))}
+          </div>
+          <div className="mt-1 flex justify-between text-[11px] text-muted">
+            <span>Not at all likely</span>
+            <span>Extremely likely</span>
+          </div>
+        </div>
+      );
+    }
     case 'slider': {
       const cur = typeof value === 'number' ? value : q.min;
       return (
@@ -1671,7 +1745,9 @@ function packIntoRows(qs: Question[]): Question[][] {
       q.type === 'matrix-multi' ||
       q.type === 'matrix-dropdown' ||
       q.type === 'matrix-rating' ||
-      q.type === 'ranking';
+      q.type === 'ranking' ||
+      q.type === 'likert' ||
+      q.type === 'nps';
     const w = widthFraction(q.layout?.width);
     if (isStandalone || w === 1) {
       flush();

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -75,6 +75,8 @@ export const QUESTION_TYPES = [
   'geotrace', // polyline
   'geoshape', // polygon
   'rating', // 1-5 stars (or configurable max)
+  'likert', // single-row Likert (Strongly disagree -> Strongly agree)
+  'nps', // Net Promoter Score (0..10 buttons)
   'slider', // numeric range slider
   'calculated', // read-only, derived from `calculate` expression
   'note', // display-only static text (no value captured)
@@ -473,6 +475,36 @@ interface RatingQuestion extends QuestionBase {
   shape?: 'star' | 'heart' | 'thumb';
 }
 
+/**
+ * Single-row Likert scale. Today this is doable with `select-one`
+ * plus careful labeling, but a first-class type lets the runtime
+ * render a canonical horizontal scale and lets future analytics
+ * treat the value as ordinal rather than categorical.
+ *
+ * Response: the index of the chosen point (1..points), or null.
+ */
+interface LikertQuestion extends QuestionBase {
+  type: 'likert';
+  /** Number of points. Common values: 5 or 7. Default 5. */
+  points?: number;
+  /** Label for the leftmost point. */
+  leftLabel?: string;
+  /** Label for the rightmost point. */
+  rightLabel?: string;
+  /** Optional middle label (shown above the centre point). */
+  centerLabel?: string;
+}
+
+/**
+ * Net Promoter Score: 0..10 buttons with the standard
+ * Detractor / Passive / Promoter coloring. Captured as integer.
+ */
+interface NpsQuestion extends QuestionBase {
+  type: 'nps';
+  /** Optional caption above the scale (e.g. "How likely..."). */
+  caption?: string;
+}
+
 interface SliderQuestion extends QuestionBase {
   type: 'slider';
   min: number;
@@ -546,6 +578,8 @@ export type Question =
   | GeoTraceQuestion
   | GeoShapeQuestion
   | RatingQuestion
+  | LikertQuestion
+  | NpsQuestion
   | SliderQuestion
   | CalculatedQuestion
   | NoteQuestion
@@ -1192,6 +1226,21 @@ function validateType(q: Question, value: unknown): string | null {
     case 'slider':
     case 'calculated':
       return null;
+    case 'likert': {
+      if (typeof value !== 'number' || !Number.isInteger(value)) {
+        return 'Pick a point on the scale.';
+      }
+      const points = q.points ?? 5;
+      if (value < 1 || value > points) return 'Pick a point on the scale.';
+      return null;
+    }
+    case 'nps': {
+      if (typeof value !== 'number' || !Number.isInteger(value)) {
+        return 'Pick a number from 0 to 10.';
+      }
+      if (value < 0 || value > 10) return 'Pick a number from 0 to 10.';
+      return null;
+    }
     default:
       return null;
   }
@@ -1398,6 +1447,16 @@ export function defaultQuestion(type: QuestionType, id: QuestionId): Question {
       return { ...base, type };
     case 'rating':
       return { ...base, type, max: 5, shape: 'star' };
+    case 'likert':
+      return {
+        ...base,
+        type,
+        points: 5,
+        leftLabel: 'Strongly disagree',
+        rightLabel: 'Strongly agree',
+      };
+    case 'nps':
+      return { ...base, type };
     case 'slider':
       return { ...base, type, min: 0, max: 100, step: 1, showValue: true };
     case 'calculated':
@@ -1446,6 +1505,8 @@ function defaultLabel(type: QuestionType): string {
       geotrace: 'Path (polyline)',
       geoshape: 'Area (polygon)',
       rating: 'Rating',
+      likert: 'Likert',
+      nps: 'NPS (0-10)',
       slider: 'Slider',
       calculated: 'Calculated',
       note: 'Note',


### PR DESCRIPTION
## Summary

Slice 4 of the question-type expansion (#145). Promotes Likert and NPS
from "build it yourself with select-one" to first-class types.

## What ships

### Schema (`packages/form-schema`)

- `likert`: `points` (default 5), `leftLabel`, `rightLabel`,
  optional `centerLabel`. Response is the integer index 1..points.
- `nps`: optional `caption`. Response is the integer 0..10.
- Validators: integer + range checks.

### Runtime (`form-runtime.tsx`)

- Likert: row of N anchor buttons with the anchor labels under the
  row, layout via CSS grid so 5-point and 7-point both feel
  proportional.
- NPS: 11 buttons (0..10) using `bg-danger` / `bg-warning` /
  `bg-success` bands so the chosen number visually maps to its
  detractor / passive / promoter score.
- packIntoRows treats both as standalone rows.

### Designer (`designer.tsx`)

- Palette: likert and nps in the Scale group with Sliders / BarChart3
  icons.
- Properties: Likert exposes points, leftLabel, rightLabel,
  centerLabel; NPS exposes caption.

## Quality gate

`pnpm typecheck`, `pnpm lint`, `pnpm test` all clean. Stacked on top
of #17 (slice 3); rebased onto main after that merged.
