### PR TITLE
feat(housekeeping): storage card, largest-tables card, type-aware item sizing (#161)

### DIFF
--- a/apps/portal-api/src/admin/admin.module.ts
+++ b/apps/portal-api/src/admin/admin.module.ts
@@ -13,6 +13,7 @@ import { V3TablesModule } from '../features-v3/v3-tables.module.js';
 import { ItemsModule } from '../items/items.module.js';
 import { NotificationsModule } from '../notifications/notifications.module.js';
 import { NotificationsAdminController } from '../notifications/admin.controller.js';
+import { StorageModule } from '../storage/storage.module.js';
 
 /**
  * Wires the admin surfaces: Keycloak integration (users +
@@ -27,7 +28,7 @@ import { NotificationsAdminController } from '../notifications/admin.controller.
  * management yet.
  */
 @Module({
-  imports: [V3TablesModule, ItemsModule, NotificationsModule],
+  imports: [V3TablesModule, ItemsModule, NotificationsModule, StorageModule],
   controllers: [
     AdminUsersController,
     AdminBrandingController,

--- a/apps/portal-api/src/admin/housekeeping.controller.ts
+++ b/apps/portal-api/src/admin/housekeeping.controller.ts
@@ -78,6 +78,27 @@ export class HousekeepingController {
   }
 
   /**
+   * Storage telemetry (#161). Postgres total size, MinIO bucket
+   * usage, host-disk free / total. The MinIO walk is O(objects),
+   * so this endpoint is fetched lazily on Housekeeping page render
+   * and not as part of the lighter `summary` cards.
+   */
+  @Get('storage')
+  storage() {
+    return this.housekeeping.storageMetrics();
+  }
+
+  /**
+   * Top N tables by total relation size (#161). Read-only diagnostic
+   * for "which table is bloating the cluster"; returns schema /
+   * name / total / table / index bytes plus a row estimate.
+   */
+  @Get('largest-tables')
+  largestTables() {
+    return this.housekeeping.largestTables();
+  }
+
+  /**
    * "Soon to expire" share rows (#86). `?within=` is the lookahead
    * window in days; defaults to 30. Already-expired rows are
    * included with `isExpired: true` so the admin can extend or

--- a/apps/portal-api/src/admin/housekeeping.service.ts
+++ b/apps/portal-api/src/admin/housekeeping.service.ts
@@ -1,3 +1,4 @@
+import { statfs } from 'node:fs/promises';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import type { ItemType } from '@prisma/client';
@@ -18,6 +19,7 @@ import {
   extractDependencies,
   normalizeArcgisUrl,
 } from '../items/dependency-extractor.js';
+import { StorageService } from '../storage/storage.service.js';
 
 /**
  * Heuristics-based analytics for the /admin/housekeeping page.
@@ -46,6 +48,7 @@ export class HousekeepingService {
     private readonly cfg: ConfigService,
     private readonly v3Tables: V3TablesService,
     private readonly credentials: CredentialService,
+    private readonly storage: StorageService,
   ) {}
 
   private get staleItemDays(): number {
@@ -283,44 +286,240 @@ export class HousekeepingService {
    * anyway; #65 follow-up can split that out.
    */
   async largeItems(orgId: string) {
-    // pg_column_size accounts for compression; octet_length of the
-    // JSON text is closer to "bytes the client saw". Close enough
-    // for housekeeping: we just want a sortable proxy.
-    const rows = await this.prisma.$queryRaw<
-      Array<{
-        id: string;
-        title: string;
-        type: string;
-        owner_id: string;
-        owner_label: string | null;
-        bytes: bigint;
-        updated_at: Date;
-      }>
-    >`
+    // Two passes. First, the JSON metadata size of every item (cheap;
+    // single-statement scan). Second, for v3 data_layer items, the
+    // sum of pg_total_relation_size over each item's per-layer
+    // feature tables (`fs_<itemIdNoDashes>_*`). Adding those gives
+    // total backend footprint, not just metadata. Form submissions
+    // and file attachments aren't attributed back to their owning
+    // item here -- those show up under the "Largest database tables"
+    // card (form_submission table) and are tracked separately on the
+    // MinIO usage row. Mixing them in here would require either a
+    // join keyed on form_id (different unit) or an N+1 walk into
+    // MinIO (slow). The follow-up to track per-item sizeBytes on
+    // upload would close those gaps.
+    type RawRow = {
+      id: string;
+      title: string;
+      type: string;
+      owner_id: string;
+      owner_label: string | null;
+      metadata_bytes: bigint;
+      data_bytes: bigint | null;
+      updated_at: Date;
+    };
+    const rows = await this.prisma.$queryRaw<RawRow[]>`
+      WITH meta AS (
+        SELECT
+          i.id,
+          i.title,
+          i.type,
+          i.owner_id,
+          COALESCE(NULLIF(u.full_name, ''), u.username) AS owner_label,
+          octet_length(i.data_json::text)::bigint AS metadata_bytes,
+          i.updated_at
+        FROM "item" i
+        LEFT JOIN "user" u ON u.id = i.owner_id
+        WHERE i.org_id = ${orgId}::uuid
+          AND i.deleted_at IS NULL
+      ),
+      data_sizes AS (
+        SELECT
+          (REPLACE(SUBSTRING(c.relname FROM 4 FOR 32), '_', '-')) AS item_id_compact,
+          SUM(pg_total_relation_size(c.oid))::bigint AS bytes
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relkind = 'r'
+          AND c.relname LIKE 'fs\_%' ESCAPE '\'
+        GROUP BY 1
+      )
       SELECT
-        i.id,
-        i.title,
-        i.type,
-        i.owner_id,
-        COALESCE(NULLIF(u.full_name, ''), u.username) AS owner_label,
-        octet_length(i.data_json::text) AS bytes,
-        i.updated_at
-      FROM "item" i
-      LEFT JOIN "user" u ON u.id = i.owner_id
-      WHERE i.org_id = ${orgId}::uuid
-        AND i.deleted_at IS NULL
-      ORDER BY bytes DESC
+        m.id,
+        m.title,
+        m.type,
+        m.owner_id,
+        m.owner_label,
+        m.metadata_bytes,
+        d.bytes AS data_bytes,
+        m.updated_at
+      FROM meta m
+      LEFT JOIN data_sizes d
+        ON d.item_id_compact = REPLACE(m.id::text, '-', '')
+      ORDER BY (m.metadata_bytes + COALESCE(d.bytes, 0)) DESC
       LIMIT ${this.topN}
     `;
+    return rows.map((r) => {
+      const metadataBytes = Number(r.metadata_bytes);
+      const dataBytes = r.data_bytes == null ? 0 : Number(r.data_bytes);
+      return {
+        id: r.id,
+        title: r.title,
+        type: r.type as string,
+        ownerId: r.owner_id,
+        ownerLabel: r.owner_label ?? r.owner_id.slice(0, 8),
+        // Total = metadata JSON + (for data_layer) feature-table footprint.
+        sizeBytes: metadataBytes + dataBytes,
+        metadataBytes,
+        // dataBytes is set only for items whose feature tables we
+        // can attribute back via the fs_<itemId>_* naming pattern --
+        // i.e. v3 data_layer items. 0 for everything else.
+        dataBytes,
+        updatedAt: r.updated_at.toISOString(),
+      };
+    });
+  }
+
+  /**
+   * High-level storage telemetry surfaced on the Housekeeping page
+   * (#161). Three sources stitched together so the operator can
+   * answer "are we running low on disk" in one glance:
+   *
+   *   - postgres: total database size (pg_database_size). The
+   *                bulk of GratisGIS data lives here -- feature
+   *                tables, form submissions, item metadata.
+   *   - minio:    object count + bytes across the configured
+   *                bucket. Thumbnails, hero images, avatars,
+   *                feature attachments. Computed by walking
+   *                ListObjectsV2; null if MinIO isn't reachable.
+   *   - host:     free / total bytes on the volume the API
+   *                process is running on (statfs over '/'). On
+   *                a docker-compose deployment this is the same
+   *                volume as the postgres data dir for most
+   *                operators, so it's the right "are we full"
+   *                signal even though it's not an exact match.
+   *                Returns null on unsupported platforms.
+   *
+   * All values are cheap to compute except the bucket walk, which
+   * is O(N objects). The caller (HousekeepingController.storage)
+   * is expected to be hit on demand -- not on every page render --
+   * so a few hundred ms on a large bucket is fine.
+   */
+  async storageMetrics() {
+    const [dbSize, hostDisk, bucket] = await Promise.all([
+      this.queryDatabaseSize(),
+      this.queryHostDisk(),
+      this.storage.getBucketUsage(),
+    ]);
+    return {
+      postgres: {
+        databaseName: dbSize.databaseName,
+        totalBytes: dbSize.totalBytes,
+      },
+      minio: bucket
+        ? {
+            bucket: this.storage.bucketName,
+            objectCount: bucket.objectCount,
+            totalBytes: bucket.totalBytes,
+            unavailable: false,
+          }
+        : {
+            bucket: this.storage.bucketName,
+            objectCount: 0,
+            totalBytes: 0,
+            unavailable: true,
+          },
+      host: hostDisk,
+    };
+  }
+
+  /**
+   * Top N database tables by total relation size (heap + indexes +
+   * TOAST). Useful when one feature table is bloating the cluster
+   * and the operator wants to know which one. Joins to pg_stat_user_tables
+   * for live row-count estimates. Limited to public-schema regular
+   * tables so we skip toast/index/sequence noise.
+   */
+  async largestTables() {
+    type Row = {
+      schema: string;
+      name: string;
+      total_bytes: bigint;
+      table_bytes: bigint;
+      index_bytes: bigint;
+      row_estimate: number | null;
+    };
+    const rows = await this.prisma.$queryRaw<Row[]>`
+      SELECT
+        n.nspname AS schema,
+        c.relname AS name,
+        pg_total_relation_size(c.oid)::bigint AS total_bytes,
+        pg_relation_size(c.oid)::bigint AS table_bytes,
+        (pg_total_relation_size(c.oid) - pg_relation_size(c.oid))::bigint
+          AS index_bytes,
+        c.reltuples::float8::int AS row_estimate
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND c.relkind = 'r'
+      ORDER BY pg_total_relation_size(c.oid) DESC
+      LIMIT 10
+    `;
     return rows.map((r) => ({
-      id: r.id,
-      title: r.title,
-      type: r.type as string,
-      ownerId: r.owner_id,
-      ownerLabel: r.owner_label ?? r.owner_id.slice(0, 8),
-      sizeBytes: Number(r.bytes),
-      updatedAt: r.updated_at.toISOString(),
+      schema: r.schema,
+      name: r.name,
+      totalBytes: Number(r.total_bytes),
+      tableBytes: Number(r.table_bytes),
+      indexBytes: Number(r.index_bytes),
+      rowEstimate: r.row_estimate ?? 0,
     }));
+  }
+
+  /**
+   * Total bytes used by the current Postgres database. Includes
+   * heap, indexes, TOAST, and per-relation FSM. Cheap (O(1) catalog
+   * lookup); safe to call on every Housekeeping page render.
+   */
+  private async queryDatabaseSize(): Promise<{
+    databaseName: string;
+    totalBytes: number;
+  }> {
+    const rows = await this.prisma.$queryRaw<
+      Array<{ db: string; size: bigint }>
+    >`
+      SELECT
+        current_database() AS db,
+        pg_database_size(current_database())::bigint AS size
+    `;
+    const r = rows[0];
+    return {
+      databaseName: r?.db ?? 'unknown',
+      totalBytes: r ? Number(r.size) : 0,
+    };
+  }
+
+  /**
+   * Free / total bytes on the volume hosting the API process.
+   * Returns null when statfs isn't supported (older Node, exotic
+   * platform): the UI hides the disk gauge in that case rather
+   * than guessing.
+   */
+  private async queryHostDisk(): Promise<{
+    mountPoint: string;
+    totalBytes: number;
+    freeBytes: number;
+  } | null> {
+    // We probe the filesystem the API process is on. On a typical
+    // single-host docker-compose deployment, the postgres data
+    // volume and the MinIO data volume both live on this same
+    // disk, so this is a defensible "the box is full" signal.
+    // Operators who split data across volumes should replace this
+    // with a deployment-specific monitor (#161 follow-up).
+    const probePath = process.platform === 'win32' ? 'C:\\' : '/';
+    try {
+      const s = await statfs(probePath);
+      // Node's StatFs reports bsize + blocks + bavail. Multiply for
+      // bytes. bavail (not bfree) is what's available to a non-root
+      // user; that's the right "we can write more" number.
+      const totalBytes = Number(BigInt(s.bsize) * BigInt(s.blocks));
+      const freeBytes = Number(BigInt(s.bsize) * BigInt(s.bavail));
+      return { mountPoint: probePath, totalBytes, freeBytes };
+    } catch (err) {
+      this.log.warn(
+        `Disk metrics unavailable: ${err instanceof Error ? err.message : err}`,
+      );
+      return null;
+    }
   }
 
   /**

--- a/apps/portal-api/src/storage/storage.service.ts
+++ b/apps/portal-api/src/storage/storage.service.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import {
   CreateBucketCommand,
   HeadBucketCommand,
+  ListObjectsV2Command,
   PutBucketCorsCommand,
   PutBucketPolicyCommand,
   PutObjectCommand,
@@ -240,5 +241,62 @@ export class StorageService implements OnModuleInit {
   /** Exposed for DTO tests and error messages. */
   get allowedContentTypes(): ReadonlySet<string> {
     return ALLOWED_CONTENT_TYPES;
+  }
+
+  /**
+   * The bucket name we're configured to use. The Housekeeping page
+   * shows it next to the usage readout so the operator can spot a
+   * misconfigured deployment (e.g., still pointing at a leftover
+   * dev bucket) at a glance.
+   */
+  get bucketName(): string {
+    return this.bucket;
+  }
+
+  /**
+   * Walk every object in the bucket and total count + bytes.
+   *
+   * Used by the Housekeeping admin page (#161) to surface MinIO
+   * usage. ListObjectsV2 returns up to 1000 keys per page; we paginate
+   * via ContinuationToken until done. For a deployment with many
+   * thousands of objects this is O(N), so the controller calls it
+   * lazily (only when the admin opens the Storage card) rather than
+   * on every page render.
+   *
+   * Returns null if the bucket can't be enumerated (MinIO down at
+   * boot, credentials wrong, etc.) so the UI can surface that
+   * gracefully without a 500.
+   */
+  async getBucketUsage(): Promise<{
+    objectCount: number;
+    totalBytes: number;
+  } | null> {
+    let objectCount = 0;
+    let totalBytes = 0;
+    let continuationToken: string | undefined;
+    try {
+      do {
+        const cmd = new ListObjectsV2Command({
+          Bucket: this.bucket,
+          ...(continuationToken
+            ? { ContinuationToken: continuationToken }
+            : {}),
+        });
+        const res = await this.client.send(cmd);
+        for (const obj of res.Contents ?? []) {
+          objectCount += 1;
+          totalBytes += obj.Size ?? 0;
+        }
+        continuationToken = res.IsTruncated
+          ? res.NextContinuationToken
+          : undefined;
+      } while (continuationToken);
+      return { objectCount, totalBytes };
+    } catch (err) {
+      this.log.warn(
+        `Bucket usage query failed: ${err instanceof Error ? err.message : err}`,
+      );
+      return null;
+    }
   }
 }

--- a/apps/portal-web/src/app/admin/housekeeping/housekeeping-view.tsx
+++ b/apps/portal-web/src/app/admin/housekeeping/housekeeping-view.tsx
@@ -11,6 +11,8 @@ import {
   ChevronRight,
   Clock,
   Database,
+  HardDrive,
+  Layers,
   Loader2,
   Timer,
   Trash2,
@@ -74,8 +76,53 @@ export interface HousekeepingBundle {
     type: string;
     ownerId: string;
     ownerLabel: string;
+    /** Total = metadataBytes + dataBytes (the latter is non-zero only
+     *  for data_layer items, where it sums every per-layer feature
+     *  table). Sort key. */
     sizeBytes: number;
+    /** Just the item's JSON blob in the `item` table. */
+    metadataBytes: number;
+    /** For data_layer items: pg_total_relation_size summed across the
+     *  v3 feature tables (`fs_<itemIdNoDashes>_*`). 0 for any other
+     *  type -- file attachments and form submissions aren't attributed
+     *  back to the item here; they're visible in the storage cards. */
+    dataBytes: number;
     updatedAt: string;
+  }>;
+  /** Storage telemetry (#161). Rendered as a single card at the top
+   *  of the page so the operator can answer "are we running low" at
+   *  a glance. */
+  storage: {
+    postgres: {
+      databaseName: string;
+      totalBytes: number;
+    };
+    minio: {
+      bucket: string;
+      objectCount: number;
+      totalBytes: number;
+      /** True when MinIO couldn't be enumerated (down at boot, wrong
+       *  credentials, etc.). UI shows a fallback message instead of a
+       *  misleading "0 bytes". */
+      unavailable: boolean;
+    };
+    /** Null when statfs isn't supported on the API host (older Node /
+     *  exotic platform). UI hides the gauge in that case. */
+    host: {
+      mountPoint: string;
+      totalBytes: number;
+      freeBytes: number;
+    } | null;
+  };
+  /** Top 10 tables by pg_total_relation_size (#161). Diagnostic
+   *  for "which table is bloating the cluster". */
+  largestTables: Array<{
+    schema: string;
+    name: string;
+    totalBytes: number;
+    tableBytes: number;
+    indexBytes: number;
+    rowEstimate: number;
   }>;
   expiringShares: Array<{
     itemId: string;
@@ -114,6 +161,8 @@ export function HousekeepingView({ bundle }: Props) {
     largeItems,
     expiringShares,
     expiringUsers,
+    storage,
+    largestTables,
   } = bundle;
 
   // One selection set per table: items and users live in different
@@ -464,6 +513,12 @@ export function HousekeepingView({ bundle }: Props) {
         </div>
       ) : null}
 
+      {/* Storage usage (#161). Single card: host-disk gauge plus
+          per-store readouts (Postgres + MinIO). The disk gauge is
+          the "are we running low" signal at a glance; the readouts
+          tell the operator which store dominates. */}
+      <StorageCard storage={storage} />
+
       {/* Soon-to-expire shares (#86). Mixes already-expired
           (red) and within-window (amber) rows so the admin can
           deal with both in one place. Empty list collapses to a
@@ -635,11 +690,25 @@ export function HousekeepingView({ bundle }: Props) {
         />
       ) : null}
 
+      {/* Top tables by total relation size (#161). Diagnostic for
+          "which table is bloating the cluster" -- if the database
+          card above is heavy, this is where to look. */}
+      <Section
+        icon={<Layers className="h-4 w-4" />}
+        title="Largest database tables"
+        empty="No tables to report."
+        caption="Top 10 tables in the public schema by total size (heap + indexes). The fs_* tables are the per-layer feature stores for individual data_layer items; form_submission holds every form response."
+      >
+        {largestTables.length === 0 ? null : (
+          <LargestTablesTable rows={largestTables} />
+        )}
+      </Section>
+
       <Section
         icon={<Database className="h-4 w-4" />}
-        title="Largest items by stored size"
+        title="Largest items by total size"
         empty="No items yet."
-        caption="Rough size of the item's settings and metadata. Heavier items are the ones most likely to be slow to load or copy around. Actual map tiles, feature rows, and uploaded files live in separate storage and aren't counted here."
+        caption="Each item's settings/metadata blob plus, for data_layer items, the per-layer feature tables that hold the actual rows and geometry. File attachments and form submissions aren't attributed back to their owning items here -- attachments live in MinIO (see the Storage card above) and submissions live in form_submission (see the Largest database tables card)."
       >
         {largeItems.length === 0 ? null : (
           <LargeItemsTable rows={largeItems} />
@@ -1071,7 +1140,14 @@ function LargeItemsTable({
             <td className="px-4 py-2 text-muted">{r.type}</td>
             <td className="px-4 py-2 text-muted">{r.ownerLabel}</td>
             <td className="px-4 py-2 font-mono text-ink-0">
-              {formatBytes(r.sizeBytes)}
+              <span title="Total backend footprint: metadata JSON plus, for data_layer items, the per-layer feature tables.">
+                {formatBytes(r.sizeBytes)}
+              </span>
+              {r.dataBytes > 0 ? (
+                <span className="ml-2 text-[10px] text-muted">
+                  ({formatBytes(r.dataBytes)} data + {formatBytes(r.metadataBytes)} meta)
+                </span>
+              ) : null}
             </td>
             <td className="px-4 py-2 text-muted">
               {new Date(r.updatedAt).toLocaleDateString()}
@@ -1084,6 +1160,167 @@ function LargeItemsTable({
                 Open
                 <ChevronRight className="h-3 w-3" />
               </Link>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+/**
+ * Top-of-page storage telemetry card (#161). Three readouts plus a
+ * single visual gauge. We pick "host disk used %" as the gauge
+ * because that's the universal "are we running out" signal: even
+ * if Postgres dominates today, when the disk fills the postgres
+ * data dir, MinIO bucket, and backup archive all stop writing.
+ *
+ * The gauge color steps from accent (cool) -> amber (warn at 75%)
+ * -> danger (crit at 90%) so a quick glance from across the room
+ * tells the operator how worried to be.
+ */
+function StorageCard({
+  storage,
+}: {
+  storage: HousekeepingBundle['storage'];
+}) {
+  const host = storage.host;
+  const usedBytes = host ? host.totalBytes - host.freeBytes : 0;
+  const usedPct = host && host.totalBytes > 0
+    ? (usedBytes / host.totalBytes) * 100
+    : 0;
+  const tone =
+    usedPct >= 90
+      ? 'bg-danger'
+      : usedPct >= 75
+        ? 'bg-amber-400'
+        : 'bg-accent';
+  return (
+    <section className="rounded-md border border-border bg-surface-1">
+      <header className="flex items-center gap-2 border-b border-border bg-surface-2 px-4 py-2 text-xs font-medium text-ink-1">
+        <HardDrive className="h-4 w-4 text-muted" />
+        <span>Storage usage</span>
+      </header>
+      <div className="space-y-3 p-4">
+        {host ? (
+          <div>
+            <div className="mb-1 flex items-baseline justify-between text-xs">
+              <span className="text-muted">
+                Host disk{' '}
+                <span className="font-mono text-[11px]">
+                  {host.mountPoint}
+                </span>
+              </span>
+              <span className="text-ink-0">
+                <span className="font-mono">{formatBytes(host.freeBytes)}</span>
+                <span className="text-muted"> free of </span>
+                <span className="font-mono">{formatBytes(host.totalBytes)}</span>
+                <span className="text-muted">
+                  {' '}
+                  ({usedPct.toFixed(0)}% used)
+                </span>
+              </span>
+            </div>
+            <div className="h-2 w-full overflow-hidden rounded-full bg-surface-2">
+              <div
+                className={`h-full ${tone} transition-all`}
+                style={{ width: `${Math.min(100, usedPct).toFixed(1)}%` }}
+              />
+            </div>
+            {usedPct >= 75 ? (
+              <p className="mt-1 text-[11px] text-amber-700">
+                Free space is running low. Backups, MinIO uploads, and
+                Postgres autovacuum all need headroom on this volume.
+              </p>
+            ) : null}
+          </div>
+        ) : (
+          <p className="text-xs text-muted">
+            Host disk metrics aren't available on this platform.
+          </p>
+        )}
+
+        <dl className="grid grid-cols-1 gap-3 text-xs sm:grid-cols-2">
+          <div className="rounded-md border border-border bg-surface-0 p-3">
+            <dt className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted">
+              <Database className="h-3.5 w-3.5" />
+              Postgres
+            </dt>
+            <dd className="mt-1 font-mono text-base text-ink-0">
+              {formatBytes(storage.postgres.totalBytes)}
+            </dd>
+            <dd className="mt-0.5 text-[11px] text-muted">
+              database{' '}
+              <span className="font-mono">{storage.postgres.databaseName}</span>{' '}
+              (heap + indexes + TOAST)
+            </dd>
+          </div>
+          <div className="rounded-md border border-border bg-surface-0 p-3">
+            <dt className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted">
+              <Archive className="h-3.5 w-3.5" />
+              MinIO
+            </dt>
+            <dd className="mt-1 font-mono text-base text-ink-0">
+              {storage.minio.unavailable
+                ? 'unavailable'
+                : formatBytes(storage.minio.totalBytes)}
+            </dd>
+            <dd className="mt-0.5 text-[11px] text-muted">
+              {storage.minio.unavailable ? (
+                <>bucket couldn't be enumerated; check MinIO connectivity</>
+              ) : (
+                <>
+                  bucket{' '}
+                  <span className="font-mono">{storage.minio.bucket}</span>
+                  {' · '}
+                  {storage.minio.objectCount.toLocaleString()} object
+                  {storage.minio.objectCount === 1 ? '' : 's'}
+                </>
+              )}
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+  );
+}
+
+function LargestTablesTable({
+  rows,
+}: {
+  rows: HousekeepingBundle['largestTables'];
+}) {
+  return (
+    <table className="w-full text-sm">
+      <thead className="bg-surface-2 text-left text-[11px] uppercase tracking-wide text-muted">
+        <tr>
+          <th className="px-4 py-2">Table</th>
+          <th className="px-4 py-2">Total</th>
+          <th className="px-4 py-2">Heap</th>
+          <th className="px-4 py-2">Indexes</th>
+          <th className="px-4 py-2">Rows (est.)</th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-border">
+        {rows.map((r) => (
+          <tr key={`${r.schema}.${r.name}`}>
+            <td className="px-4 py-2 font-mono text-ink-0">
+              {r.name}
+              {r.schema !== 'public' ? (
+                <span className="text-muted">.{r.schema}</span>
+              ) : null}
+            </td>
+            <td className="px-4 py-2 font-mono text-ink-0">
+              {formatBytes(r.totalBytes)}
+            </td>
+            <td className="px-4 py-2 font-mono text-muted">
+              {formatBytes(r.tableBytes)}
+            </td>
+            <td className="px-4 py-2 font-mono text-muted">
+              {formatBytes(r.indexBytes)}
+            </td>
+            <td className="px-4 py-2 font-mono text-muted">
+              {r.rowEstimate >= 0 ? r.rowEstimate.toLocaleString() : '–'}
             </td>
           </tr>
         ))}

--- a/apps/portal-web/src/app/admin/housekeeping/page.tsx
+++ b/apps/portal-web/src/app/admin/housekeeping/page.tsx
@@ -38,6 +38,8 @@ export default async function AdminHousekeepingPage() {
       largeItems,
       expiringShares,
       expiringUsers,
+      storage,
+      largestTables,
       config,
       runs,
     ] = await Promise.all([
@@ -59,6 +61,12 @@ export default async function AdminHousekeepingPage() {
       apiFetch<HousekeepingBundle['expiringUsers']>(
         '/api/admin/housekeeping/expiring-users',
       ),
+      apiFetch<HousekeepingBundle['storage']>(
+        '/api/admin/housekeeping/storage',
+      ),
+      apiFetch<HousekeepingBundle['largestTables']>(
+        '/api/admin/housekeeping/largest-tables',
+      ),
       apiFetch<HousekeepingConfig>('/api/admin/housekeeping/config'),
       apiFetch<HousekeepingRun[]>(
         '/api/admin/housekeeping/runs?limit=10',
@@ -71,6 +79,8 @@ export default async function AdminHousekeepingPage() {
       largeItems,
       expiringShares,
       expiringUsers,
+      storage,
+      largestTables,
     };
     scheduleConfig = config;
     scheduleRuns = runs;


### PR DESCRIPTION
## Summary

The Housekeeping page now answers "are we running low on disk?"
and "what's eating the database?" at a glance, and the long-
misleading "Largest items by stored size" card finally measures
the right thing.

## Storage usage card (new)

Top of the Housekeeping page. A single visual gauge plus three
readouts.

- **Visual gauge:** host-disk used %. Slides accent -> amber (75%)
  -> danger (90%). Below 75% it's a calm bar; above 90% it's
  shouting at you.
- **Host disk:** free / total bytes on the volume the API is
  running on, via `fs/promises.statfs`. On a single-host docker
  compose this is also where the Postgres data dir, MinIO bucket,
  and backup archive live, so it's the right "are we full?"
  signal even if it isn't perfectly granular.
- **Postgres:** `pg_database_size(current_database())`. Heap +
  indexes + TOAST + per-relation FSM.
- **MinIO:** object count + total bytes via paginated
  `ListObjectsV2`. Bucket name is shown so a misconfigured
  deployment is easy to spot.

Each readout fails closed: statfs unsupported -> gauge hidden;
MinIO unreachable -> "unavailable" label.

## Largest database tables card (new)

Top 10 public-schema tables by `pg_total_relation_size`, with
total / heap / indexes / row estimate columns. Useful when the
Postgres readout is heavy and you need to know *which* table.

The caption notes that `fs_*` are per-layer feature stores for
individual data_layer items, and `form_submission` is the shared
table holding every form response.

## "Largest items" -- now type-aware

**Before.** `octet_length(data_json::text)` only. So a 50-row
data_layer with a long description beat a 50,000-row data_layer
with a short one. The label said "by stored size" but it was
really "by metadata size".

**After.** Total = metadata bytes + (for data_layer items) the
sum of `pg_total_relation_size` over `fs_<itemIdNoDashes>_*`. The
Size column shows the total; data_layer rows also show
`(X data + Y meta)` so the split is visible.

The card's title and caption are rewritten to be honest about
scope: attachments live in MinIO (Storage card) and form
submissions live in `form_submission` (Largest database tables).
Per-item attribution for those two stores is a follow-up that
needs a `sizeBytes` column tracked at upload time.

## What changed

API:

- `StorageService` gains `getBucketUsage()` (paginated
  `ListObjectsV2` totalling count + bytes) and a `bucketName`
  getter. Null return on enumeration failure.
- `HousekeepingService` gains `storageMetrics()` (postgres +
  MinIO + host disk) and `largestTables()`. `largeItems()` is
  rewritten as a CTE joining per-item metadata bytes to a
  per-item sum over `fs_*` feature tables, ordered by their sum.
- `AdminModule` imports `StorageModule`.
- `HousekeepingController` exposes `GET /admin/housekeeping/storage`
  and `GET /admin/housekeeping/largest-tables`.

Web:

- `housekeeping-view.tsx` adds `StorageCard` + `LargestTablesTable`
  components, threads the new bundle fields, and rewrites the
  Largest-items caption.
- `page.tsx` fetches the two new endpoints in parallel with the
  existing six.

## Follow-ups

- Track `sizeBytes` on `Item` for `file` items at upload time so
  the Largest-items card can attribute MinIO bytes back to their
  owning item.
- Same idea for form submissions: per-form aggregation could fold
  `form_submission` rows into the owning form item's row.

## Quality gate

`pnpm typecheck`, `pnpm lint` clean. Hot-reloaded API verified
serving the new endpoints on :4000.
