### PR TITLE
fix(forms): Add condition button now actually adds a row

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -2222,7 +2222,13 @@ function Properties({
       <details className="mt-3 rounded-md border border-border bg-surface-1 p-2 text-xs">
         <summary className="cursor-pointer text-muted">Conditional logic</summary>
         <div className="mt-2 space-y-3">
+          {/* `key` forces a fresh editor instance when the selected
+              question changes. The editor holds local row state
+              (so partially-filled rows survive across "Add
+              condition" clicks); without the key, that local state
+              would leak across questions. */}
           <ExpressionEditor
+            key={`${question.id}:visibleIf`}
             label="Visible if"
             value={question.visibleIf}
             // Exclude the current question. A "visible if Species
@@ -2248,6 +2254,7 @@ function Properties({
               reads the question's own value (it's "is this answer
               valid"). */}
           <ExpressionEditor
+            key={`${question.id}:constraint`}
             label="Valid if"
             value={question.constraint}
             allFields={collectFieldRefs(form)}
@@ -3255,19 +3262,39 @@ function ExpressionEditor({
   disabled: boolean;
   onChange: (next: Expression | undefined) => void;
 }) {
-  const decomposed = decomposeExpression(value);
-  const isComplex = decomposed === null;
-  const rows = decomposed?.rows ?? [];
-  const combinator: 'and' | 'or' = decomposed?.combinator ?? 'and';
+  // Local state for the row list. We can't derive this from `value`
+  // on every render because composeExpression intentionally drops
+  // rows whose `ref` is empty -- a freshly-added row has no ref yet,
+  // so it would never persist back through `value` and the "Add
+  // condition" button would appear to do nothing.
+  //
+  // The parent wraps each ExpressionEditor in a `key` keyed by
+  // question id + slot, so when the user selects a different
+  // question the component remounts and re-initialises from the new
+  // `value`. That keeps state per-question without us having to
+  // diff `value` against local state in an effect.
+  const initial = decomposeExpression(value);
+  const [rows, setRows] = useState<ConditionRow[]>(initial?.rows ?? []);
+  const [combinator, setCombinator] = useState<'and' | 'or'>(
+    initial?.combinator ?? 'and',
+  );
+  // "Complex fallback" stays sticky for the lifetime of the component
+  // unless the user explicitly clears. Local state so the banner
+  // doesn't flicker on each re-render.
+  const [showComplexFallback, setShowComplexFallback] = useState(
+    initial === null,
+  );
 
   const update = (
     nextRows: ConditionRow[],
     nextCombinator: 'and' | 'or' = combinator,
   ) => {
+    setRows(nextRows);
+    setCombinator(nextCombinator);
     onChange(composeExpression(nextCombinator, nextRows));
   };
 
-  if (isComplex) {
+  if (showComplexFallback) {
     return (
       <div>
         <p className="mb-0.5 text-[10px] uppercase tracking-wide text-muted">
@@ -3282,7 +3309,12 @@ function ExpressionEditor({
           <button
             type="button"
             disabled={disabled}
-            onClick={() => onChange(undefined)}
+            onClick={() => {
+              setRows([]);
+              setCombinator('and');
+              setShowComplexFallback(false);
+              onChange(undefined);
+            }}
             className="inline-flex items-center gap-1 rounded border border-amber-300 bg-white px-1.5 py-0.5 text-[11px] hover:bg-amber-100 disabled:opacity-50"
           >
             Clear and start over


### PR DESCRIPTION
## Summary

Hot-fix for #162: clicking "Add condition" did nothing visible.

## What was broken

`composeExpression` intentionally drops rows whose `ref` is empty,
so they don't persist as half-baked AST. A freshly-added row from
`DEFAULT_ROW()` has `ref: ''`, which means:

1. Click "Add condition" -> rows = `[DEFAULT_ROW()]`.
2. composeExpression filters that out -> returns `undefined`.
3. `onChange(undefined)` -> parent re-renders with `value=undefined`.
4. The editor decomposes that to zero rows.
5. Nothing visible changed.

## Fix

Hold the row list in component state. Writes still flow through
`composeExpression` so the persisted `Expression` only contains
complete rows, but the in-flight rows now survive between "Add"
clicks until the author picks a field.

Per-question state isolation comes from a `key={question.id +
slot}` on each `ExpressionEditor` instance, so switching the
selected question remounts the editor with the new `value` and no
stale rows leak across questions.

Also turned the "Complex expression" fallback into a local sticky
flag so clicking "Clear and start over" drops the banner instead of
getting re-derived from the old `value` next render.

## Quality gate

`pnpm typecheck`, `pnpm lint` clean.
