### PR TITLE
feat(forms): acknowledge + hidden + divider (#145)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -15,6 +15,7 @@ import {
   Database,
   Download,
   Eye,
+  EyeOff,
   Grid3x3,
   GripVertical,
   Hash,
@@ -26,9 +27,11 @@ import {
   Loader2,
   Mail,
   MapPin,
+  Minus,
   Phone,
   Plus,
   Regex,
+  ShieldCheck,
   Save,
   Sliders,
   SplitSquareHorizontal,
@@ -649,6 +652,9 @@ const PALETTE: PaletteEntry[] = [
   { type: 'geoshape', label: 'Area', icon: Square, group: 'spatial' },
   { type: 'calculated', label: 'Calculated', icon: Calculator, group: 'logic' },
   { type: 'note', label: 'Note', icon: TextIcon, group: 'layout' },
+  { type: 'divider', label: 'Divider', icon: Minus, group: 'layout' },
+  { type: 'acknowledge', label: 'Acknowledge', icon: ShieldCheck, group: 'logic' },
+  { type: 'hidden', label: 'Hidden', icon: EyeOff, group: 'logic' },
   { type: 'page', label: 'Page break', icon: Workflow, group: 'layout' },
   { type: 'group', label: 'Group / Repeat', icon: ListChecks, group: 'layout' },
 ];
@@ -1554,6 +1560,69 @@ function Properties({
             disabled={!canEdit}
             onChange={(e) =>
               onChange({ maxPoints: Number(e.target.value) } as Partial<Question>)
+            }
+            className={inputCls}
+          />
+        </Field>
+      ) : null}
+
+      {question.type === 'divider' ? (
+        <Field label="Caption">
+          <input
+            type="text"
+            value={question.caption ?? ''}
+            disabled={!canEdit}
+            onChange={(e) =>
+              onChange({ caption: e.target.value || undefined } as Partial<Question>)
+            }
+            className={inputCls}
+          />
+        </Field>
+      ) : null}
+
+      {question.type === 'acknowledge' ? (
+        <>
+          <Field label="Body" hint="Long-form text shown above the checkbox.">
+            <textarea
+              rows={4}
+              value={question.body}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({ body: e.target.value } as Partial<Question>)
+              }
+              className={inputCls}
+            />
+          </Field>
+          <Field label="Agree label">
+            <input
+              type="text"
+              value={question.agreeLabel ?? ''}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({
+                  agreeLabel: e.target.value || undefined,
+                } as Partial<Question>)
+              }
+              className={inputCls}
+            />
+          </Field>
+        </>
+      ) : null}
+
+      {question.type === 'hidden' ? (
+        <Field label="Default value" hint="Used when prefill / calculate doesn't set a value.">
+          <input
+            type="text"
+            value={
+              question.defaultValue === null || question.defaultValue === undefined
+                ? ''
+                : String(question.defaultValue)
+            }
+            disabled={!canEdit}
+            onChange={(e) =>
+              onChange({
+                defaultValue: e.target.value === '' ? undefined : e.target.value,
+              } as Partial<Question>)
             }
             className={inputCls}
           />

--- a/apps/portal-web/src/components/form-runtime.tsx
+++ b/apps/portal-web/src/components/form-runtime.tsx
@@ -295,12 +295,19 @@ function QuestionField({
   if (!isVisible(q, response)) return null;
 
   if (q.type === 'page') return null;
+  if (q.type === 'hidden') return null;
   if (q.type === 'note') {
     return (
       <div className="rounded-md border border-border bg-surface-2/40 px-3 py-2 text-sm text-ink-1">
         {q.label}
       </div>
     );
+  }
+  if (q.type === 'divider') {
+    return <Input q={q} value={null} readOnly={readOnly} onChange={onChange} />;
+  }
+  if (q.type === 'image-display') {
+    return <Input q={q} value={null} readOnly={readOnly} onChange={onChange} />;
   }
   if (q.type === 'group') {
     return <GroupField q={q} response={response} error={error} readOnly={readOnly} onChange={onChange} />;
@@ -922,7 +929,28 @@ function Input({
     case 'note':
     case 'page':
     case 'group':
+    case 'hidden':
       return null;
+    case 'divider':
+      return (
+        <div className="my-1">
+          {q.caption ? (
+            <p className="mb-1 text-[11px] uppercase tracking-wide text-muted">
+              {q.caption}
+            </p>
+          ) : null}
+          <hr className="border-border" />
+        </div>
+      );
+    case 'acknowledge':
+      return (
+        <AcknowledgeInput
+          q={q}
+          value={value}
+          readOnly={readOnly}
+          onChange={onChange}
+        />
+      );
   }
 }
 
@@ -999,6 +1027,67 @@ function PhotoInput({
  * select per `q.multi`. The whole tile is the click target so
  * touch users don't have to hit a small radio.
  */
+/**
+ * Acknowledgement: long-form text plus a required checkbox. When
+ * the user checks the box the runtime stamps an ISO timestamp into
+ * the response so the system has an audit trail of when consent
+ * was given. Unchecking clears the timestamp.
+ */
+function AcknowledgeInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'acknowledge' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  const checked =
+    typeof value === 'object' && value !== null && !Array.isArray(value)
+      ? Boolean((value as { acknowledged?: unknown }).acknowledged)
+      : false;
+  const at =
+    typeof value === 'object' && value !== null && !Array.isArray(value)
+      ? (value as { at?: unknown }).at
+      : undefined;
+
+  function set(nextChecked: boolean) {
+    if (readOnly) return;
+    if (nextChecked) {
+      onChange({ acknowledged: true, at: new Date().toISOString() });
+    } else {
+      onChange({ acknowledged: false });
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="rounded-md border border-border bg-surface-2/30 p-3 text-sm text-ink-1 whitespace-pre-line">
+        {q.body}
+      </div>
+      <label className="flex items-start gap-2 rounded-md border border-border bg-surface-1 p-3 text-sm">
+        <input
+          type="checkbox"
+          checked={checked}
+          disabled={readOnly}
+          onChange={(e) => set(e.target.checked)}
+          className="mt-0.5"
+        />
+        <span>
+          <span>{q.agreeLabel ?? 'I have read and agree.'}</span>
+          {checked && typeof at === 'string' ? (
+            <span className="ml-2 text-[11px] text-muted">
+              ({new Date(at).toLocaleString()})
+            </span>
+          ) : null}
+        </span>
+      </label>
+    </div>
+  );
+}
+
 function ImageChoiceInput({
   q,
   value,
@@ -2133,7 +2222,10 @@ function packIntoRows(qs: Question[]): Question[][] {
       q.type === 'name' ||
       q.type === 'address' ||
       q.type === 'image-display' ||
-      q.type === 'image-hotspot';
+      q.type === 'image-hotspot' ||
+      q.type === 'divider' ||
+      q.type === 'acknowledge' ||
+      q.type === 'hidden';
     const w = widthFraction(q.layout?.width);
     if (isStandalone || w === 1) {
       flush();

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -85,6 +85,9 @@ export const QUESTION_TYPES = [
   'slider', // numeric range slider
   'calculated', // read-only, derived from `calculate` expression
   'note', // display-only static text (no value captured)
+  'divider', // thin visual separator with optional caption
+  'acknowledge', // display long-form text + required "I agree" checkbox
+  'hidden', // not rendered; value via prefill / calculate
   'page', // page break (for paged surveys)
   'group', // logical grouping with optional repeat (see `repeat`)
 ] as const;
@@ -631,6 +634,43 @@ interface NoteQuestion extends QuestionBase {
   appearance?: 'plain' | 'markdown';
 }
 
+/** A thin visual separator. No value captured. The optional
+ *  `caption` is shown above the rule. */
+interface DividerQuestion extends QuestionBase {
+  type: 'divider';
+  caption?: string;
+}
+
+/**
+ * Long-form text plus a required acknowledgement checkbox. When the
+ * respondent checks the box the runtime stamps an ISO timestamp so
+ * the system has an audit trail of when consent was given.
+ *
+ * Response shape: `{ acknowledged: boolean, at?: string }`.
+ */
+interface AcknowledgeQuestion extends QuestionBase {
+  type: 'acknowledge';
+  /** Body text shown above the checkbox. Markdown-lite is rendered
+   *  the same way as `note.appearance === 'markdown'`. */
+  body: string;
+  appearance?: 'plain' | 'markdown';
+  /** Label next to the checkbox. Default: "I have read and agree". */
+  agreeLabel?: string;
+}
+
+/**
+ * Hidden field. Never rendered. Value comes from URL prefill, a
+ * `calculated` expression, or some other surface (e.g. a campaign
+ * tracking id seeded by the page). The runtime preserves the
+ * captured value across submissions so analytics can stitch the
+ * record together.
+ */
+interface HiddenQuestion extends QuestionBase {
+  type: 'hidden';
+  /** Default value. Used when no prefill or calculate hits. */
+  defaultValue?: string | number | boolean | null;
+}
+
 interface PageQuestion extends QuestionBase {
   type: 'page';
   /** Page header text (overrides `label` when present). */
@@ -691,6 +731,9 @@ export type Question =
   | SliderQuestion
   | CalculatedQuestion
   | NoteQuestion
+  | DividerQuestion
+  | AcknowledgeQuestion
+  | HiddenQuestion
   | PageQuestion
   | GroupQuestion;
 
@@ -1030,6 +1073,7 @@ export function validate(form: FormSchema, response: Response): ValidationResult
       q.type === 'page' ||
       q.type === 'note' ||
       q.type === 'group' ||
+      q.type === 'divider' ||
       q.type === 'image-display'
     ) {
       continue;
@@ -1421,6 +1465,16 @@ function validateType(q: Question, value: unknown): string | null {
     case 'image-display':
       // Display-only: no captured value to validate.
       return null;
+    case 'acknowledge': {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        return 'Please acknowledge to continue.';
+      }
+      const v = (value as { acknowledged?: unknown }).acknowledged;
+      if (v !== true) return 'Please acknowledge to continue.';
+      return null;
+    }
+    case 'hidden':
+      return null;
     case 'image-hotspot': {
       if (!Array.isArray(value)) return 'Expected one or more points.';
       const max = q.maxPoints ?? 1;
@@ -1511,6 +1565,7 @@ export function pruneHidden(form: FormSchema, response: Response): Response {
       q.type === 'page' ||
       q.type === 'note' ||
       q.type === 'group' ||
+      q.type === 'divider' ||
       q.type === 'image-display'
     ) {
       continue;
@@ -1722,6 +1777,16 @@ export function defaultQuestion(type: QuestionType, id: QuestionId): Question {
       };
     case 'note':
       return { ...base, type, appearance: 'plain' };
+    case 'divider':
+      return { ...base, type, label: '' };
+    case 'acknowledge':
+      return {
+        ...base,
+        type,
+        body: 'Please read the terms and check the box to continue.',
+      };
+    case 'hidden':
+      return { ...base, type };
     case 'page':
       return { ...base, type, label: 'Page break' };
     case 'group':
@@ -1767,6 +1832,9 @@ function defaultLabel(type: QuestionType): string {
       slider: 'Slider',
       calculated: 'Calculated',
       note: 'Note',
+      divider: 'Divider',
+      acknowledge: 'Acknowledge',
+      hidden: 'Hidden',
       page: 'New page',
       group: 'Group',
     } satisfies Record<QuestionType, string>


### PR DESCRIPTION
## Summary

Slice 8 of the question-type expansion (#145). Three small but
useful utility types.

## What ships

### Schema (`packages/form-schema`)

- `divider`: thin separator with optional caption. No value.
- `acknowledge`: long-form body + required checkbox. When checked,
  the runtime stamps an ISO timestamp into the response (audit
  trail of when consent was given).
- `hidden`: never rendered. Holds a value supplied by URL prefill
  or a `calculated` expression. `defaultValue` seeds it when no
  other source hits.

### Runtime (`form-runtime.tsx`)

- divider renders a small caption + horizontal rule, no label.
- AcknowledgeInput renders the body + checkbox. Checking writes
  `{ acknowledged: true, at: ISO }`; unchecking clears the
  timestamp.
- hidden renders nothing. Its captured value survives submit.
- packIntoRows treats all three as standalone rows.

### Designer (`designer.tsx`)

- Palette: divider in Layout; acknowledge + hidden in Logic with
  ShieldCheck and EyeOff icons.
- Properties: divider gets Caption; acknowledge gets Body textarea
  + Agree label; hidden gets Default value.

## Quality gate

`pnpm typecheck`, `pnpm lint` clean. Stacked on top of #20 (slice 6);
rebased onto main after that merged.
