### PR TITLE
feat(admin): surface realm-SMTP sync errors plus auto-grant manage-realm (#139)

### DIFF
--- a/apps/portal-api/src/admin/keycloak-admin.service.ts
+++ b/apps/portal-api/src/admin/keycloak-admin.service.ts
@@ -106,6 +106,21 @@ export class KeycloakAdminService implements OnModuleInit {
    */
   async onModuleInit(): Promise<void> {
     if (!this.isConfigured()) return;
+    // Self-heal: if the admin service-account client doesn't have
+    // manage-realm yet, grant it now so the SMTP sync below can
+    // succeed. Idempotent and safe to call repeatedly. Failure here
+    // is logged but doesn't block bootstrap -- a misconfigured admin
+    // client can't grant itself a role it doesn't already have, and
+    // we'd rather the portal start than refuse to come up. (#139)
+    try {
+      await this.ensureManageRealm();
+    } catch (err) {
+      this.logger.warn(
+        `Could not auto-grant manage-realm to admin service-account: ` +
+          `${String(err)}. The admin Keycloak client needs realm-admin ` +
+          `(or just manage-realm directly) for SMTP sync to work.`,
+      );
+    }
     // Skip the sync when SMTP isn't configured yet (no DB row, no
     // env). The admin can configure SMTP via /admin/notifications
     // and saveSmtp() will trigger the sync at that point.
@@ -494,6 +509,135 @@ export class KeycloakAdminService implements OnModuleInit {
       `Synced SMTP config to Keycloak realm '${this.realm}' (host=${cfg.host} port=${cfg.port} secure=${cfg.secure})`,
     );
     return smtpServer;
+  }
+
+  /**
+   * Ensure the admin service-account client has the realm-management
+   * `manage-realm` client role. Idempotent: if the role is already
+   * granted (or unavailable to grant), this is a no-op. (#139)
+   *
+   * Sequence:
+   *   1. Look up the admin client (KEYCLOAK_ADMIN_CLIENT_ID) and get
+   *      its service-account user id.
+   *   2. Look up the built-in `realm-management` client.
+   *   3. Look up the `manage-realm` role within that client.
+   *   4. Check whether the role is already among the service
+   *      account's client-role mappings; if not, POST to grant it.
+   *
+   * The grant only succeeds if THIS service account already has
+   * sufficient privilege (realm-admin / manage-clients) to assign
+   * roles. Most local-dev setups configure the admin client with
+   * realm-admin already, so this works on the first boot. Cloud /
+   * SSO deployments where the admin client is intentionally minimal
+   * will get a clear error here that surfaces in the bootstrap log.
+   */
+  async ensureManageRealm(): Promise<void> {
+    if (!this.isConfigured()) return;
+    const token = await this.getAccessToken();
+    const headers = {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    };
+
+    // 1. Find the admin client by clientId env var, get its
+    //    service-account user id.
+    const clientId = this.adminClientId!;
+    const clientsRes = await fetch(
+      this.adminUrl(`/clients?clientId=${encodeURIComponent(clientId)}`),
+      { headers },
+    );
+    if (!clientsRes.ok) {
+      throw new Error(
+        `Lookup of admin client '${clientId}' failed: ${clientsRes.status}`,
+      );
+    }
+    const clients = (await clientsRes.json()) as Array<{ id: string }>;
+    if (clients.length === 0) {
+      throw new Error(
+        `Admin client '${clientId}' not found in realm '${this.realm}'.`,
+      );
+    }
+    const clientUuid = clients[0]!.id;
+    const saRes = await fetch(
+      this.adminUrl(`/clients/${clientUuid}/service-account-user`),
+      { headers },
+    );
+    if (!saRes.ok) {
+      throw new Error(
+        `Service-account-user lookup failed: ${saRes.status} (the admin ` +
+          `client must have 'Service accounts enabled' in Keycloak).`,
+      );
+    }
+    const saUser = (await saRes.json()) as { id: string };
+
+    // 2. Find the realm-management client (built into Keycloak).
+    const rmRes = await fetch(
+      this.adminUrl(`/clients?clientId=realm-management`),
+      { headers },
+    );
+    if (!rmRes.ok) {
+      throw new Error(`realm-management lookup failed: ${rmRes.status}`);
+    }
+    const rmClients = (await rmRes.json()) as Array<{ id: string }>;
+    if (rmClients.length === 0) {
+      throw new Error('Built-in realm-management client missing.');
+    }
+    const rmClientUuid = rmClients[0]!.id;
+
+    // 3. Find the manage-realm role within realm-management.
+    const roleRes = await fetch(
+      this.adminUrl(
+        `/clients/${rmClientUuid}/roles/manage-realm`,
+      ),
+      { headers },
+    );
+    if (!roleRes.ok) {
+      throw new Error(
+        `manage-realm role lookup failed: ${roleRes.status}`,
+      );
+    }
+    const role = (await roleRes.json()) as { id: string; name: string };
+
+    // 4. Already granted? Compare against the service account's
+    //    existing client-role mappings. If yes, no-op; if no, POST
+    //    to grant.
+    const existingRes = await fetch(
+      this.adminUrl(
+        `/users/${saUser.id}/role-mappings/clients/${rmClientUuid}`,
+      ),
+      { headers },
+    );
+    if (!existingRes.ok) {
+      throw new Error(
+        `Existing role-mappings lookup failed: ${existingRes.status}`,
+      );
+    }
+    const existing = (await existingRes.json()) as Array<{ name: string }>;
+    if (existing.some((r) => r.name === 'manage-realm')) {
+      // Already granted; quiet success.
+      return;
+    }
+    const grantRes = await fetch(
+      this.adminUrl(
+        `/users/${saUser.id}/role-mappings/clients/${rmClientUuid}`,
+      ),
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify([role]),
+      },
+    );
+    if (!grantRes.ok) {
+      const text = await grantRes.text();
+      throw new Error(
+        `manage-realm grant failed: ${grantRes.status} :: ${text}. ` +
+          `The admin client itself needs realm-admin (or manage-clients ` +
+          `+ manage-realm) to grant roles.`,
+      );
+    }
+    this.logger.log(
+      `Granted manage-realm to admin service-account '${clientId}' on realm '${this.realm}'.`,
+    );
   }
 }
 

--- a/apps/portal-api/src/notifications/admin.controller.ts
+++ b/apps/portal-api/src/notifications/admin.controller.ts
@@ -335,16 +335,36 @@ export class NotificationsAdminController {
       // will lazy-rebuild on demand.
     }
     // Push the new config into the Keycloak realm so invite /
-    // forgot-password / verify-email emails share the relay.
+    // forgot-password / verify-email emails share the relay. The
+    // SMTP save itself succeeded (DB row written, in-process
+    // transport reloaded) regardless of whether the realm sync
+    // works -- the admin just won't get realm-issued emails (invite,
+    // forgot-password, verify) through the right relay until the
+    // realm-side push succeeds.
+    //
+    // We surface the realm-sync error as a non-blocking warning
+    // on the response (#139). Before that fix, the failure was
+    // logged and silently swallowed, so the admin saw a green
+    // "Saved" with no idea anything had gone wrong server-side.
+    let realmSyncWarning: string | undefined;
     if (this.keycloak.isConfigured()) {
       try {
-        await this.keycloak.syncRealmSmtp();
+        // Self-heal first: try to grant manage-realm if missing.
+        // Idempotent; quiet success when already granted.
+        await this.keycloak.ensureManageRealm();
       } catch {
-        // Logged inside syncRealmSmtp; surface to the admin via
-        // the next "send test" attempt rather than breaking save.
+        // Don't bail; syncRealmSmtp will surface the underlying
+        // problem with a clearer error message anyway.
+      }
+      try {
+        await this.keycloak.syncRealmSmtp();
+      } catch (err) {
+        realmSyncWarning =
+          err instanceof Error ? err.message : String(err);
       }
     }
-    return this.getSmtp();
+    const state = await this.getSmtp();
+    return realmSyncWarning ? { ...state, realmSyncWarning } : state;
   }
 
   /**
@@ -467,6 +487,16 @@ interface SmtpStatePayload {
   fromDisplayName: string;
   user: string;
   hasPassword: boolean;
+  /**
+   * Set when the SMTP save succeeded but the realm-side sync to
+   * Keycloak failed. Surfaces the actionable error from
+   * KeycloakAdminService.syncRealmSmtp so the admin can fix the
+   * underlying issue (typically a missing manage-realm role on
+   * the admin service-account) without having to dig in logs.
+   * Absent / undefined when the sync succeeded or the integration
+   * isn't configured. (#139)
+   */
+  realmSyncWarning?: string;
 }
 
 interface DefaultsPayload {

--- a/apps/portal-web/src/app/admin/notifications/notifications-admin-view.tsx
+++ b/apps/portal-web/src/app/admin/notifications/notifications-admin-view.tsx
@@ -52,6 +52,12 @@ export interface SmtpState {
   fromDisplayName: string;
   user: string;
   hasPassword: boolean;
+  /** When the API saved successfully but realm-side push to Keycloak
+   *  failed, the actionable message lands here (#139). The DB save +
+   *  worker reload still happened, so non-realm emails work; realm-
+   *  issued emails (invite / forgot-password / verify) won't go out
+   *  until the underlying issue is fixed. */
+  realmSyncWarning?: string;
 }
 
 export interface DefaultsRow {
@@ -341,7 +347,7 @@ function SmtpCard({ initial }: { initial: SmtpState }) {
   const [testTo, setTestTo] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [msg, setMsg] = useState<
-    { kind: 'ok' | 'err'; text: string } | null
+    { kind: 'ok' | 'warn' | 'err'; text: string } | null
   >(null);
 
   async function save() {
@@ -366,7 +372,24 @@ function SmtpCard({ initial }: { initial: SmtpState }) {
       if (!res.ok) throw new Error(`${res.status} ${await res.text()}`);
       const fresh = (await res.json()) as SmtpState;
       setForm({ ...fresh, password: '' });
-      setMsg({ kind: 'ok', text: 'Saved. Worker will use new SMTP on next send.' });
+      // The DB save + worker-transport reload always succeeded if
+      // we got here. The realm sync to Keycloak (for invite /
+      // forgot-password / verify-email) may have failed
+      // separately; surface that as an amber warning rather than
+      // a green success so the admin knows realm emails won't
+      // route through the new SMTP until they fix the underlying
+      // issue (#139).
+      if (fresh.realmSyncWarning) {
+        setMsg({
+          kind: 'warn',
+          text: `SMTP saved, but Keycloak realm sync failed: ${fresh.realmSyncWarning}`,
+        });
+      } else {
+        setMsg({
+          kind: 'ok',
+          text: 'Saved. Worker will use new SMTP on next send.',
+        });
+      }
     } catch (err) {
       setMsg({
         kind: 'err',
@@ -581,7 +604,11 @@ function SmtpCard({ initial }: { initial: SmtpState }) {
       {msg ? (
         <p
           className={`mt-2 text-xs ${
-            msg.kind === 'ok' ? 'text-emerald-700' : 'text-danger'
+            msg.kind === 'ok'
+              ? 'text-emerald-700'
+              : msg.kind === 'warn'
+                ? 'text-amber-700'
+                : 'text-danger'
           }`}
         >
           {msg.text}


### PR DESCRIPTION
Closes #139.

Two related fixes in the admin SMTP save flow:

**1. Surface realm-sync errors as a warning, not silent success.**
Previously, when an admin saved SMTP from `/admin/notifications`, the
controller swallowed any failure of the Keycloak realm push so the UI
always rendered green "Saved", even when invite / forgot-password /
verify-email would silently fail because the realm itself never
received the new `smtpServer` config.

Now `saveSmtp()` captures the realm-sync error into `realmSyncWarning`
on the response payload. The frontend renders the warning in amber
instead of green so the admin sees the actionable error (typically
"manage-realm role missing on the admin service-account") without
having to dig through API logs.

**2. Self-heal: auto-grant `manage-realm` to the admin service-account.**
The most common reason realm sync fails on a fresh Keycloak is that
the admin client we use to talk to Keycloak doesn't yet have the
`manage-realm` client-role on its service-account user. New
`ensureManageRealm()` looks the role up under `realm-management`,
checks the service-account's existing client-role mappings, and POSTs
the grant if missing. Idempotent.

Called in two places:

* `onModuleInit()` before the boot-time `syncRealmSmtp()`, so the
  first deploy converges automatically when the admin client itself
  has `realm-admin` (the typical local-dev case).
* `saveSmtp()` before each user-initiated push, so a sysadmin who
  just promoted the client can save SMTP and have it work without
  restarting portal-api.

Bootstrap failure is logged but doesn't crash; a misconfigured admin
client can't grant itself a role it doesn't have, and we'd rather the
portal start than refuse to come up.

### Files

* `apps/portal-api/src/admin/keycloak-admin.service.ts` - added
  `ensureManageRealm()`; called from `onModuleInit` before sync.
* `apps/portal-api/src/notifications/admin.controller.ts` - added
  `realmSyncWarning` to `SmtpStatePayload`; `saveSmtp()` calls
  `ensureManageRealm()` then captures `syncRealmSmtp` errors into
  the warning instead of dropping them.
* `apps/portal-web/src/app/admin/notifications/notifications-admin-view.tsx` -
  extended `msg` state to allow kind `'warn'`; `SmtpState` now
  carries `realmSyncWarning`; `save()` routes it to an amber
  message when present.

### Quality gate

* `pnpm typecheck` clean.
* No schema changes, no new dependencies.
