### PR TITLE
feat(forms): generic file upload + Phase 2 doc update (#145)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -16,6 +16,7 @@ import {
   Download,
   Eye,
   EyeOff,
+  FileText,
   Grid3x3,
   GripVertical,
   Hash,
@@ -643,6 +644,7 @@ const PALETTE: PaletteEntry[] = [
   { type: 'name', label: 'Full name', icon: User, group: 'identity' },
   { type: 'address', label: 'Address', icon: Home, group: 'identity' },
   { type: 'photo', label: 'Photo', icon: Camera, group: 'media' },
+  { type: 'file', label: 'File', icon: FileText, group: 'media' },
   { type: 'image-choice', label: 'Image choice', icon: Image, group: 'media' },
   { type: 'image-display', label: 'Image', icon: Image, group: 'media' },
   { type: 'image-hotspot', label: 'Image hotspot', icon: Crosshair, group: 'media' },
@@ -1520,6 +1522,55 @@ function Properties({
             } as Partial<Question>)
           }
         />
+      ) : null}
+
+      {question.type === 'file' ? (
+        <>
+          <div className="mb-2 grid grid-cols-2 gap-2">
+            <Field label="Max files">
+              <input
+                type="number"
+                min={1}
+                value={question.maxCount ?? 1}
+                disabled={!canEdit}
+                onChange={(e) =>
+                  onChange({
+                    maxCount: Number(e.target.value),
+                  } as Partial<Question>)
+                }
+                className={inputCls}
+              />
+            </Field>
+            <Field label="Max bytes">
+              <input
+                type="number"
+                min={0}
+                value={question.maxBytes ?? ''}
+                disabled={!canEdit}
+                onChange={(e) =>
+                  onChange({
+                    maxBytes:
+                      e.target.value === '' ? undefined : Number(e.target.value),
+                  } as Partial<Question>)
+                }
+                className={inputCls}
+              />
+            </Field>
+          </div>
+          <Field label="Accept" hint='e.g. ".pdf,application/pdf"'>
+            <input
+              type="text"
+              value={question.accept ?? ''}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({
+                  accept: e.target.value || undefined,
+                } as Partial<Question>)
+              }
+              className={inputCls}
+            />
+          </Field>
+        </>
       ) : null}
 
       {question.type === 'image-display' || question.type === 'image-hotspot' ? (

--- a/apps/portal-web/src/components/form-runtime.tsx
+++ b/apps/portal-web/src/components/form-runtime.tsx
@@ -765,6 +765,8 @@ function Input({
       return <AddressInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
     case 'photo':
       return <PhotoInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
+    case 'file':
+      return <FileInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
     case 'image-choice':
       return (
         <ImageChoiceInput
@@ -1084,6 +1086,116 @@ function AcknowledgeInput({
           ) : null}
         </span>
       </label>
+    </div>
+  );
+}
+
+/**
+ * Generic file upload. Captures attachments as `{ name, mimeType,
+ * sizeBytes, dataUrl }` so the offline outbox can persist them
+ * without an immediate network upload. Phase 2 swaps the data URL
+ * for a MinIO object key once the server-side pipeline lands.
+ */
+function FileInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'file' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  type Attachment = {
+    name: string;
+    mimeType: string;
+    sizeBytes: number;
+    dataUrl: string;
+  };
+  const files: Attachment[] = Array.isArray(value)
+    ? (value as Attachment[]).filter(
+        (f): f is Attachment =>
+          f !== null &&
+          typeof f === 'object' &&
+          typeof (f as Attachment).name === 'string' &&
+          typeof (f as Attachment).dataUrl === 'string',
+      )
+    : [];
+  const max = q.maxCount ?? 1;
+
+  async function onPick(e: React.ChangeEvent<HTMLInputElement>) {
+    if (readOnly) return;
+    const picked = e.target.files;
+    if (!picked || picked.length === 0) return;
+    const next: Attachment[] = files.slice();
+    for (const f of Array.from(picked)) {
+      if (next.length >= max) break;
+      const dataUrl = await fileToDataUrl(f);
+      next.push({
+        name: f.name,
+        mimeType: f.type || 'application/octet-stream',
+        sizeBytes: f.size,
+        dataUrl,
+      });
+    }
+    onChange(next);
+    e.target.value = '';
+  }
+
+  function remove(idx: number) {
+    if (readOnly) return;
+    onChange(files.filter((_, i) => i !== idx));
+  }
+
+  function fmtSize(b: number): string {
+    if (b < 1024) return `${b} B`;
+    if (b < 1024 * 1024) return `${(b / 1024).toFixed(1)} KB`;
+    return `${(b / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  return (
+    <div className="space-y-2">
+      {files.length > 0 ? (
+        <ul className="space-y-1">
+          {files.map((f, i) => (
+            <li
+              key={i}
+              className="flex items-center gap-2 rounded-md border border-border bg-surface-1 px-3 py-2 text-sm"
+            >
+              <span className="flex-1 truncate" title={f.name}>
+                {f.name}
+              </span>
+              <span className="text-[11px] text-muted">{fmtSize(f.sizeBytes)}</span>
+              {!readOnly ? (
+                <button
+                  type="button"
+                  onClick={() => remove(i)}
+                  className="rounded p-1 text-muted hover:bg-surface-2 hover:text-danger"
+                  aria-label="Remove file"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {!readOnly && files.length < max ? (
+        <label className="inline-flex h-10 cursor-pointer items-center gap-2 rounded-md border border-dashed border-border bg-surface-1 px-3 text-sm text-ink-1 hover:bg-surface-2">
+          <Plus className="h-4 w-4 text-muted" />
+          <span>Add file</span>
+          <input
+            type="file"
+            className="sr-only"
+            accept={q.accept}
+            onChange={onPick}
+          />
+        </label>
+      ) : null}
+      <p className="text-[11px] text-muted">
+        {files.length} of {max} {max === 1 ? 'file' : 'files'} attached
+      </p>
     </div>
   );
 }

--- a/docs/forms-question-types.md
+++ b/docs/forms-question-types.md
@@ -31,18 +31,28 @@ needs because they share the geometry, offline, and Field-mode story.
 
 ## What we have today (schema v1)
 
-Twenty-one types in `packages/form-schema/src/index.ts`:
+The Phase-2 expansion landed in PRs #15..#22 and brings the catalog
+from 21 to 47 types in `packages/form-schema/src/index.ts`. The
+sections marked "shipped" all rendered, validated, designable, and
+mobile-friendly:
 
-  - Text: `text`, `multiline`
-  - Numeric: `number`, `integer`
-  - Boolean: `boolean`
-  - Choice: `select-one` (radio or dropdown), `select-many`
-  - Date / time: `date`, `time`, `datetime`
-  - Capture: `photo`, `signature`
-  - Geometry: `geopoint`, `geotrace`, `geoshape`
-  - Scales: `rating` (1-N stars), `slider`
-  - Computation: `calculated`
-  - Layout: `note`, `page`, `group` (with optional repeat)
+  - Text (shipped): `text`, `multiline`, `email`, `url`, `phone`,
+    `regex`
+  - Numeric (shipped): `number`, `integer`
+  - Boolean (shipped): `boolean`
+  - Choice (shipped): `select-one`, `select-many`, `ranking`
+  - Matrix (shipped): `matrix-single`, `matrix-multi`,
+    `matrix-dropdown`, `matrix-rating`
+  - Scales (shipped): `rating`, `likert`, `nps`, `slider`
+  - Date / time (shipped): `date`, `time`, `datetime`
+  - Identity (shipped): `name`, `address`
+  - Capture (shipped): `photo`, `file`, `signature`
+  - Geometry (shipped): `geopoint`, `geotrace`, `geoshape`
+  - Image-driven (shipped): `image-choice`, `image-display`,
+    `image-hotspot`
+  - Computation (shipped): `calculated`
+  - Utility (shipped): `note`, `divider`, `acknowledge`, `hidden`,
+    `page`, `group`
 
 Strengths: the JSON-only expression DSL, the `bindTo` link to data
 layer columns, and the offline outbox give us a foundation that the
@@ -337,6 +347,30 @@ already do this on schema-version mismatch.
 becomes unusable. Group the palette into the categories above (Text,
 Choice, Matrix, Scale, Date / time, Capture, Identity, Geometry,
 Display, Advanced) and add a search box.
+
+## What is left
+
+Three slices from the original ten are still pending. They are the
+ones with the heaviest infrastructure cost; we deferred them so the
+text / scale / matrix / identity / image work could land first.
+
+  - **Audio + video capture** (`audio`, `video`): MediaRecorder,
+    permissions UX, blob handling, server-side upload pipeline.
+    Useful enough to be its own slice.
+  - **Barcode scan** (`barcode`): browser BarcodeDetector +
+    polyfill on devices that don't support it. Useful to field
+    workflows but a deeper UX investment than the rest of slice 7.
+  - **Drawing / sketch** (`drawing`): Canvas2D capture, undo,
+    SVG + PNG dual-output. Useful for damage diagrams over a
+    silhouette.
+  - **GIS extras** (`pick-feature`, `route`, `area-buffer`): all
+    three need a runtime map embed and either a routing service
+    or a feature search. Best addressed alongside the data
+    collection Phase 1b runtime work (#141) where the Field-mode
+    map is already on the table.
+  - **Designer palette polish**: search box across the now-47-type
+    palette. Categories already shipped in slice 1 so the flat
+    list is no longer a problem; search is a nice-to-have.
 
 ## Suggested rollout order
 

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -72,6 +72,7 @@ export const QUESTION_TYPES = [
   'name', // composite person name (first / middle / last / suffix / prefix)
   'address', // composite postal address
   'photo', // one or more image attachments
+  'file', // generic file upload (any MIME)
   'image-choice', // single/multi choice where each option is an image
   'image-display', // display-only image embed (no value captured)
   'image-hotspot', // click point(s) on a reference image
@@ -498,6 +499,28 @@ interface PhotoQuestion extends QuestionBase {
   maxBytes?: number;
 }
 
+/**
+ * Generic file upload. Accepts any MIME by default; the optional
+ * `accept` array narrows the picker (e.g. ['application/pdf']).
+ *
+ * Response shape: an array of attachment descriptors:
+ *   { name: string; mimeType: string; sizeBytes: number; dataUrl: string }
+ *
+ * Phase 1 stores the file as a data: URL inside the queued
+ * submission, which works for the offline outbox. Phase 2 uploads
+ * to MinIO and replaces the data URL with the object key.
+ */
+interface FileQuestion extends QuestionBase {
+  type: 'file';
+  /** Max attachments. Default 1. */
+  maxCount?: number;
+  /** Soft cap per file in bytes. */
+  maxBytes?: number;
+  /** Accept filter for the picker; matches the HTML `accept`
+   *  attribute (e.g. ".pdf,application/pdf"). */
+  accept?: string;
+}
+
 /** A choice-with-image. Same shape as Choice plus an imageUrl that
  *  the runtime renders as the visual face of the option. */
 export interface ImageChoice {
@@ -718,6 +741,7 @@ export type Question =
   | NameQuestion
   | AddressQuestion
   | PhotoQuestion
+  | FileQuestion
   | ImageChoiceQuestion
   | ImageDisplayQuestion
   | ImageHotspotQuestion
@@ -1440,6 +1464,29 @@ function validateType(q: Question, value: unknown): string | null {
         return `Up to ${q.maxCount} attachments allowed.`;
       }
       return null;
+    case 'file':
+      if (!Array.isArray(value)) return 'Expected one or more files.';
+      if (q.maxCount !== undefined && value.length > q.maxCount) {
+        return `Up to ${q.maxCount} files allowed.`;
+      }
+      for (const v of value) {
+        if (
+          typeof v !== 'object' ||
+          v === null ||
+          typeof (v as { name?: unknown }).name !== 'string' ||
+          typeof (v as { dataUrl?: unknown }).dataUrl !== 'string'
+        ) {
+          return 'File entry has an unexpected shape.';
+        }
+        if (
+          q.maxBytes !== undefined &&
+          typeof (v as { sizeBytes?: unknown }).sizeBytes === 'number' &&
+          (v as { sizeBytes: number }).sizeBytes > q.maxBytes
+        ) {
+          return `Files must be ${q.maxBytes} bytes or smaller.`;
+        }
+      }
+      return null;
     case 'image-choice': {
       const validValues = new Set(q.choices.map((c) => c.value));
       if (q.multi) {
@@ -1731,6 +1778,8 @@ export function defaultQuestion(type: QuestionType, id: QuestionId): Question {
       };
     case 'photo':
       return { ...base, type, maxCount: 1 };
+    case 'file':
+      return { ...base, type, maxCount: 1 };
     case 'image-choice':
       return {
         ...base,
@@ -1819,6 +1868,7 @@ function defaultLabel(type: QuestionType): string {
       name: 'Full name',
       address: 'Address',
       photo: 'Photo',
+      file: 'File',
       'image-choice': 'Image choice',
       'image-display': 'Image',
       'image-hotspot': 'Image hotspot',


### PR DESCRIPTION
## Summary

Slice 7 (subset) and the Phase 2 wrap-up. Lands the generic `file`
upload type and updates the design doc to reflect what shipped
across slices 1-8 plus what's still pending.

## What ships

### Schema (`packages/form-schema`)

- `file`: any-MIME upload. Same offline-friendly attachment shape
  `photo` uses (`{ name, mimeType, sizeBytes, dataUrl }`) so the
  IndexedDB outbox can persist files without a network round-trip.
  Optional `accept` narrows the picker; optional `maxBytes`
  enforces a soft cap.

### Runtime (`form-runtime.tsx`)

- `FileInput`: list of attached files (name + size + remove button)
  plus an "Add file" button using the standard `<input type="file">`
  picker. Phase 2 swaps the data URL for a MinIO object key once
  the server-side pipeline lands.

### Designer (`designer.tsx`)

- Palette: file in Media group with a FileText icon.
- Properties: max files + max bytes + accept input.

### Docs

- `docs/forms-question-types.md` updated to reflect the 47-type
  catalog post-expansion. Adds a "What is left" section listing
  audio / video / barcode / drawing / GIS extras / palette search
  as deferred follow-ups, with reasoning so a future session can
  pick them up cleanly.

## What is deferred

Slices 7 (audio / video / barcode / drawing) and 9 (pick-feature /
route / area-buffer) are deferred -- they each need substantial
infra (MediaRecorder, BarcodeDetector, Canvas2D, runtime map embed)
that's better paired with the Data Collection Phase 1b work (#141).

## Quality gate

`pnpm typecheck`, `pnpm lint` clean. Stacked on top of #21 (slice 8);
rebased onto main after that merged.
