### PR TITLE
feat(seed): replace bob/mateo dev users with admin/contributor/viewer (#170)

### DIFF
--- a/GIT_SETUP.md
+++ b/GIT_SETUP.md
@@ -148,8 +148,9 @@ pnpm dev
 
 You should then be able to:
 
-- Sign in at http://localhost:3000 as `bob` / `devpassword` (admin)
-  or `mateo` / `devpassword` (contributor) via Keycloak
+- Sign in at http://localhost:3000 as `admin` / `admin`,
+  `contributor` / `contributor`, or `viewer` / `viewer` via
+  Keycloak (passwords match usernames, dev-only)
 - Hit http://localhost:4000/docs for the Swagger UI
 - See the seeded Acme org, the Field Team group, and a few example
   items

--- a/apps/portal-api/prisma/seed.ts
+++ b/apps/portal-api/prisma/seed.ts
@@ -1,6 +1,12 @@
 /**
- * Dev seed. Mirrors the Keycloak realm seed: org `acme` with Mateo (contributor)
- * and Bob (admin), plus a group and a couple of example items.
+ * Dev seed. Mirrors the Keycloak realm seed: org `acme` with three
+ * generic users keyed on the role they exercise (admin, contributor,
+ * viewer). Passwords match usernames so a fresh-install reviewer can
+ * sign in without consulting docs.
+ *
+ * Replaces the older Mateo / Bob / Alice naming (#170): role-named
+ * accounts are easier to remember and self-document what each session
+ * is testing.
  *
  * Run: `pnpm --filter @gratis-gis/portal-api db:seed`
  */
@@ -9,10 +15,13 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 const ACME_ID = '11111111-1111-1111-1111-111111111111';
-// UUID preserved from the previous "Alice" seed so existing dev databases
-// stay aligned on foreign keys even though the human identifiers moved.
-const MATEO_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
-const BOB_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+// UUIDs preserved from the previous seed so existing dev databases
+// stay aligned on foreign keys even though the human identifiers
+// moved. CONTRIBUTOR_ID was Mateo (originally Alice); ADMIN_ID was
+// Bob. VIEWER_ID is brand new in this seed.
+const CONTRIBUTOR_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const ADMIN_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const VIEWER_ID = 'eeeeeeee-1111-eeee-1111-eeeeeeeeeeee';
 const GROUP_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
 
 async function main() {
@@ -25,31 +34,54 @@ async function main() {
 
   console.log('-> seeding users');
   await prisma.user.upsert({
-    where: { id: MATEO_ID },
+    where: { id: ADMIN_ID },
     update: {
-      username: 'mateo',
-      email: 'mateo@acme.test',
-      fullName: 'Mateo García',
+      username: 'admin',
+      email: 'admin@acme.test',
+      fullName: 'Admin User',
+      orgRole: 'admin',
     },
     create: {
-      id: MATEO_ID,
+      id: ADMIN_ID,
       orgId: org.id,
-      username: 'mateo',
-      email: 'mateo@acme.test',
-      fullName: 'Mateo García',
+      username: 'admin',
+      email: 'admin@acme.test',
+      fullName: 'Admin User',
+      orgRole: 'admin',
+    },
+  });
+  await prisma.user.upsert({
+    where: { id: CONTRIBUTOR_ID },
+    update: {
+      username: 'contributor',
+      email: 'contributor@acme.test',
+      fullName: 'Contributor User',
+      orgRole: 'contributor',
+    },
+    create: {
+      id: CONTRIBUTOR_ID,
+      orgId: org.id,
+      username: 'contributor',
+      email: 'contributor@acme.test',
+      fullName: 'Contributor User',
       orgRole: 'contributor',
     },
   });
   await prisma.user.upsert({
-    where: { id: BOB_ID },
-    update: {},
+    where: { id: VIEWER_ID },
+    update: {
+      username: 'viewer',
+      email: 'viewer@acme.test',
+      fullName: 'Viewer User',
+      orgRole: 'viewer',
+    },
     create: {
-      id: BOB_ID,
+      id: VIEWER_ID,
       orgId: org.id,
-      username: 'bob',
-      email: 'bob@acme.test',
-      fullName: 'Bob Example',
-      orgRole: 'admin',
+      username: 'viewer',
+      email: 'viewer@acme.test',
+      fullName: 'Viewer User',
+      orgRole: 'viewer',
     },
   });
 
@@ -63,23 +95,28 @@ async function main() {
       title: 'Field Team',
       description: 'Members collecting field data for Acme.',
       access: 'org',
-      ownerId: BOB_ID,
+      ownerId: ADMIN_ID,
     },
   });
   await prisma.groupMember.upsert({
-    where: { groupId_userId: { groupId: GROUP_ID, userId: MATEO_ID } },
+    where: { groupId_userId: { groupId: GROUP_ID, userId: CONTRIBUTOR_ID } },
     update: {},
-    create: { groupId: GROUP_ID, userId: MATEO_ID, role: 'member' },
+    create: { groupId: GROUP_ID, userId: CONTRIBUTOR_ID, role: 'member' },
   });
   await prisma.groupMember.upsert({
-    where: { groupId_userId: { groupId: GROUP_ID, userId: BOB_ID } },
+    where: { groupId_userId: { groupId: GROUP_ID, userId: ADMIN_ID } },
     update: {},
-    create: { groupId: GROUP_ID, userId: BOB_ID, role: 'admin' },
+    create: { groupId: GROUP_ID, userId: ADMIN_ID, role: 'admin' },
+  });
+  await prisma.groupMember.upsert({
+    where: { groupId_userId: { groupId: GROUP_ID, userId: VIEWER_ID } },
+    update: {},
+    create: { groupId: GROUP_ID, userId: VIEWER_ID, role: 'member' },
   });
 
   console.log('-> seeding items');
 
-  // Small demo feature service: a handful of points around the Acme HQ
+  // Small demo data_layer: a handful of points around the Acme HQ
   // neighborhood with a category attribute so unique-value and filter
   // UI have something to chew on.
   const demoBuildings = {
@@ -119,10 +156,10 @@ async function main() {
     create: {
       id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
       orgId: org.id,
-      ownerId: MATEO_ID,
+      ownerId: CONTRIBUTOR_ID,
       type: 'data_layer',
       title: 'Acme Buildings',
-      description: 'Demo feature service with the Acme campus buildings.',
+      description: 'Demo data layer with the Acme campus buildings.',
       tags: ['campus', 'buildings', 'demo'],
       data: {
         version: 1,
@@ -144,7 +181,7 @@ async function main() {
     create: {
       id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
       orgId: org.id,
-      ownerId: MATEO_ID,
+      ownerId: CONTRIBUTOR_ID,
       type: 'map',
       title: 'Acme HQ Campus Map',
       description: 'Basemap + building outlines, shared to the Field Team.',
@@ -162,7 +199,7 @@ async function main() {
     },
   });
 
-  console.log('✓ seed complete');
+  console.log('seed complete');
 }
 
 main()

--- a/apps/portal-api/src/auth/auth-sync.service.ts
+++ b/apps/portal-api/src/auth/auth-sync.service.ts
@@ -112,7 +112,7 @@ export class AuthSyncService {
     // We key on `username` rather than Keycloak's `sub`. The local user.id is
     // our own stable identifier (possibly seeded or provisioned before the user
     // ever touched Keycloak), while `sub` is the IdP's opaque id. Keying on
-    // username means a seeded `alice` and a Keycloak-authenticated `alice`
+    // username means a seeded `admin` and a Keycloak-authenticated `admin`
     // resolve to the same row, and downstream FKs (items, group memberships)
     // remain stable even if the IdP is swapped out or the sub changes.
     // After both the org and the user exist (the user upsert happens

--- a/apps/portal-api/src/items/items.service.ts
+++ b/apps/portal-api/src/items/items.service.ts
@@ -424,7 +424,7 @@ export class ItemsService {
       include: {
         shares: true,
         // Same lean owner projection the list endpoint uses, so the
-        // detail page header can render "Owner: Mateo Garcia" without
+        // detail page header can render "Owner: Contributor User" without
         // a separate lookup.
         owner: {
           select: {
@@ -1518,9 +1518,10 @@ export class ItemsService {
     // was shared.
     //
     // Earlier slice (#44) had a callerHasFolderAccess bypass that
-    // let folder shares cascade to every child. That confused Bob
-    // testing with Mateo: Bob's private map showed up under a
-    // shared parent folder. Ripped out 2026-04-26.
+    // let folder shares cascade to every child. That confused
+    // testing across users: an admin's private map showed up
+    // under a folder shared with a contributor. Ripped out
+    // 2026-04-26.
     const rows = await this.prisma.item.findMany({
       where: {
         AND: [

--- a/apps/portal-api/src/notifications/sample-payloads.ts
+++ b/apps/portal-api/src/notifications/sample-payloads.ts
@@ -23,7 +23,7 @@ export const SAMPLE_PAYLOADS: { [K in NotificationType]?: unknown } = {
     itemTitle: 'City Park Trees',
     itemType: 'data-layer',
     permission: 'view',
-    sharedByName: 'Bob Example',
+    sharedByName: 'Admin User',
     expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
   } satisfies ShareCreatedPayload,
   share_expiring: {
@@ -55,7 +55,7 @@ export const SAMPLE_PAYLOADS: { [K in NotificationType]?: unknown } = {
     dataLayerTitle: 'Storm Drains',
     layerKey: 'drains',
     featureId: 'drains/123',
-    createdByName: 'Alice Example',
+    createdByName: 'Contributor User',
     summary: 'Inspection #4127 (cracked grate)',
   } satisfies EditorFeatureCreatedPayload,
 };

--- a/apps/portal-api/src/notifications/templates.ts
+++ b/apps/portal-api/src/notifications/templates.ts
@@ -43,7 +43,7 @@ export interface ShareCreatedPayload {
   itemTitle: string;
   itemType: string;
   permission: 'view' | 'download' | 'edit' | 'admin';
-  /** Display name of the author who shared (e.g. "Bob Example"). */
+  /** Display name of the author who shared (e.g. "Admin User"). */
   sharedByName: string;
   /** Optional ISO expiry; rendered when present. */
   expiresAt?: string;

--- a/apps/portal-web/src/app/items/[id]/data-layer/provenance-panel.tsx
+++ b/apps/portal-web/src/app/items/[id]/data-layer/provenance-panel.tsx
@@ -25,7 +25,7 @@ interface Props {
   data: DataLayerData | null | undefined;
   /**
    * Optional map of userId -> display name. When present, the panel
-   * uses it to render 'by Mateo Garcia' instead of the raw uuid
+   * uses it to render 'by Contributor User' instead of the raw uuid
    * slice. Supplied from the server-rendered detail page.
    */
   userNames?: Record<string, string>;

--- a/apps/portal-web/src/app/items/[id]/folder/folder-detail.tsx
+++ b/apps/portal-web/src/app/items/[id]/folder/folder-detail.tsx
@@ -907,8 +907,8 @@ function SmartFolderPanel({
   );
 
   // When mounting with a pre-existing ownerId, fetch the
-  // matching display name so the user sees "Alice" not the
-  // UUID. Bounded one-shot lookup; failure is silent (the
+  // matching display name so the user sees the person's name
+  // not the UUID. Bounded one-shot lookup; failure is silent (the
   // editor falls back to showing the id, but at least the
   // Clear button still works).
   useEffect(() => {

--- a/apps/portal-web/src/components/item-sharing-indicator.tsx
+++ b/apps/portal-web/src/components/item-sharing-indicator.tsx
@@ -192,13 +192,14 @@ export function ItemSharingIndicator({
 
   // Show every share row, including a share whose principal is the
   // current viewer. Previously we filtered self-shares out as
-  // "don't tell the user they shared with themselves" -- but that
-  // filter mis-fires for sharees: when Mateo (not the owner) opens
-  // the popover on Bob's item, the share row TO Mateo is exactly
-  // what's granting him visibility, and hiding it made the popover
-  // read "0 shares" while the chip count agreed and lied. We keep
-  // the row visible and tag it "(you)" inside SharingRow; the
-  // remove button is hidden for self-shares regardless of
+  // "don't tell the user they shared with themselves", but that
+  // filter mis-fires for sharees: when a contributor (not the
+  // owner) opens the popover on someone else's item, the share row
+  // TO them is exactly what's granting visibility, and hiding it
+  // made the popover read "0 shares" while the chip count agreed
+  // and lied. We keep the row visible and tag it "(you)" inside
+  // SharingRow; the remove button is hidden for self-shares
+  // regardless of
   // canManage so users don't accidentally yank their own access.
   const visibleShares = currentShares;
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -134,9 +134,10 @@ Migrations apply the Prisma schema (auth tables, items, sharing,
 folders, etc.). The seed script creates:
 
 - Org **Acme Corp** (`acme`)
-- User **Mateo García** (username `mateo`, role `contributor`)
-- User **Bob Example** (username `bob`, role `admin`)
-- Group **Field Team** with both users as members
+- User **Admin User** (username `admin`, role `admin`)
+- User **Contributor User** (username `contributor`, role `contributor`)
+- User **Viewer User** (username `viewer`, role `viewer`)
+- Group **Field Team** with all three users as members
 - A couple of example items so the items page isn't empty
 
 These match the users that the Keycloak realm import already set
@@ -168,15 +169,19 @@ Keycloak's sign-in page.
 
 ## 6. Sign in
 
-Two test accounts are seeded on both sides:
+Three test accounts are seeded on both sides. Passwords match the
+username so a fresh-install reviewer can sign in without consulting
+docs.
 
 | Username | Password | Role | Why use this one |
 | --- | --- | --- | --- |
-| `bob` | `devpassword` | Org admin | Sees every item in Acme; can manage users / branding / housekeeping |
-| `mateo` | `devpassword` | Contributor | Sees only what's shared with him; the realistic "everyday user" view |
+| `admin` | `admin` | Org admin | Sees every item in Acme; can manage users / branding / housekeeping |
+| `contributor` | `contributor` | Contributor | Sees only what's shared with them; can create new items |
+| `viewer` | `viewer` | Viewer | Read-only; the realistic "everyday consumer" view |
 
-Sign in as Bob first to take the admin tour, then sign out and
-sign in as Mateo to see what a non-admin's portal looks like.
+Sign in as `admin` first to take the admin tour, then sign out and
+sign in as `contributor` (or `viewer`) to see what a non-admin's
+portal looks like.
 
 If you need to add more users, create them in Keycloak under
 realm `gratis-gis`. The portal-api auto-syncs Keycloak users into

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -11,16 +11,17 @@ If the dev environment isn't running yet, see [SETUP.md](./SETUP.md).
 
 ## Sign in
 
-Open <http://localhost:3000>. Two seeded accounts on a fresh
-install:
+Open <http://localhost:3000>. Three seeded accounts on a fresh
+install (passwords match the username, dev-only):
 
-- **`bob` / `devpassword`** — admin in org Acme, sees every
-  item in the org
-- **`mateo` / `devpassword`** — contributor in org Acme, only
-  sees items shared with him
+- **`admin` / `admin`**: admin in org Acme, sees every item
+  in the org and can manage users, branding, housekeeping
+- **`contributor` / `contributor`**: contributor in org Acme,
+  can create items and only sees items shared with them
+- **`viewer` / `viewer`**: viewer in org Acme, read-only
 
-Sign in as Bob first to see the full surface, then re-test as
-Mateo to feel the sharing model.
+Sign in as `admin` first to see the full surface, then re-test
+as `contributor` or `viewer` to feel the sharing model.
 
 
 ## Vocabulary (AGO ↔ GratisGIS)
@@ -173,7 +174,7 @@ can still delete; the dependent items will fail gracefully on
 the missing reference.
 
 
-## Admin features (Bob only)
+## Admin features (admin only)
 
 `/admin` surfaces, in roughly the order of usefulness:
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -17,7 +17,7 @@ Keycloak is pre-seeded with:
 
 - Realm: `gratis-gis`
 - Clients: `portal-web`, `portal-api`, `field-app`
-- Users: `mateo` (contributor) and `bob` (admin) in org `acme`, password `devpassword`
+- Users: `admin` / `contributor` / `viewer` in org `acme`; password matches the username (dev-only)
 
 ## Usage
 

--- a/infra/keycloak/realm-gratis-gis.json
+++ b/infra/keycloak/realm-gratis-gis.json
@@ -148,16 +148,42 @@
   },
   "users": [
     {
-      "username": "mateo",
-      "email": "mateo@acme.test",
-      "firstName": "Mateo",
-      "lastName": "Garc\u00eda",
+      "username": "admin",
+      "email": "admin@acme.test",
+      "firstName": "Admin",
+      "lastName": "User",
       "enabled": true,
       "emailVerified": true,
       "credentials": [
         {
           "type": "password",
-          "value": "devpassword",
+          "value": "admin",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "admin"
+      ],
+      "attributes": {
+        "org": [
+          "acme"
+        ],
+        "org_role": [
+          "admin"
+        ]
+      }
+    },
+    {
+      "username": "contributor",
+      "email": "contributor@acme.test",
+      "firstName": "Contributor",
+      "lastName": "User",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "contributor",
           "temporary": false
         }
       ],
@@ -174,28 +200,28 @@
       }
     },
     {
-      "username": "bob",
-      "email": "bob@acme.test",
-      "firstName": "Bob",
-      "lastName": "Example",
+      "username": "viewer",
+      "email": "viewer@acme.test",
+      "firstName": "Viewer",
+      "lastName": "User",
       "enabled": true,
       "emailVerified": true,
       "credentials": [
         {
           "type": "password",
-          "value": "devpassword",
+          "value": "viewer",
           "temporary": false
         }
       ],
       "realmRoles": [
-        "admin"
+        "viewer"
       ],
       "attributes": {
         "org": [
           "acme"
         ],
         "org_role": [
-          "admin"
+          "viewer"
         ]
       }
     },


### PR DESCRIPTION
Closes #170.

Generic role-named seed accounts where the password matches the
username so a fresh-install reviewer can sign in without
consulting docs.

* `mateo` (contributor) -> **`contributor` / `contributor`**
* `bob` (admin) -> **`admin` / `admin`**
* (new) **`viewer` / `viewer`**, exercising the read-only path
  the seed previously had no user for.

UUIDs are preserved on the original two accounts so existing dev
databases stay aligned on foreign keys after `pnpm db:seed` re-runs.

### Files

* `apps/portal-api/prisma/seed.ts` rewrites the user upserts and
  group memberships. Demo items keep their existing UUIDs.
* `infra/keycloak/realm-gratis-gis.json` swaps the realm users.
* `docs/SETUP.md`, `docs/walkthrough.md`, `infra/README.md`,
  `GIT_SETUP.md` rewritten where they referenced the old
  identities.
* `apps/portal-api/src/notifications/sample-payloads.ts` and
  `templates.ts` updated example display names that show up in
  the admin email-template preview.
* A few lingering code comments in `items.service.ts`,
  `item-sharing-indicator.tsx`, `provenance-panel.tsx`,
  `folder-detail.tsx`, and `auth-sync.service.ts` updated.

### To pick up the new realm users

Either:

* `pnpm infra:reset && pnpm db:seed` for a clean Keycloak + DB,
* or manually delete `mateo` and `bob` from Keycloak, or just
  leave them (they keep working until removed).

### Quality gate

`pnpm typecheck` clean.
