### PR TITLE
feat(forms): calculate on every QuestionBase + designer surface (#164)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -2263,6 +2263,31 @@ function Properties({
               onChange({ constraint } as Partial<Question>)
             }
           />
+          {/* Calculate -- #164 Slice 3. Any question type that
+              captures a value can opt in to being computed. When set,
+              the runtime evaluates the expression after every
+              response change and forces the question read-only.
+              Hidden for layout / display-only types since they don't
+              hold a value to compute. */}
+          {isLayoutType(question.type) ? null : (
+            <ExpressionEditor
+              key={`${question.id}:calculate`}
+              label="Calculate (computed value)"
+              value={question.calculate}
+              // Self-reference is allowed but pointless (would loop).
+              // Filter the current question out to nudge authors
+              // toward a sensible expression; if they really want
+              // self-reference they can switch to the Builder modal
+              // which doesn't filter.
+              allFields={collectFieldRefs(form).filter(
+                (f) => f.id !== question.id,
+              )}
+              disabled={!canEdit}
+              onChange={(calculate) =>
+                onChange({ calculate } as Partial<Question>)
+              }
+            />
+          )}
         </div>
       </details>
     </aside>

--- a/apps/portal-web/src/components/form-runtime.tsx
+++ b/apps/portal-web/src/components/form-runtime.tsx
@@ -984,7 +984,7 @@ function Input({
       return (
         <div className="rounded-md border border-border bg-surface-2/40 px-3 py-2 text-sm text-ink-1">
           {value === null || value === undefined || value === ''
-            ? '—'
+            ? '-'
             : String(value)}
         </div>
       );
@@ -2357,6 +2357,12 @@ function collectIdsOnPage(page: Page): Set<string> {
 }
 
 function isReadOnly(q: Question, response: Response): boolean {
+  // A calculated question -- whether the dedicated `calculated`
+  // type or a QuestionBase with the optional `calculate` field
+  // (#164) -- is always read-only. The respondent isn't meant to
+  // override a derived value, and applyCalculations would just
+  // overwrite their edit on the next render anyway.
+  if (q.type === 'calculated' || q.calculate) return true;
   if (q.readOnly === undefined || q.readOnly === false) return false;
   if (q.readOnly === true) return true;
   return Boolean(evaluate(q.readOnly as Expression, response));

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -188,6 +188,20 @@ interface QuestionBase {
   message?: string | undefined;
   /** Read-only: the runtime renders a value but does not allow edits. */
   readOnly?: boolean | Expression | undefined;
+  /** Optional derived value. When set, the runtime evaluates this
+   *  expression after every response change and writes the result
+   *  into the response under this question's id. A question with a
+   *  `calculate` is implicitly read-only -- the respondent isn't
+   *  meant to override a derived value -- so the runtime treats it
+   *  the same as `readOnly: true` regardless of the explicit flag.
+   *
+   *  Historically this lived only on the dedicated `calculated`
+   *  question type, but in #164 it moved here so any question type
+   *  (number, date, text, select, …) can carry a derived value
+   *  without forcing authors to pick a different type. The
+   *  `calculated` type still works (its own `calculate` field is
+   *  required); the optional one here is the broader knob. */
+  calculate?: Expression | undefined;
   /** Layer binding (Field runtime only). */
   bindTo?: BindTo | undefined;
   /** Per-question layout (width within the form column). */
@@ -1583,10 +1597,12 @@ function validateType(q: Question, value: unknown): string | null {
 // ---------------------------------------------------------------------------
 
 /**
- * For every `calculated` question whose dependencies have changed,
- * recompute its value and write it into the response. Returns the
- * mutated response (callers can rely on identity equality when
- * nothing changed).
+ * For every question carrying a `calculate` expression -- whether
+ * it's the dedicated `calculated` type (required `calculate`) or any
+ * other type that opts in via the optional QuestionBase.calculate
+ * (#164) -- recompute its value and write it into the response.
+ * Returns the mutated response (callers can rely on identity
+ * equality when nothing changed).
  */
 export function applyCalculations(
   form: FormSchema,
@@ -1595,8 +1611,14 @@ export function applyCalculations(
   let next = response;
   let changed = false;
   for (const q of walkQuestions(form)) {
-    if (q.type !== 'calculated') continue;
-    const computed = evaluate(q.calculate, response);
+    // Pull the expression from either source: the required field on
+    // the `calculated` type, or the optional QuestionBase one. We
+    // prefer the type-specific field when it exists so v3-import or
+    // legacy data round-trips cleanly.
+    const expr =
+      q.type === 'calculated' ? q.calculate : q.calculate ?? undefined;
+    if (!expr) continue;
+    const computed = evaluate(expr, response);
     if (next[q.id] !== computed) {
       if (!changed) {
         next = { ...response };


### PR DESCRIPTION
Slice 3 of the expression builder series. Lets any question type opt into being computed via a new optional `calculate?: Expression` on QuestionBase, surfaced through the same row-based ExpressionEditor used by Visible-If and Valid-If. The runtime treats any question with `calculate` set as read-only. Drive-by: replaced one pre-existing em-dash in form-runtime.tsx with a hyphen to match the no-em-dash project rule. `pnpm typecheck` / `pnpm lint` clean.