### PR TITLE
fix(infra): repair fresh-clone dev setup for Keycloak 26 and seed

### DIFF
--- a/apps/portal-api/prisma/seed.ts
+++ b/apps/portal-api/prisma/seed.ts
@@ -170,4 +170,4 @@ main()
     console.error(e);
     process.exit(1);
   })
-  .finally(() => prisma.$dis
+  .finally(() => prisma.$disconnect());

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -28,7 +28,8 @@ services:
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: admin
-      KC_HOSTNAME: localhost
+      KC_HOSTNAME_URL: http://localhost:8080
+      KC_HOSTNAME_ADMIN_URL: http://localhost:8080
       KC_HTTP_ENABLED: "true"
       # dev-file keeps data in a local H2 file that survives container restarts
       # AND stays alive when the connection pool idles. dev-mem loses everything

--- a/infra/keycloak/realm-gratis-gis.json
+++ b/infra/keycloak/realm-gratis-gis.json
@@ -9,7 +9,7 @@
   "editUsernameAllowed": false,
   "loginWithEmailAllowed": true,
   "duplicateEmailsAllowed": false,
-  "sslRequired": "external",
+  "sslRequired": "NONE",
   "accessTokenLifespan": 300,
   "ssoSessionIdleTimeout": 3600,
   "ssoSessionMaxLifespan": 36000,
@@ -24,8 +24,12 @@
       "publicClient": true,
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": false,
-      "redirectUris": ["http://localhost:3000/*"],
-      "webOrigins": ["http://localhost:3000"],
+      "redirectUris": [
+        "http://localhost:3000/*"
+      ],
+      "webOrigins": [
+        "http://localhost:3000"
+      ],
       "attributes": {
         "pkce.code.challenge.method": "S256"
       },
@@ -128,9 +132,18 @@
   ],
   "roles": {
     "realm": [
-      { "name": "viewer", "description": "Can view shared items" },
-      { "name": "contributor", "description": "Can create and share items" },
-      { "name": "admin", "description": "Organization administrator" }
+      {
+        "name": "viewer",
+        "description": "Can view shared items"
+      },
+      {
+        "name": "contributor",
+        "description": "Can create and share items"
+      },
+      {
+        "name": "admin",
+        "description": "Organization administrator"
+      }
     ]
   },
   "users": [
@@ -138,14 +151,26 @@
       "username": "mateo",
       "email": "mateo@acme.test",
       "firstName": "Mateo",
-      "lastName": "García",
+      "lastName": "Garc\u00eda",
       "enabled": true,
       "emailVerified": true,
-      "credentials": [{ "type": "password", "value": "devpassword", "temporary": false }],
-      "realmRoles": ["contributor"],
+      "credentials": [
+        {
+          "type": "password",
+          "value": "devpassword",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "contributor"
+      ],
       "attributes": {
-        "org": ["acme"],
-        "org_role": ["contributor"]
+        "org": [
+          "acme"
+        ],
+        "org_role": [
+          "contributor"
+        ]
       }
     },
     {
@@ -155,11 +180,33 @@
       "lastName": "Example",
       "enabled": true,
       "emailVerified": true,
-      "credentials": [{ "type": "password", "value": "devpassword", "temporary": false }],
-      "realmRoles": ["admin"],
+      "credentials": [
+        {
+          "type": "password",
+          "value": "devpassword",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "admin"
+      ],
       "attributes": {
-        "org": ["acme"],
-        "org_role": ["admin"]
+        "org": [
+          "acme"
+        ],
+        "org_role": [
+          "admin"
+        ]
+      }
+    },
+    {
+      "username": "service-account-portal-api-admin",
+      "enabled": true,
+      "serviceAccountClientId": "portal-api-admin",
+      "clientRoles": {
+        "realm-management": [
+          "manage-users"
+        ]
       }
     }
   ]


### PR DESCRIPTION
## Summary

- **seed.ts truncated**: the file ended mid-expression (`.finally(() => prisma.$dis`), causing `db:seed` to fail with an esbuild parse error on a fresh clone
- **Keycloak 26 HTTPS redirect loop**: `KC_HOSTNAME=localhost` activates the hostname-v2 provider, which enforces HTTPS on all requests regardless of `sslRequired`; replaced with `KC_HOSTNAME_URL=http://localhost:8080` to make the scheme explicit
- **Users page 502**: `realm-gratis-gis.json` was missing the `portal-api-admin` service account entry with `manage-users`, so the admin client could not list Keycloak users; also set `sslRequired=NONE` (consistent with the HTTP-only dev setup) so the fix survives `pnpm infra:reset`

All three changes are platform-agnostic and tested on Apple Silicon. The Keycloak hostname fix applies equally on x86.

## Test plan

- [ ] Fresh clone: `pnpm install && pnpm infra:up`
- [ ] `pnpm --filter @gratis-gis/portal-api db:migrate:deploy && pnpm --filter @gratis-gis/portal-api db:seed` completes without error
- [ ] `pnpm dev` starts both servers
- [ ] Sign in at http://localhost:3000 as `bob` / `devpassword` (no redirect loop)
- [ ] Admin users page loads without 502