### PR TITLE
feat(forms): name + address composite types (#145)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -17,6 +17,7 @@ import {
   Grid3x3,
   GripVertical,
   Hash,
+  Home,
   Link,
   ListOrdered,
   ListChecks,
@@ -36,6 +37,7 @@ import {
   Trash2,
   Type,
   Upload,
+  User,
   Workflow,
   X,
 } from 'lucide-react';
@@ -579,6 +581,7 @@ type PaletteGroup =
   | 'matrix'
   | 'scale'
   | 'time'
+  | 'identity'
   | 'media'
   | 'spatial'
   | 'logic'
@@ -601,6 +604,7 @@ const PALETTE_GROUPS: { id: PaletteGroup; label: string }[] = [
   { id: 'matrix', label: 'Matrix' },
   { id: 'scale', label: 'Scale' },
   { id: 'time', label: 'Date & time' },
+  { id: 'identity', label: 'Identity' },
   { id: 'media', label: 'Media' },
   { id: 'spatial', label: 'Geometry' },
   { id: 'logic', label: 'Logic' },
@@ -631,6 +635,8 @@ const PALETTE: PaletteEntry[] = [
   { type: 'date', label: 'Date', icon: Calendar, group: 'time' },
   { type: 'time', label: 'Time', icon: Clock, group: 'time' },
   { type: 'datetime', label: 'Date + time', icon: CalendarClock, group: 'time' },
+  { type: 'name', label: 'Full name', icon: User, group: 'identity' },
+  { type: 'address', label: 'Address', icon: Home, group: 'identity' },
   { type: 'photo', label: 'Photo', icon: Camera, group: 'media' },
   { type: 'signature', label: 'Signature', icon: Type, group: 'media' },
   { type: 'geopoint', label: 'Location', icon: MapPin, group: 'spatial' },
@@ -1480,6 +1486,66 @@ function Properties({
         </Field>
       ) : null}
 
+      {question.type === 'name' ? (
+        <ComponentToggleEditor
+          label="Components"
+          allComponents={[
+            { value: 'prefix', label: 'Prefix' },
+            { value: 'first', label: 'First name' },
+            { value: 'middle', label: 'Middle name' },
+            { value: 'last', label: 'Last name' },
+            { value: 'suffix', label: 'Suffix' },
+          ]}
+          components={question.components ?? ['first', 'last']}
+          requiredComponents={question.requiredComponents}
+          canEdit={canEdit}
+          onChangeComponents={(components) =>
+            onChange({ components } as Partial<Question>)
+          }
+          onChangeRequired={(requiredComponents) =>
+            onChange({
+              requiredComponents:
+                requiredComponents.length === 0 ? undefined : requiredComponents,
+            } as Partial<Question>)
+          }
+        />
+      ) : null}
+
+      {question.type === 'address' ? (
+        <ComponentToggleEditor
+          label="Components"
+          allComponents={[
+            { value: 'street1', label: 'Street address' },
+            { value: 'street2', label: 'Apt / suite' },
+            { value: 'city', label: 'City' },
+            { value: 'region', label: 'State / region' },
+            { value: 'postal', label: 'Postal code' },
+            { value: 'country', label: 'Country' },
+          ]}
+          components={
+            question.components ?? [
+              'street1',
+              'street2',
+              'city',
+              'region',
+              'postal',
+              'country',
+            ]
+          }
+          requiredComponents={question.requiredComponents}
+          canEdit={canEdit}
+          onChangeComponents={(components) =>
+            onChange({ components } as Partial<Question>)
+          }
+          onChangeRequired={(requiredComponents) =>
+            onChange({
+              requiredComponents:
+                requiredComponents.length === 0 ? undefined : requiredComponents,
+            } as Partial<Question>)
+          }
+        />
+      ) : null}
+
       <details className="mt-3 rounded-md border border-border bg-surface-1 p-2 text-xs">
         <summary className="cursor-pointer text-muted">Conditional logic</summary>
         <div className="mt-2 space-y-2">
@@ -2045,6 +2111,87 @@ function MatrixDropdownEditor({
             </button>
           ) : null}
         </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Toggle which components a composite question (name / address)
+ * surfaces, plus which of those are required. Two checkboxes per
+ * row: "Show" and "Required". Required implies Show.
+ */
+function ComponentToggleEditor<T extends string>({
+  label,
+  allComponents,
+  components,
+  requiredComponents,
+  canEdit,
+  onChangeComponents,
+  onChangeRequired,
+}: {
+  label: string;
+  allComponents: { value: T; label: string }[];
+  components: T[];
+  requiredComponents: T[] | undefined;
+  canEdit: boolean;
+  onChangeComponents: (next: T[]) => void;
+  onChangeRequired: (next: T[]) => void;
+}) {
+  const shown = new Set(components);
+  const required = new Set(requiredComponents ?? []);
+  return (
+    <div className="mb-3">
+      <p className="mb-1 text-[10px] uppercase tracking-wide text-muted">
+        {label}
+      </p>
+      <div className="space-y-1">
+        {allComponents.map((c) => (
+          <div key={c.value} className="flex items-center justify-between gap-2 text-xs">
+            <span className="flex-1 truncate">{c.label}</span>
+            <label className="inline-flex items-center gap-1 text-[11px]">
+              <input
+                type="checkbox"
+                checked={shown.has(c.value)}
+                disabled={!canEdit}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    onChangeComponents([
+                      ...allComponents
+                        .map((x) => x.value)
+                        .filter((v) => shown.has(v) || v === c.value),
+                    ]);
+                  } else {
+                    onChangeComponents(components.filter((v) => v !== c.value));
+                    if (required.has(c.value)) {
+                      onChangeRequired(
+                        Array.from(required).filter((v) => v !== c.value),
+                      );
+                    }
+                  }
+                }}
+              />
+              <span>Show</span>
+            </label>
+            <label className="inline-flex items-center gap-1 text-[11px]">
+              <input
+                type="checkbox"
+                checked={required.has(c.value)}
+                disabled={!canEdit || !shown.has(c.value)}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    onChangeRequired([...Array.from(required), c.value]);
+                  } else {
+                    onChangeRequired(
+                      Array.from(required).filter((v) => v !== c.value),
+                    );
+                  }
+                }}
+              />
+              <span>Required</span>
+            </label>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/apps/portal-web/src/components/form-runtime.tsx
+++ b/apps/portal-web/src/components/form-runtime.tsx
@@ -19,6 +19,8 @@ import {
   evaluate,
   isRequired,
   isVisible,
+  labelForAddressComponent,
+  labelForNameComponent,
   pruneHidden,
   validate,
   walkQuestions,
@@ -750,6 +752,10 @@ function Input({
           className={baseClass}
         />
       );
+    case 'name':
+      return <NameInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
+    case 'address':
+      return <AddressInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
     case 'photo':
       return <PhotoInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
     case 'signature':
@@ -959,6 +965,159 @@ function PhotoInput({
       <p className="text-[11px] text-muted">
         {photos.length} of {max} {max === 1 ? 'photo' : 'photos'}
       </p>
+    </div>
+  );
+}
+
+/**
+ * Composite name input. Renders one labeled <input> per requested
+ * component; lays them out in a responsive grid that collapses on
+ * mobile. The `prefix` and `suffix` cells stay narrow when shown.
+ */
+function NameInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'name' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  const components = q.components ?? ['first', 'last'];
+  const map: Record<string, string> =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, string>)
+      : {};
+
+  function set(component: string, raw: string) {
+    const next = { ...map };
+    if (raw === '') delete next[component];
+    else next[component] = raw;
+    onChange(Object.keys(next).length === 0 ? null : next);
+  }
+
+  // Two-column on sm+: prefix / first / middle / last / suffix in a
+  // sane shape. We use a 6-col grid where prefix/suffix span 1, the
+  // name cells span 2.
+  function spanFor(c: string): string {
+    if (c === 'prefix' || c === 'suffix') return 'sm:col-span-1';
+    return 'sm:col-span-2';
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-6">
+      {components.map((c) => (
+        <label key={c} className={`flex flex-col gap-1 ${spanFor(c)}`}>
+          <span className="text-[11px] text-muted">
+            {labelForNameComponent(c)}
+          </span>
+          <input
+            type="text"
+            value={map[c] ?? ''}
+            disabled={readOnly}
+            autoComplete={
+              c === 'first'
+                ? 'given-name'
+                : c === 'last'
+                  ? 'family-name'
+                  : c === 'middle'
+                    ? 'additional-name'
+                    : c === 'prefix'
+                      ? 'honorific-prefix'
+                      : c === 'suffix'
+                        ? 'honorific-suffix'
+                        : 'off'
+            }
+            onChange={(e) => set(c, e.target.value)}
+            className="h-11 w-full rounded-md border border-border bg-surface-1 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
+          />
+        </label>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * Composite postal address input. Components are rendered in a
+ * sensible form layout (street1/2 stack full-width, city/region/postal
+ * share a row on sm+, country full-width).
+ */
+function AddressInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'address' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  const components =
+    q.components ?? ['street1', 'street2', 'city', 'region', 'postal', 'country'];
+  const map: Record<string, string> =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, string>)
+      : {};
+
+  function set(component: string, raw: string) {
+    const next = { ...map };
+    if (raw === '') delete next[component];
+    else next[component] = raw;
+    onChange(Object.keys(next).length === 0 ? null : next);
+  }
+
+  // Map component to its grid placement. We use a 6-col grid:
+  // street1, street2, country: full row
+  // city: 3, region: 2, postal: 1 -- the standard US-style row.
+  function spanFor(c: string): string {
+    if (c === 'street1' || c === 'street2' || c === 'country') {
+      return 'sm:col-span-6';
+    }
+    if (c === 'city') return 'sm:col-span-3';
+    if (c === 'region') return 'sm:col-span-2';
+    if (c === 'postal') return 'sm:col-span-1';
+    return 'sm:col-span-6';
+  }
+
+  function autoFor(c: string): string {
+    switch (c) {
+      case 'street1':
+        return 'address-line1';
+      case 'street2':
+        return 'address-line2';
+      case 'city':
+        return 'address-level2';
+      case 'region':
+        return 'address-level1';
+      case 'postal':
+        return 'postal-code';
+      case 'country':
+        return 'country-name';
+      default:
+        return 'off';
+    }
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-6">
+      {components.map((c) => (
+        <label key={c} className={`flex flex-col gap-1 ${spanFor(c)}`}>
+          <span className="text-[11px] text-muted">
+            {labelForAddressComponent(c)}
+          </span>
+          <input
+            type="text"
+            value={map[c] ?? ''}
+            disabled={readOnly}
+            autoComplete={autoFor(c)}
+            onChange={(e) => set(c, e.target.value)}
+            className="h-11 w-full rounded-md border border-border bg-surface-1 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
+          />
+        </label>
+      ))}
     </div>
   );
 }
@@ -1747,7 +1906,9 @@ function packIntoRows(qs: Question[]): Question[][] {
       q.type === 'matrix-rating' ||
       q.type === 'ranking' ||
       q.type === 'likert' ||
-      q.type === 'nps';
+      q.type === 'nps' ||
+      q.type === 'name' ||
+      q.type === 'address';
     const w = widthFraction(q.layout?.width);
     if (isStandalone || w === 1) {
       flush();

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -69,6 +69,8 @@ export const QUESTION_TYPES = [
   'date', // calendar date
   'time', // wall-clock time
   'datetime', // calendar + clock
+  'name', // composite person name (first / middle / last / suffix / prefix)
+  'address', // composite postal address
   'photo', // one or more image attachments
   'signature', // ink-on-canvas, stored as PNG
   'geopoint', // single lat/lon
@@ -437,6 +439,51 @@ interface DateTimeQuestion extends QuestionBase {
   max?: string;
 }
 
+/** Components a `name` question can request. The renderer hides
+ *  components not in this set (or all six when omitted). */
+export type NameComponent =
+  | 'prefix'
+  | 'first'
+  | 'middle'
+  | 'last'
+  | 'suffix';
+
+/**
+ * Composite person name. Captures named subfields. Response shape:
+ * `{ prefix?, first?, middle?, last?, suffix? }` -- all optional
+ * strings. The form-level `required` flag means at least one of the
+ * required components must be filled.
+ */
+interface NameQuestion extends QuestionBase {
+  type: 'name';
+  /** Which components to surface. Default: ['first', 'last']. */
+  components?: NameComponent[];
+  /** Required components. Defaults to ['first', 'last'] when the
+   *  question is required. Hidden when the question is optional. */
+  requiredComponents?: NameComponent[];
+}
+
+/** Components an `address` question can request. */
+export type AddressComponent =
+  | 'street1'
+  | 'street2'
+  | 'city'
+  | 'region'
+  | 'postal'
+  | 'country';
+
+/**
+ * Composite postal address. Response shape:
+ * `{ street1?, street2?, city?, region?, postal?, country? }` --
+ * all optional strings. The renderer hides components not in
+ * `components`.
+ */
+interface AddressQuestion extends QuestionBase {
+  type: 'address';
+  components?: AddressComponent[];
+  requiredComponents?: AddressComponent[];
+}
+
 interface PhotoQuestion extends QuestionBase {
   type: 'photo';
   /** Max number of attachments. Default 1. */
@@ -572,6 +619,8 @@ export type Question =
   | DateQuestion
   | TimeQuestion
   | DateTimeQuestion
+  | NameQuestion
+  | AddressQuestion
   | PhotoQuestion
   | SignatureQuestion
   | GeoPointQuestion
@@ -965,6 +1014,41 @@ export function isRequired(q: Question, response: Response): boolean {
   return Boolean(evaluate(q.required, response));
 }
 
+/** Human label for a NameComponent. Exported because the runtime
+ *  uses it for placeholders too. */
+export function labelForNameComponent(c: NameComponent): string {
+  switch (c) {
+    case 'prefix':
+      return 'Prefix';
+    case 'first':
+      return 'First name';
+    case 'middle':
+      return 'Middle name';
+    case 'last':
+      return 'Last name';
+    case 'suffix':
+      return 'Suffix';
+  }
+}
+
+/** Human label for an AddressComponent. */
+export function labelForAddressComponent(c: AddressComponent): string {
+  switch (c) {
+    case 'street1':
+      return 'Street address';
+    case 'street2':
+      return 'Apt / suite';
+    case 'city':
+      return 'City';
+    case 'region':
+      return 'State / region';
+    case 'postal':
+      return 'Postal code';
+    case 'country':
+      return 'Country';
+  }
+}
+
 function isEmpty(value: unknown): boolean {
   if (value === null || value === undefined) return true;
   if (typeof value === 'string') return value.trim() === '';
@@ -1212,6 +1296,34 @@ function validateType(q: Question, value: unknown): string | null {
     case 'datetime':
       if (typeof value !== 'string') return 'Expected a valid value.';
       return null;
+    case 'name': {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return 'Expected a name object.';
+      }
+      const map = value as Record<string, unknown>;
+      const reqd = q.requiredComponents ?? (q.required ? ['first', 'last'] : []);
+      for (const c of reqd) {
+        const v = map[c];
+        if (typeof v !== 'string' || v.trim() === '') {
+          return `${labelForNameComponent(c)} is required.`;
+        }
+      }
+      return null;
+    }
+    case 'address': {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return 'Expected an address object.';
+      }
+      const map = value as Record<string, unknown>;
+      const reqd = q.requiredComponents ?? [];
+      for (const c of reqd) {
+        const v = map[c];
+        if (typeof v !== 'string' || v.trim() === '') {
+          return `${labelForAddressComponent(c)} is required.`;
+        }
+      }
+      return null;
+    }
     case 'photo':
       if (!Array.isArray(value)) return 'Expected one or more attachments.';
       if (q.maxCount !== undefined && value.length > q.maxCount) {
@@ -1435,6 +1547,14 @@ export function defaultQuestion(type: QuestionType, id: QuestionId): Question {
       return { ...base, type };
     case 'datetime':
       return { ...base, type };
+    case 'name':
+      return { ...base, type, components: ['first', 'last'] };
+    case 'address':
+      return {
+        ...base,
+        type,
+        components: ['street1', 'street2', 'city', 'region', 'postal', 'country'],
+      };
     case 'photo':
       return { ...base, type, maxCount: 1 };
     case 'signature':
@@ -1499,6 +1619,8 @@ function defaultLabel(type: QuestionType): string {
       date: 'Date',
       time: 'Time',
       datetime: 'Date and time',
+      name: 'Full name',
+      address: 'Address',
       photo: 'Photo',
       signature: 'Signature',
       geopoint: 'Location (point)',


### PR DESCRIPTION
## Summary

Slice 5 of the question-type expansion (#145). Two composite types
every general-purpose form product ships -- a multipart name input
and a multipart address input. Captured as one logical question with
an object-shaped response so the data layer can map sub-components
back to discrete columns when the form is bound to a layer.

## What ships

### Schema (`packages/form-schema`)

- `name`: `NameComponent` union (prefix / first / middle / last /
  suffix). `components[]` picks which to surface (default first +
  last); `requiredComponents[]` picks which to require.
- `address`: `AddressComponent` union (street1 / street2 / city /
  region / postal / country) with the same components / required
  API.
- Validators check that required components are non-empty strings.

### Runtime (`form-runtime.tsx`)

- `NameInput`: 6-col grid on `sm+` where prefix/suffix span 1 cell
  and the three name parts span 2; stacks on mobile. autoComplete
  is set to the right WHATWG token per cell so iOS / Android can
  auto-fill from the address book.
- `AddressInput`: 6-col grid where street1/2 + country are
  full-width and city/region/postal share a row 3/2/1.
  autoComplete uses the WHATWG `address-line1` etc. tokens so OS
  autofill can fill the whole address from a single suggestion.
- packIntoRows treats both as standalone rows.

### Designer (`designer.tsx`)

- New "Identity" palette group: Full name + Address.
- Properties: a generic `ComponentToggleEditor` with two checkboxes
  per row -- Show + Required. Required implies Show.

## Quality gate

`pnpm typecheck`, `pnpm lint`, `pnpm test` all clean. Stacked on top
of #18 (slice 4); rebased onto main after that merged.
