### PR TITLE
feat(forms): expression Slice 4 - matches op + 12 new BUILTINS + quick-start shortcuts (#165)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -3157,7 +3157,7 @@ function ComponentToggleEditor<T extends string>({
  * "text" field actually holds numeric content.
  */
 const COMPARISON_OPERATORS: ReadonlyArray<{
-  op: 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'between';
+  op: 'eq' | 'neq' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'between' | 'matches';
   label: string;
   /** True when the right-hand side is a single value, false when
    *  this op uses a different shape (in: list-ish; between: min+max). */
@@ -3171,6 +3171,10 @@ const COMPARISON_OPERATORS: ReadonlyArray<{
   { op: 'lte', label: 'less than or equal', rhsKind: 'value' },
   { op: 'in', label: 'contains', rhsKind: 'value' },
   { op: 'between', label: 'between', rhsKind: 'range' },
+  // Slice 4 (#165): regex match. RHS is a regex pattern as a string;
+  // the evaluator anchors with implicit ^...$. The same row UI works
+  // because rhsKind = 'value' and we read the raw string.
+  { op: 'matches', label: 'matches pattern', rhsKind: 'value' },
 ];
 type ComparisonOp = (typeof COMPARISON_OPERATORS)[number]['op'];
 
@@ -3242,7 +3246,8 @@ function decomposeRow(expr: Expression): ConditionRow | null {
     expr.op === 'gte' ||
     expr.op === 'lt' ||
     expr.op === 'lte' ||
-    expr.op === 'in'
+    expr.op === 'in' ||
+    expr.op === 'matches'
   ) {
     if ('ref' in expr.left && 'value' in expr.right) {
       const v = expr.right.value;
@@ -3304,6 +3309,15 @@ function rowToExpression(r: ConditionRow): Expression {
       value: { ref: r.ref },
       min: { value: coerceLiteral(r.min) },
       max: { value: coerceLiteral(r.max) },
+    };
+  }
+  if (r.op === 'matches') {
+    // RHS is a regex pattern -- never coerce to number/boolean even
+    // if the pattern happens to look like one (e.g. "true|false").
+    return {
+      op: 'matches',
+      left: { ref: r.ref },
+      right: { value: r.value },
     };
   }
   return {
@@ -3762,6 +3776,45 @@ function ruleToExpression(rule: Rule): Expression | undefined {
 }
 
 /**
+ * Quick-start templates for the modal builder (Slice 4, #165). Each
+ * appends a pre-shaped row to the tree's top-level rules. The author
+ * still picks the field via the row's dropdown -- we just save them
+ * the operator + value-shape decisions for the common patterns.
+ *
+ * Patterns that need a function call on the left (Min length via
+ * len(), Selected option via selected(), etc.) aren't represented
+ * here yet because ConditionRow only models a `ref` left side. Those
+ * land alongside a value-mode editor for calculate / defaultValue
+ * in a future slice.
+ */
+type QuickStart = 'not-empty' | 'equals' | 'range' | 'regex';
+
+function insertQuickStartRow(
+  setTree: (next: RuleTree) => void,
+  tree: RuleTree,
+  allFields: FieldRef[],
+  kind: QuickStart,
+): void {
+  const ref = allFields[0]?.id ?? '';
+  const row: ConditionRow = (() => {
+    switch (kind) {
+      case 'not-empty':
+        return { ...DEFAULT_ROW(), ref, op: 'neq', value: '' };
+      case 'equals':
+        return { ...DEFAULT_ROW(), ref, op: 'eq', value: '' };
+      case 'range':
+        return { ...DEFAULT_ROW(), ref, op: 'between', min: '', max: '' };
+      case 'regex':
+        return { ...DEFAULT_ROW(), ref, op: 'matches', value: '' };
+    }
+  })();
+  setTree({
+    combinator: tree.combinator,
+    rules: [...tree.rules, { kind: 'row', row }],
+  });
+}
+
+/**
  * Modal "Expression Builder" reachable via the "Builder" link on
  * each ExpressionEditor heading. Two-column body: tree editor on
  * the left, reference panel (Fields / Operators / Functions) on
@@ -3817,12 +3870,56 @@ function ExpressionBuilderModal({
           </button>
         </header>
         <div className="grid grid-cols-[1fr_280px] divide-x divide-border overflow-hidden">
-          <div className="overflow-auto p-4">
-            <RuleTreeEditor
-              tree={tree}
-              allFields={allFields}
-              onChange={setTree}
-            />
+          <div className="flex min-h-0 flex-col overflow-hidden">
+            {/* Slice 4 (#165): quick-start shortcuts. Each button
+                inserts a pre-shaped row at the end of the tree's
+                current top-level rules, so the author skips the
+                operator-and-value typing. The buttons that need a
+                target field assume the FIRST field in `allFields`;
+                the author retunes the picker afterwards if needed.
+                Anything that requires a function call on the left
+                (Min length via len(), Selected option via selected(),
+                etc.) is a follow-up -- those need a richer row that
+                can take an Operand on the left, which lands when the
+                modal grows a value-mode editor for calculate. */}
+            <div className="flex flex-wrap gap-1.5 border-b border-border bg-surface-1/40 px-4 py-2 text-[11px]">
+              <span className="self-center text-muted">Quick start:</span>
+              <button
+                type="button"
+                onClick={() => insertQuickStartRow(setTree, tree, allFields, 'not-empty')}
+                className="rounded border border-border bg-surface-0 px-2 py-0.5 hover:bg-surface-2"
+              >
+                Required (not empty)
+              </button>
+              <button
+                type="button"
+                onClick={() => insertQuickStartRow(setTree, tree, allFields, 'equals')}
+                className="rounded border border-border bg-surface-0 px-2 py-0.5 hover:bg-surface-2"
+              >
+                Equals value
+              </button>
+              <button
+                type="button"
+                onClick={() => insertQuickStartRow(setTree, tree, allFields, 'range')}
+                className="rounded border border-border bg-surface-0 px-2 py-0.5 hover:bg-surface-2"
+              >
+                Range (between)
+              </button>
+              <button
+                type="button"
+                onClick={() => insertQuickStartRow(setTree, tree, allFields, 'regex')}
+                className="rounded border border-border bg-surface-0 px-2 py-0.5 hover:bg-surface-2"
+              >
+                Regex pattern
+              </button>
+            </div>
+            <div className="min-h-0 flex-1 overflow-auto p-4">
+              <RuleTreeEditor
+                tree={tree}
+                allFields={allFields}
+                onChange={setTree}
+              />
+            </div>
           </div>
           <aside className="flex min-h-0 flex-col bg-surface-1">
             <nav className="flex border-b border-border text-xs">
@@ -4117,42 +4214,91 @@ function OperatorsReferencePanel() {
   );
 }
 
-/** Functions reference panel: lists the existing 8 BUILTINS, with
- *  copy describing each. Slice 4 expands the registry and makes
- *  these clickable to insert call-shaped operands. */
+/** Functions reference panel: lists every BUILTIN the runtime
+ *  evaluator supports. Pure reference -- click-to-insert into a
+ *  calculate field's left-side Operand is a follow-up that needs the
+ *  modal to grow a value-mode editor (Operand-shaped, not Expression-
+ *  shaped). For visibleIf / constraint these are mainly informational
+ *  context for the author. */
 function FunctionsReferencePanel() {
-  const fns: Array<{ name: string; sig: string; hint: string }> = [
-    { name: 'today', sig: 'today()', hint: 'current date as YYYY-MM-DD' },
-    { name: 'now', sig: 'now()', hint: 'current ISO datetime' },
-    { name: 'len', sig: 'len(text)', hint: 'string length' },
-    { name: 'sum', sig: 'sum(a, b, …)', hint: 'numeric sum of refs / values' },
+  const groups: Array<{
+    heading: string;
+    fns: Array<{ sig: string; hint: string }>;
+  }> = [
     {
-      name: 'count',
-      sig: 'count(field)',
-      hint: 'number of selected choices in a select-many',
+      heading: 'Date / time',
+      fns: [
+        { sig: 'today()', hint: 'current date as YYYY-MM-DD' },
+        { sig: 'now()', hint: 'current ISO datetime' },
+      ],
     },
-    { name: 'coalesce', sig: 'coalesce(a, b, …)', hint: 'first non-null value' },
-    { name: 'lower', sig: 'lower(text)', hint: 'lowercase' },
-    { name: 'upper', sig: 'upper(text)', hint: 'uppercase' },
+    {
+      heading: 'Text',
+      fns: [
+        { sig: 'len(text)', hint: 'string length' },
+        { sig: 'lower(text)', hint: 'lowercase' },
+        { sig: 'upper(text)', hint: 'uppercase' },
+        { sig: 'trim(text)', hint: 'strip leading + trailing whitespace' },
+        { sig: 'contains(s, sub)', hint: 'does the string contain a substring?' },
+        { sig: 'starts_with(s, prefix)', hint: 'string starts with prefix' },
+        { sig: 'ends_with(s, suffix)', hint: 'string ends with suffix' },
+        {
+          sig: 'substring(s, start, end?)',
+          hint: '0-based slice; end omitted means to end',
+        },
+      ],
+    },
+    {
+      heading: 'Numeric',
+      fns: [
+        { sig: 'sum(a, b, ...)', hint: 'numeric sum of refs / values' },
+        { sig: 'abs(n)', hint: 'absolute value' },
+        { sig: 'round(n, places?)', hint: 'rounds to `places` decimals (default 0)' },
+        { sig: 'floor(n)', hint: 'round down to integer' },
+        { sig: 'ceil(n)', hint: 'round up to integer' },
+        { sig: 'min_of(a, b, ...)', hint: 'smallest numeric arg, ignoring nulls' },
+        { sig: 'max_of(a, b, ...)', hint: 'largest numeric arg, ignoring nulls' },
+      ],
+    },
+    {
+      heading: 'Selection / null',
+      fns: [
+        {
+          sig: 'count(field)',
+          hint: 'number of selected choices in a select-many',
+        },
+        {
+          sig: 'selected(field, value)',
+          hint: 'true when `value` is among a select-many\'s choices',
+        },
+        { sig: 'coalesce(a, b, ...)', hint: 'first non-null / non-empty value' },
+      ],
+    },
   ];
   return (
-    <div>
-      <p className="mb-2 text-[10px] text-muted">
-        Slice 4 adds click-to-insert and many more functions (regex,
-        contains, substr, selected, …). For now this is a reference of
-        what the runtime evaluator supports.
+    <div className="space-y-3">
+      <p className="text-[10px] text-muted">
+        Reference. The runtime evaluator supports each of these on
+        both browser and server.
       </p>
-      <ul className="space-y-1">
-        {fns.map((f) => (
-          <li
-            key={f.name}
-            className="rounded border border-border bg-surface-0 px-2 py-1"
-          >
-            <p className="font-mono text-[12px] text-ink-0">{f.sig}</p>
-            <p className="text-[10px] text-muted">{f.hint}</p>
-          </li>
-        ))}
-      </ul>
+      {groups.map((g) => (
+        <div key={g.heading}>
+          <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted">
+            {g.heading}
+          </p>
+          <ul className="space-y-1">
+            {g.fns.map((f) => (
+              <li
+                key={f.sig}
+                className="rounded border border-border bg-surface-0 px-2 py-1"
+              >
+                <p className="font-mono text-[11px] text-ink-0">{f.sig}</p>
+                <p className="text-[10px] text-muted">{f.hint}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
     </div>
   );
 }

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -847,6 +847,17 @@ export type Expression =
   | { op: 'not'; operand: Expression }
   | { op: 'in'; left: Operand; right: Operand }
   | { op: 'between'; value: Operand; min: Operand; max: Operand }
+  /** Test a value against a regex pattern. The right operand is the
+   *  pattern (string); the evaluator anchors with implicit ^...$ to
+   *  match XLSForm semantics (whole-value match) and applies optional
+   *  flags via the `flags` field (e.g. "i" for case-insensitive).
+   *  Added in Slice 4 of the expression builder series (#165). */
+  | {
+      op: 'matches';
+      left: Operand;
+      right: Operand;
+      flags?: string;
+    }
   | {
       op: 'add' | 'sub' | 'mul' | 'div';
       left: Operand;
@@ -865,12 +876,26 @@ export type Operand =
 export const BUILTINS = [
   'today', // current date as YYYY-MM-DD string
   'now', // current ISO datetime string
-  'len', // string length
+  'len', // string length (or array length)
   'sum', // numeric sum of a list of refs/values
   'count', // count of selected choices in a select-many
   'coalesce', // first non-null
   'lower',
   'upper',
+  // Slice 4 (#165) additions. All ship in both browser + server via
+  // the same evaluator; no new dependencies.
+  'trim', // strip leading + trailing whitespace
+  'contains', // contains(haystack, needle): does the string contain the substring?
+  'starts_with', // starts_with(s, prefix)
+  'ends_with', // ends_with(s, suffix)
+  'substring', // substring(s, start, end?): start/end are 0-based
+  'abs', // numeric absolute value
+  'round', // round(n, places?): banker's-free, default 0 places
+  'floor',
+  'ceil',
+  'min_of', // min_of(a, b, ...): smallest numeric arg, ignoring nulls
+  'max_of', // max_of(a, b, ...): largest numeric arg, ignoring nulls
+  'selected', // selected(field, value): is `value` in the array (select-many)
 ] as const;
 export type BuiltinName = (typeof BUILTINS)[number];
 
@@ -922,6 +947,25 @@ export function evaluate(expr: Expression | undefined, response: Response): unkn
       const hi = numericResolve(expr.max, response);
       if (v === null || lo === null || hi === null) return false;
       return v >= lo && v <= hi;
+    }
+    case 'matches': {
+      const subject = resolve(expr.left, response);
+      const pattern = resolve(expr.right, response);
+      if (typeof subject !== 'string' || typeof pattern !== 'string') {
+        return false;
+      }
+      try {
+        // Implicit ^...$ anchoring: the responder's whole answer must
+        // match. This is the XLSForm convention and matches the
+        // existing Pattern-question semantics in validateValue. A bad
+        // pattern is a designer-side error, not a respondent-blocking
+        // condition, so we treat construction failures as a no-match
+        // (false) rather than throwing.
+        const re = new RegExp(`^(?:${pattern})$`, expr.flags ?? '');
+        return re.test(subject);
+      } catch {
+        return false;
+      }
     }
     case 'add':
     case 'sub':
@@ -1029,6 +1073,86 @@ function callBuiltin(
     case 'upper': {
       const v = args[0] ? resolve(args[0], response) : null;
       return typeof v === 'string' ? v.toUpperCase() : v;
+    }
+    case 'trim': {
+      const v = args[0] ? resolve(args[0], response) : null;
+      return typeof v === 'string' ? v.trim() : v;
+    }
+    case 'contains': {
+      const hay = args[0] ? resolve(args[0], response) : null;
+      const needle = args[1] ? resolve(args[1], response) : null;
+      if (typeof hay !== 'string' || typeof needle !== 'string') return false;
+      return hay.includes(needle);
+    }
+    case 'starts_with': {
+      const s = args[0] ? resolve(args[0], response) : null;
+      const prefix = args[1] ? resolve(args[1], response) : null;
+      if (typeof s !== 'string' || typeof prefix !== 'string') return false;
+      return s.startsWith(prefix);
+    }
+    case 'ends_with': {
+      const s = args[0] ? resolve(args[0], response) : null;
+      const suffix = args[1] ? resolve(args[1], response) : null;
+      if (typeof s !== 'string' || typeof suffix !== 'string') return false;
+      return s.endsWith(suffix);
+    }
+    case 'substring': {
+      const s = args[0] ? resolve(args[0], response) : null;
+      const start = args[1] ? numericResolve(args[1], response) : 0;
+      const end = args[2] ? numericResolve(args[2], response) : null;
+      if (typeof s !== 'string') return '';
+      const a = start ?? 0;
+      return end === null ? s.substring(a) : s.substring(a, end);
+    }
+    case 'abs': {
+      const v = args[0] ? numericResolve(args[0], response) : null;
+      return v === null ? null : Math.abs(v);
+    }
+    case 'round': {
+      const v = args[0] ? numericResolve(args[0], response) : null;
+      const places = args[1] ? numericResolve(args[1], response) : 0;
+      if (v === null) return null;
+      const p = places ?? 0;
+      const m = Math.pow(10, p);
+      return Math.round(v * m) / m;
+    }
+    case 'floor': {
+      const v = args[0] ? numericResolve(args[0], response) : null;
+      return v === null ? null : Math.floor(v);
+    }
+    case 'ceil': {
+      const v = args[0] ? numericResolve(args[0], response) : null;
+      return v === null ? null : Math.ceil(v);
+    }
+    case 'min_of': {
+      let best: number | null = null;
+      for (const a of args) {
+        const v = numericResolve(a, response);
+        if (v === null) continue;
+        if (best === null || v < best) best = v;
+      }
+      return best;
+    }
+    case 'max_of': {
+      let best: number | null = null;
+      for (const a of args) {
+        const v = numericResolve(a, response);
+        if (v === null) continue;
+        if (best === null || v > best) best = v;
+      }
+      return best;
+    }
+    case 'selected': {
+      // selected(field, value): for select-many fields whose value is
+      // an array of selected option values, true when `value` is one
+      // of them. Mirrors the XLSForm convention so authors who know
+      // the ODK pattern feel at home.
+      const field = args[0] ? resolve(args[0], response) : null;
+      const target = args[1] ? resolve(args[1], response) : null;
+      if (Array.isArray(field)) {
+        return field.some((v) => v === target);
+      }
+      return field === target;
     }
   }
 }


### PR DESCRIPTION
Slice 4 of the expression builder series. Adds the matches operator (regex test with implicit anchoring + flags), expands BUILTINS from 8 to 20 (trim, contains, starts_with, ends_with, substring, abs, round, floor, ceil, min_of, max_of, selected), and surfaces four quick-start shortcuts in the modal builder header (Required not-empty, Equals value, Range, Regex pattern). Functions reference panel now groups by category. Typecheck/lint clean.