### PR TITLE
feat(forms): side-by-side layout in design view + respect explicit width on all types (#152)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -70,7 +70,12 @@ import {
   type QuestionType,
 } from '@gratis-gis/form-schema';
 import { useConfirm } from '@/components/dialog-provider';
-import { FormRuntime, QuestionPreview } from '@/components/form-runtime';
+import {
+  FormRuntime,
+  QuestionPreview,
+  packIntoRows,
+  widthToClass,
+} from '@/components/form-runtime';
 
 interface Props {
   itemId: string;
@@ -888,20 +893,64 @@ function QuestionList({
   containerId,
   ...cb
 }: { list: Question[]; containerId: QuestionId | null } & CanvasCallbacks) {
+  // Mirror the runtime's row-packing so the design view shows
+  // questions side-by-side when the author has set narrower widths.
+  // Each row becomes a flex container; insert-before drop slots go
+  // ABOVE each row (and there's a trailing drop slot at the bottom).
+  // We don't offer drop targets between cells in the same row to
+  // keep the drag-drop story simple -- if you need to insert a
+  // question between two side-by-side ones, drop at the row above
+  // and reorder, or temporarily widen one to break the row.
+  const rows = packIntoRows(list);
+  // We need each question's absolute index in the flat `list` for
+  // the drop targets, not its index within the row.
+  const indexOf = new Map(list.map((q, i) => [q.id, i]));
   return (
     <ul className="space-y-2">
-      {list.map((q, i) => (
-        <QuestionRow
-          key={q.id}
-          q={q}
-          index={i}
-          containerId={containerId}
-          {...cb}
-        />
-      ))}
-      {/* Trailing drop zone for "drop at the end". Without this you
-          can't drop into an empty group, and you can't append-via-
-          drop on the top-level list either. */}
+      {rows.map((row, ri) => {
+        const firstId = row[0]!.id;
+        const firstIdx = indexOf.get(firstId) ?? 0;
+        return (
+          <li key={`row-${ri}-${firstId}`}>
+            <DropSlot
+              containerId={containerId}
+              index={firstIdx}
+              canEdit={cb.canEdit}
+              onAddType={(t) => cb.onAddInto(t, containerId)}
+              onMove={(id) =>
+                cb.onMove(id, { containerId, index: firstIdx })
+              }
+            />
+            {row.length === 1 ? (
+              <QuestionRow
+                q={row[0]!}
+                index={firstIdx}
+                containerId={containerId}
+                {...cb}
+              />
+            ) : (
+              <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-stretch">
+                {row.map((q) => {
+                  const idx = indexOf.get(q.id) ?? 0;
+                  return (
+                    <div
+                      key={q.id}
+                      className={`min-w-0 ${widthToClass(q.layout?.width)}`}
+                    >
+                      <QuestionRow
+                        q={q}
+                        index={idx}
+                        containerId={containerId}
+                        {...cb}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </li>
+        );
+      })}
       <li>
         <DropSlot
           containerId={containerId}
@@ -986,26 +1035,12 @@ function QuestionRow({
   }
 
   return (
-    <li>
-      {/* Insert-before drop zone. Sits above the row card so the user
-          gets a target *between* questions, distinct from "drop on
-          the row" (which would be ambiguous). */}
-      <DropSlot
-        containerId={containerId}
-        index={index}
-        canEdit={canEdit}
-        onAddType={(t) => onAddInto(t, containerId)}
-        onMove={(id) => {
-          if (id !== q.id) onMove(id, { containerId, index });
-        }}
-      />
-
-      <div
-        className={`relative rounded-md border ${
-          q.id === selectedId
-            ? 'border-accent ring-2 ring-accent/30'
-            : 'border-border'
-        } bg-surface-1 p-3 ${overTop ? 'border-accent' : ''}`}
+    <div
+      className={`relative h-full rounded-md border ${
+        q.id === selectedId
+          ? 'border-accent ring-2 ring-accent/30'
+          : 'border-border'
+      } bg-surface-1 p-3 ${overTop ? 'border-accent' : ''}`}
         onClick={(e) => {
           e.stopPropagation();
           onSelect(q.id);
@@ -1074,10 +1109,10 @@ function QuestionRow({
 
         {/* Group children rendered inside the row, so dropping on
             the group adds to its children, not to the parent. */}
-        {q.type === 'group' ? (
-          <div
-            className="mt-3 rounded border border-dashed border-border bg-surface-2/30 p-2"
-            onClick={(e) => e.stopPropagation()}
+      {q.type === 'group' ? (
+        <div
+          className="mt-3 rounded border border-dashed border-border bg-surface-2/30 p-2"
+          onClick={(e) => e.stopPropagation()}
             onDragOver={(e) => {
               if (!canEdit) return;
               e.preventDefault();
@@ -1113,10 +1148,9 @@ function QuestionRow({
                 onMove={onMove}
               />
             )}
-          </div>
-        ) : null}
-      </div>
-    </li>
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/portal-web/src/components/form-runtime.tsx
+++ b/apps/portal-web/src/components/form-runtime.tsx
@@ -2344,13 +2344,18 @@ function isReadOnly(q: Question, response: Response): boolean {
 
 /**
  * Pack a list of questions into visual rows based on their declared
- * widths. A `full` (or unspecified) width starts a new row by itself.
- * Otherwise sequential questions are accumulated until their summed
- * widths exceed 1, then the row breaks. Note rows are flat -- no
- * recursive nesting -- so a row never contains a group; groups are
- * always on their own row at full width.
+ * widths. A question with `full` (or unspecified) width starts a new
+ * row by itself. Otherwise sequential questions are accumulated until
+ * their summed widths exceed 1, then the row breaks.
+ *
+ * Only genuinely structural types are forced standalone (page break,
+ * group, note, divider, hidden, image-display). Everything else --
+ * including the wide ones like matrix and ranking -- respects the
+ * author's `layout.width`. If the author sets a matrix to 1/2 they
+ * accept the cramped or scrolling consequence; that's an explicit
+ * choice we shouldn't second-guess.
  */
-function packIntoRows(qs: Question[]): Question[][] {
+export function packIntoRows(qs: Question[]): Question[][] {
   const rows: Question[][] = [];
   let current: Question[] = [];
   let used = 0;
@@ -2364,20 +2369,9 @@ function packIntoRows(qs: Question[]): Question[][] {
       q.type === 'page' ||
       q.type === 'group' ||
       q.type === 'note' ||
-      q.type === 'matrix-single' ||
-      q.type === 'matrix-multi' ||
-      q.type === 'matrix-dropdown' ||
-      q.type === 'matrix-rating' ||
-      q.type === 'ranking' ||
-      q.type === 'likert' ||
-      q.type === 'nps' ||
-      q.type === 'name' ||
-      q.type === 'address' ||
-      q.type === 'image-display' ||
-      q.type === 'image-hotspot' ||
       q.type === 'divider' ||
-      q.type === 'acknowledge' ||
-      q.type === 'hidden';
+      q.type === 'hidden' ||
+      q.type === 'image-display';
     const w = widthFraction(q.layout?.width);
     if (isStandalone || w === 1) {
       flush();
@@ -2410,7 +2404,7 @@ function widthFraction(width: string | undefined): number {
   }
 }
 
-function widthToClass(width: string | undefined): string {
+export function widthToClass(width: string | undefined): string {
   // Tailwind: mobile collapses to w-full; sm: applies the fractional
   // basis. We use `basis-` so flexbox does the wrapping inside the
   // `flex-wrap` parent.


### PR DESCRIPTION
## Summary

Setting two questions to 1/2 width didn't put them side-by-side.
Two reasons; this fixes both.

## What was wrong

### packIntoRows force-standalone list was too aggressive

Matrix / ranking / likert / nps / name / address / image-hotspot /
acknowledge were all forced onto their own row regardless of the
author's `layout.width`. Reason was "they're wide, they need the
space." But that's paternalistic -- if the author sets a matrix to
1/2, they accept the cramped or scrolling consequence.

Trimmed the standalone list to just genuinely structural types:
page / group / note / divider / hidden / image-display. Everything
else respects the declared width and packs into rows accordingly.

### Design view didn't pack at all

Even with the runtime fixed, the design view rendered every question
on its own row -- you couldn't see the side-by-side layout without
flipping to Preview. The new QuestionList:

- Calls the same `packIntoRows` helper, now exported from
  form-runtime.
- Renders each row as a flex container (column on mobile, row on
  sm+) of question cards, with each card sized via the same
  `widthToClass` Tailwind helper the runtime uses.
- Drop slots are row-level (above each row + trailing slot). We
  don't surface drop targets between cells in the same row -- to
  insert between side-by-side cells, drop above the row and
  reorder, or widen one cell to break the row.

## Refactor

- `QuestionRow` is now a `<div>` instead of `<li>`; the `<li>` lives
  at the row level in QuestionList.
- `QuestionRow` no longer renders its own insert-before drop slot;
  QuestionList owns all drop targets.
- `packIntoRows` + `widthToClass` exported from form-runtime so the
  designer reuses them. No code duplication.

## Quality gate

`pnpm typecheck`, `pnpm lint` clean.
