### PR TITLE
feat(forms): image-choice + image-display + image-hotspot (#145)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -11,6 +11,7 @@ import {
   CheckSquare,
   Circle,
   Clock,
+  Crosshair,
   Database,
   Download,
   Eye,
@@ -18,6 +19,7 @@ import {
   GripVertical,
   Hash,
   Home,
+  Image,
   Link,
   ListOrdered,
   ListChecks,
@@ -638,6 +640,9 @@ const PALETTE: PaletteEntry[] = [
   { type: 'name', label: 'Full name', icon: User, group: 'identity' },
   { type: 'address', label: 'Address', icon: Home, group: 'identity' },
   { type: 'photo', label: 'Photo', icon: Camera, group: 'media' },
+  { type: 'image-choice', label: 'Image choice', icon: Image, group: 'media' },
+  { type: 'image-display', label: 'Image', icon: Image, group: 'media' },
+  { type: 'image-hotspot', label: 'Image hotspot', icon: Crosshair, group: 'media' },
   { type: 'signature', label: 'Signature', icon: Type, group: 'media' },
   { type: 'geopoint', label: 'Location', icon: MapPin, group: 'spatial' },
   { type: 'geotrace', label: 'Path', icon: SplitSquareHorizontal, group: 'spatial' },
@@ -1511,6 +1516,71 @@ function Properties({
         />
       ) : null}
 
+      {question.type === 'image-display' || question.type === 'image-hotspot' ? (
+        <Field label="Image URL">
+          <input
+            type="url"
+            value={question.imageUrl}
+            disabled={!canEdit}
+            onChange={(e) =>
+              onChange({ imageUrl: e.target.value } as Partial<Question>)
+            }
+            className={inputCls}
+          />
+        </Field>
+      ) : null}
+
+      {question.type === 'image-display' ? (
+        <Field label="Caption">
+          <input
+            type="text"
+            value={question.caption ?? ''}
+            disabled={!canEdit}
+            onChange={(e) =>
+              onChange({ caption: e.target.value || undefined } as Partial<Question>)
+            }
+            className={inputCls}
+          />
+        </Field>
+      ) : null}
+
+      {question.type === 'image-hotspot' ? (
+        <Field label="Max points">
+          <input
+            type="number"
+            min={1}
+            max={50}
+            value={question.maxPoints ?? 1}
+            disabled={!canEdit}
+            onChange={(e) =>
+              onChange({ maxPoints: Number(e.target.value) } as Partial<Question>)
+            }
+            className={inputCls}
+          />
+        </Field>
+      ) : null}
+
+      {question.type === 'image-choice' ? (
+        <>
+          <label className="mb-2 inline-flex items-center gap-2 text-xs">
+            <input
+              type="checkbox"
+              checked={Boolean(question.multi)}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({ multi: e.target.checked } as Partial<Question>)
+              }
+            />
+            <span>Allow multiple selections</span>
+          </label>
+          <ImageChoicesEditor
+            choices={question.choices}
+            canEdit={canEdit}
+            onChange={(choices) => onChange({ choices } as Partial<Question>)}
+          />
+        </>
+      ) : null}
+
       {question.type === 'address' ? (
         <ComponentToggleEditor
           label="Components"
@@ -2121,6 +2191,108 @@ function MatrixDropdownEditor({
  * surfaces, plus which of those are required. Two checkboxes per
  * row: "Show" and "Required". Required implies Show.
  */
+/**
+ * Variant of ChoicesEditor that exposes an `imageUrl` per choice
+ * (and optional alt text). Same value/label inputs sit on the top
+ * row, image URL underneath.
+ */
+function ImageChoicesEditor({
+  choices,
+  canEdit,
+  onChange,
+}: {
+  choices: { value: string; label: string; imageUrl: string; alt?: string }[];
+  canEdit: boolean;
+  onChange: (next: typeof choices) => void;
+}) {
+  return (
+    <div className="mb-2">
+      <p className="mb-1 text-[10px] uppercase tracking-wide text-muted">
+        Image choices
+      </p>
+      <div className="space-y-2">
+        {choices.map((c, i) => (
+          <div key={i} className="rounded-md border border-border bg-surface-1 p-2">
+            <div className="mb-1 flex items-center gap-1">
+              <input
+                type="text"
+                value={c.value}
+                placeholder="value"
+                disabled={!canEdit}
+                onChange={(e) =>
+                  onChange(
+                    choices.map((cc, ii) =>
+                      ii === i ? { ...cc, value: e.target.value } : cc,
+                    ),
+                  )
+                }
+                className={`${inputCls} font-mono w-24`}
+              />
+              <input
+                type="text"
+                value={c.label}
+                placeholder="label"
+                disabled={!canEdit}
+                onChange={(e) =>
+                  onChange(
+                    choices.map((cc, ii) =>
+                      ii === i ? { ...cc, label: e.target.value } : cc,
+                    ),
+                  )
+                }
+                className={`${inputCls} flex-1`}
+              />
+              {canEdit ? (
+                <button
+                  type="button"
+                  onClick={() => onChange(choices.filter((_, ii) => ii !== i))}
+                  className="rounded p-1 text-muted hover:bg-surface-2 hover:text-danger"
+                  aria-label="Remove choice"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </button>
+              ) : null}
+            </div>
+            <input
+              type="url"
+              value={c.imageUrl}
+              placeholder="https://example.com/image.jpg"
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange(
+                  choices.map((cc, ii) =>
+                    ii === i ? { ...cc, imageUrl: e.target.value } : cc,
+                  ),
+                )
+              }
+              className={inputCls}
+            />
+          </div>
+        ))}
+        {canEdit ? (
+          <button
+            type="button"
+            onClick={() =>
+              onChange([
+                ...choices,
+                {
+                  value: `option_${choices.length + 1}`,
+                  label: `Option ${choices.length + 1}`,
+                  imageUrl: '',
+                },
+              ])
+            }
+            className="inline-flex h-7 items-center gap-1 rounded-md border border-dashed border-border bg-surface-1 px-2 text-[11px] text-ink-1 hover:bg-surface-2"
+          >
+            <Plus className="h-3 w-3" />
+            Add choice
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 function ComponentToggleEditor<T extends string>({
   label,
   allComponents,

--- a/apps/portal-web/src/components/form-runtime.tsx
+++ b/apps/portal-web/src/components/form-runtime.tsx
@@ -758,6 +758,26 @@ function Input({
       return <AddressInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
     case 'photo':
       return <PhotoInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
+    case 'image-choice':
+      return (
+        <ImageChoiceInput
+          q={q}
+          value={value}
+          readOnly={readOnly}
+          onChange={onChange}
+        />
+      );
+    case 'image-display':
+      return <ImageDisplay q={q} />;
+    case 'image-hotspot':
+      return (
+        <ImageHotspotInput
+          q={q}
+          value={value}
+          readOnly={readOnly}
+          onChange={onChange}
+        />
+      );
     case 'signature':
       return (
         <div className="rounded-md border border-dashed border-border bg-surface-2/30 p-4 text-center text-xs text-muted">
@@ -974,6 +994,209 @@ function PhotoInput({
  * component; lays them out in a responsive grid that collapses on
  * mobile. The `prefix` and `suffix` cells stay narrow when shown.
  */
+/**
+ * Image-choice: a grid of clickable thumbnails. Single or multi
+ * select per `q.multi`. The whole tile is the click target so
+ * touch users don't have to hit a small radio.
+ */
+function ImageChoiceInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'image-choice' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  const multi = Boolean(q.multi);
+  const arr: string[] = Array.isArray(value) ? (value as string[]) : [];
+  const single: string | null = typeof value === 'string' ? value : null;
+
+  function toggle(v: string) {
+    if (readOnly) return;
+    if (multi) {
+      onChange(arr.includes(v) ? arr.filter((x) => x !== v) : [...arr, v]);
+    } else {
+      onChange(single === v ? null : v);
+    }
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
+      {q.choices.map((c) => {
+        const selected = multi ? arr.includes(c.value) : single === c.value;
+        return (
+          <button
+            type="button"
+            key={c.value}
+            onClick={() => toggle(c.value)}
+            disabled={readOnly}
+            className={`group flex flex-col overflow-hidden rounded-md border text-left text-xs ${
+              selected
+                ? 'border-accent ring-2 ring-accent/40'
+                : 'border-border hover:border-accent/50'
+            }`}
+          >
+            <div className="aspect-square w-full bg-surface-2 sm:aspect-[4/3]">
+              {c.imageUrl ? (
+                /* eslint-disable-next-line @next/next/no-img-element */
+                <img
+                  src={c.imageUrl}
+                  alt={c.alt ?? c.label}
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-[11px] text-muted">
+                  No image
+                </div>
+              )}
+            </div>
+            <div
+              className={`px-2 py-1.5 ${selected ? 'bg-accent/10 text-accent' : 'bg-surface-1 text-ink-1'}`}
+            >
+              {c.label}
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Image-display: a static image embed. No value captured. Used as
+ * instructional content; the runtime walker treats this as a
+ * non-input question.
+ */
+function ImageDisplay({
+  q,
+}: {
+  q: Extract<Question, { type: 'image-display' }>;
+}) {
+  if (!q.imageUrl) {
+    return (
+      <div className="rounded-md border border-dashed border-border bg-surface-2/30 p-4 text-center text-xs text-muted">
+        No image set.
+      </div>
+    );
+  }
+  return (
+    <figure className="overflow-hidden rounded-md border border-border bg-surface-1">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={q.imageUrl}
+        alt={q.alt ?? q.label}
+        className="block h-auto w-full object-contain"
+      />
+      {q.caption ? (
+        <figcaption className="border-t border-border bg-surface-2/40 px-3 py-1.5 text-[11px] text-muted">
+          {q.caption}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}
+
+/**
+ * Image-hotspot: respondent clicks one or more points on the
+ * reference image. Coordinates are stored as fractions of the
+ * image's natural size so they survive resizes.
+ */
+function ImageHotspotInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'image-hotspot' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  const points: { x: number; y: number }[] = Array.isArray(value)
+    ? (value as { x: number; y: number }[]).filter(
+        (p): p is { x: number; y: number } =>
+          p !== null &&
+          typeof p === 'object' &&
+          typeof (p as { x: unknown }).x === 'number' &&
+          typeof (p as { y: unknown }).y === 'number',
+      )
+    : [];
+  const max = q.maxPoints ?? 1;
+
+  function addPoint(e: React.MouseEvent<HTMLDivElement>) {
+    if (readOnly) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return;
+    const x = (e.clientX - rect.left) / rect.width;
+    const y = (e.clientY - rect.top) / rect.height;
+    if (max <= 1) {
+      onChange([{ x, y }]);
+    } else {
+      const next = [...points, { x, y }];
+      onChange(next.slice(-max));
+    }
+  }
+
+  function clearPoints() {
+    if (readOnly) return;
+    onChange([]);
+  }
+
+  if (!q.imageUrl) {
+    return (
+      <div className="rounded-md border border-dashed border-border bg-surface-2/30 p-4 text-center text-xs text-muted">
+        Set an image URL in the question Properties to enable hotspot
+        capture.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div
+        onClick={addPoint}
+        className="relative inline-block w-full cursor-crosshair overflow-hidden rounded-md border border-border bg-surface-1"
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={q.imageUrl}
+          alt={q.alt ?? q.label}
+          className="block h-auto w-full select-none object-contain"
+          draggable={false}
+        />
+        {points.map((p, i) => (
+          <div
+            key={i}
+            style={{ left: `${p.x * 100}%`, top: `${p.y * 100}%` }}
+            className="pointer-events-none absolute -translate-x-1/2 -translate-y-1/2"
+          >
+            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-accent text-[10px] font-medium text-white shadow">
+              {i + 1}
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center justify-between text-[11px] text-muted">
+        <span>
+          {points.length} of {max} {max === 1 ? 'point' : 'points'} placed
+        </span>
+        {!readOnly && points.length > 0 ? (
+          <button
+            type="button"
+            onClick={clearPoints}
+            className="rounded-md border border-border bg-surface-1 px-2 py-1 text-xs hover:bg-surface-2"
+          >
+            Clear
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
 function NameInput({
   q,
   value,
@@ -1908,7 +2131,9 @@ function packIntoRows(qs: Question[]): Question[][] {
       q.type === 'likert' ||
       q.type === 'nps' ||
       q.type === 'name' ||
-      q.type === 'address';
+      q.type === 'address' ||
+      q.type === 'image-display' ||
+      q.type === 'image-hotspot';
     const w = widthFraction(q.layout?.width);
     if (isStandalone || w === 1) {
       flush();

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -72,6 +72,9 @@ export const QUESTION_TYPES = [
   'name', // composite person name (first / middle / last / suffix / prefix)
   'address', // composite postal address
   'photo', // one or more image attachments
+  'image-choice', // single/multi choice where each option is an image
+  'image-display', // display-only image embed (no value captured)
+  'image-hotspot', // click point(s) on a reference image
   'signature', // ink-on-canvas, stored as PNG
   'geopoint', // single lat/lon
   'geotrace', // polyline
@@ -492,6 +495,59 @@ interface PhotoQuestion extends QuestionBase {
   maxBytes?: number;
 }
 
+/** A choice-with-image. Same shape as Choice plus an imageUrl that
+ *  the runtime renders as the visual face of the option. */
+export interface ImageChoice {
+  value: string;
+  label: string;
+  imageUrl: string;
+  /** Optional alternate text. Falls back to `label`. */
+  alt?: string;
+}
+
+/**
+ * Image-choice question: the options are images. Set `multi` to
+ * allow more than one selection. Response shape:
+ *   - multi=false: chosen value (string) or null
+ *   - multi=true: chosen values (string[])
+ */
+interface ImageChoiceQuestion extends QuestionBase {
+  type: 'image-choice';
+  choices: ImageChoice[];
+  /** Default false: behaves like select-one. */
+  multi?: boolean;
+  /** Per-row only meaningful for multi=true. */
+  minSelected?: number;
+  maxSelected?: number;
+}
+
+/**
+ * Image-display question: a non-interactive image embed. No value
+ * is captured. Useful for instructional content above a question.
+ */
+interface ImageDisplayQuestion extends QuestionBase {
+  type: 'image-display';
+  imageUrl: string;
+  alt?: string;
+  /** Optional caption shown below the image. */
+  caption?: string;
+}
+
+/**
+ * Image-hotspot: respondent clicks one or more points on a
+ * reference image. Coordinates are captured as fractions of the
+ * image's natural size (so the value is resolution-independent).
+ *
+ * Response shape: Array<{ x: number; y: number }> in [0..1].
+ */
+interface ImageHotspotQuestion extends QuestionBase {
+  type: 'image-hotspot';
+  imageUrl: string;
+  alt?: string;
+  /** Maximum number of points the respondent may place. Default 1. */
+  maxPoints?: number;
+}
+
 interface SignatureQuestion extends QuestionBase {
   type: 'signature';
 }
@@ -622,6 +678,9 @@ export type Question =
   | NameQuestion
   | AddressQuestion
   | PhotoQuestion
+  | ImageChoiceQuestion
+  | ImageDisplayQuestion
+  | ImageHotspotQuestion
   | SignatureQuestion
   | GeoPointQuestion
   | GeoTraceQuestion
@@ -967,7 +1026,14 @@ export interface ValidationResult {
 export function validate(form: FormSchema, response: Response): ValidationResult {
   const errors: ValidationError[] = [];
   for (const q of walkQuestions(form)) {
-    if (q.type === 'page' || q.type === 'note' || q.type === 'group') continue;
+    if (
+      q.type === 'page' ||
+      q.type === 'note' ||
+      q.type === 'group' ||
+      q.type === 'image-display'
+    ) {
+      continue;
+    }
     if (!isVisible(q, response)) continue;
 
     const value = response[q.id];
@@ -1330,6 +1396,52 @@ function validateType(q: Question, value: unknown): string | null {
         return `Up to ${q.maxCount} attachments allowed.`;
       }
       return null;
+    case 'image-choice': {
+      const validValues = new Set(q.choices.map((c) => c.value));
+      if (q.multi) {
+        if (!Array.isArray(value)) return 'Pick one or more options.';
+        for (const v of value) {
+          if (typeof v !== 'string' || !validValues.has(v)) {
+            return 'Selection contains an unrecognized option.';
+          }
+        }
+        if (q.minSelected !== undefined && value.length < q.minSelected) {
+          return `Pick at least ${q.minSelected}.`;
+        }
+        if (q.maxSelected !== undefined && value.length > q.maxSelected) {
+          return `Pick at most ${q.maxSelected}.`;
+        }
+      } else {
+        if (typeof value !== 'string' || !validValues.has(value)) {
+          return 'Pick one option.';
+        }
+      }
+      return null;
+    }
+    case 'image-display':
+      // Display-only: no captured value to validate.
+      return null;
+    case 'image-hotspot': {
+      if (!Array.isArray(value)) return 'Expected one or more points.';
+      const max = q.maxPoints ?? 1;
+      if (value.length > max) return `Up to ${max} points allowed.`;
+      for (const p of value) {
+        if (
+          typeof p !== 'object' ||
+          p === null ||
+          typeof (p as { x: unknown }).x !== 'number' ||
+          typeof (p as { y: unknown }).y !== 'number'
+        ) {
+          return 'Point format is invalid.';
+        }
+        const x = (p as { x: number }).x;
+        const y = (p as { y: number }).y;
+        if (x < 0 || x > 1 || y < 0 || y > 1) {
+          return 'Point is outside the image.';
+        }
+      }
+      return null;
+    }
     case 'signature':
     case 'geopoint':
     case 'geotrace':
@@ -1395,7 +1507,14 @@ export function applyCalculations(
 export function pruneHidden(form: FormSchema, response: Response): Response {
   const out: Response = {};
   for (const q of walkQuestions(form)) {
-    if (q.type === 'page' || q.type === 'note' || q.type === 'group') continue;
+    if (
+      q.type === 'page' ||
+      q.type === 'note' ||
+      q.type === 'group' ||
+      q.type === 'image-display'
+    ) {
+      continue;
+    }
     if (!isVisible(q, response)) continue;
     if (q.id in response) out[q.id] = response[q.id];
   }
@@ -1557,6 +1676,19 @@ export function defaultQuestion(type: QuestionType, id: QuestionId): Question {
       };
     case 'photo':
       return { ...base, type, maxCount: 1 };
+    case 'image-choice':
+      return {
+        ...base,
+        type,
+        choices: [
+          { value: 'option_1', label: 'Option 1', imageUrl: '' },
+          { value: 'option_2', label: 'Option 2', imageUrl: '' },
+        ],
+      };
+    case 'image-display':
+      return { ...base, type, imageUrl: '' };
+    case 'image-hotspot':
+      return { ...base, type, imageUrl: '', maxPoints: 1 };
     case 'signature':
       return { ...base, type };
     case 'geopoint':
@@ -1622,6 +1754,9 @@ function defaultLabel(type: QuestionType): string {
       name: 'Full name',
       address: 'Address',
       photo: 'Photo',
+      'image-choice': 'Image choice',
+      'image-display': 'Image',
+      'image-hotspot': 'Image hotspot',
       signature: 'Signature',
       geopoint: 'Location (point)',
       geotrace: 'Path (polyline)',


### PR DESCRIPTION
## Summary

Slice 6 of the question-type expansion (#145). Three image-driven
types -- the visual side of survey UX that text-only forms can't
match.

## What ships

### Schema (`packages/form-schema`)

- `ImageChoice` shape (value + label + imageUrl + optional alt).
- `image-choice`: choices are images. `multi` toggles single vs
  multi select.
- `image-display`: instructional image embed; no value captured.
- `image-hotspot`: respondent clicks one or more points; coords
  stored as 0..1 fractions of natural image size so they survive
  resizes.
- Validators: image-choice rejects unknown values + enforces
  min/maxSelected; image-hotspot rejects non-fraction coords and
  caps at maxPoints.

### Runtime (`form-runtime.tsx`)

- `ImageChoiceInput`: 2-up mobile / 3-up sm / 4-up md grid of
  thumbnail tiles with the whole tile as the click target.
- `ImageDisplay`: `<figure>` with optional caption.
- `ImageHotspotInput`: relative-positioned overlay on the image.
  Click computes (x, y) fraction; numbered dots render at each
  captured point.
- packIntoRows treats image-display and image-hotspot as standalone.

### Designer (`designer.tsx`)

- Palette: image-choice + image-display + image-hotspot in the
  Media group with Image / Crosshair icons.
- Properties: imageUrl + caption / maxPoints; multi toggle +
  ImageChoicesEditor for image-choice.

## Quality gate

`pnpm typecheck`, `pnpm lint`, `pnpm test` all clean. Stacked on top
of #19 (slice 5); rebased onto main after that merged.
