### PR TITLE
feat(forms): interactive preview + inline question render in design (#151)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -70,7 +70,7 @@ import {
   type QuestionType,
 } from '@gratis-gis/form-schema';
 import { useConfirm } from '@/components/dialog-provider';
-import { FormRuntime } from '@/components/form-runtime';
+import { FormRuntime, QuestionPreview } from '@/components/form-runtime';
 
 interface Props {
   itemId: string;
@@ -443,12 +443,16 @@ export function FormDesigner({ itemId, initial, canEdit }: Props) {
         </div>
       ) : (
         <div className="border-t border-border bg-surface-0">
+          {/* Preview is interactive: the author should be able to
+              click radios, fill in fields, add repeat instances, hit
+              the page-break Next button, and see conditional logic
+              fire. onSubmit is a no-op so dummy data never lands
+              anywhere. */}
           <FormRuntime
             form={form}
             onSubmit={async () => {
               /* preview discards submission */
             }}
-            readOnly
           />
         </div>
       )}
@@ -1042,6 +1046,16 @@ function QuestionRow({
             </p>
             <p className="text-sm font-medium text-ink-0">{q.label}</p>
             {q.hint ? <p className="text-xs text-muted">{q.hint}</p> : null}
+            {/* Inline preview of the question's input UI. Renders
+                the same component the runtime would, wrapped in a
+                pointer-events-none div so clicks still hit the
+                row's selection handler. Authors see what their
+                form looks like without flipping to Preview. */}
+            {q.type !== 'group' && q.type !== 'page' && q.type !== 'hidden' ? (
+              <div className="mt-2">
+                <QuestionPreview q={q} />
+              </div>
+            ) : null}
           </div>
           {canEdit ? (
             <button

--- a/apps/portal-web/src/components/form-runtime.tsx
+++ b/apps/portal-web/src/components/form-runtime.tsx
@@ -442,6 +442,46 @@ function GroupField({
   );
 }
 
+/**
+ * Static, non-interactive preview of one question's input UI. The
+ * designer renders this inline beneath each question card so authors
+ * can see what a respondent would actually see without flipping to
+ * the Preview tab.
+ *
+ * The wrapper sets `pointer-events: none` so clicks on the input
+ * pass through to the design-view's selection handler instead of
+ * activating the radio / button. Also dims slightly to telegraph
+ * "this is a preview, not interactive."
+ */
+export function QuestionPreview({ q }: { q: Question }) {
+  // Pages, hidden, and group are structural -- nothing to render.
+  // Note (text panel) and divider already render on their own.
+  if (q.type === 'page' || q.type === 'hidden' || q.type === 'group') {
+    return null;
+  }
+  // Photo / signature / file would either render an empty file
+  // picker or a message. Show a small badge instead.
+  if (q.type === 'photo' || q.type === 'file' || q.type === 'signature') {
+    return (
+      <div className="rounded-md border border-dashed border-border bg-surface-2/30 px-3 py-2 text-[11px] text-muted">
+        {q.type === 'signature'
+          ? 'Signature pad'
+          : q.type === 'photo'
+            ? 'Photo capture'
+            : 'File upload'}
+      </div>
+    );
+  }
+  return (
+    <div
+      className="pointer-events-none select-none opacity-90"
+      aria-hidden="true"
+    >
+      <Input q={q} value={null} readOnly onChange={() => {}} />
+    </div>
+  );
+}
+
 // Per-type input renderers. Native HTML inputs everywhere -- mobile
 // pickers come for free.
 function Input({


### PR DESCRIPTION
## Summary

Two ergonomics fixes for the form designer, both stemming from the
same observation: the design / preview split was too costly and the
preview itself wasn't faithful.

## 1. Preview is now interactive

The Preview tab passed `readOnly` to FormRuntime, which had two
side-effects: text inputs were disabled, and the visible bug --
repeating groups hid their "Add another" button. Photos and
Inspection groups rendered as empty bars; you couldn't see what the
form actually looks like with content.

`onSubmit` is already a no-op in preview, so dropping `readOnly`
gives authors a fully interactive form: fill fields, add repeat
instances, click through page breaks, watch conditional logic fire.
Nothing they enter ever leaves the preview.

## 2. Each question renders its actual UI in the design view

Design rows used to show `TEXT · SPECIES BOUND` plus the label.
For matrix / select / scale / Likert / NPS the author had no idea
what they were building -- you had to flip to Preview every time.
Now each row renders the question's actual input below the label.

Wired in via:

- `form-runtime` exports a new `QuestionPreview` component that
  wraps the existing per-type Input renderer with
  `pointer-events: none` and `aria-hidden`. Clicks on the preview
  pass through to the row card's onClick (selection); the input is
  purely visual.
- Photo / signature / file render a small "Photo capture" / "File
  upload" badge instead of an empty file picker.
- Page / hidden / group are skipped: page is a marker, hidden has
  no UI, and group children render through the existing recursive
  question-list machinery.

## Quality gate

`pnpm typecheck`, `pnpm lint` clean.
