### PR TITLE
feat(admin): edit organization name from branding page (#171)

### DIFF
--- a/apps/portal-api/src/admin/admin-branding.controller.ts
+++ b/apps/portal-api/src/admin/admin-branding.controller.ts
@@ -16,11 +16,13 @@ import type { AuthUser } from '../auth/auth-sync.service.js';
 import { PrismaService } from '../prisma/prisma.service.js';
 
 /**
- * Admin-only read/write for the five landing-page knobs on
- * Organization. Kept tiny on purpose: the page isn't a CMS, it's a
- * handful of branding fields an admin might touch a few times in
+ * Admin-only read/write for the Organization-level settings the
+ * branding page exposes. Kept tiny on purpose: this isn't a CMS,
+ * it's a handful of fields an admin might touch a few times in
  * the lifetime of an org.
  *
+ * - name               : the organization's display name (#171). Drives
+ *                          every "Acme Corp" surface across the portal.
  * - landingTitle       : short org-facing title (defaults to org.name)
  * - landingSubtitle    : one-line tagline
  * - landingHeroImageUrl: optional hero band image; empty falls back to a
@@ -29,10 +31,19 @@ import { PrismaService } from '../prisma/prisma.service.js';
  * - landingFeaturedItemIds: ordered ids to feature ahead of the rest
  *
  * GET returns the current config so the editor can prefill. PATCH
- * accepts any subset of the five fields; omitted keys are left
- * untouched, null values explicitly clear.
+ * accepts any subset of the fields; omitted keys are left untouched,
+ * null values explicitly clear (where the column is nullable).
  */
 class UpdateBrandingDto {
+  /**
+   * Organization display name. Required column on the row, so we
+   * reject empty strings here rather than letting Prisma fail with
+   * a less helpful error. Bounded length keeps it sensible across
+   * every header / nav / email surface that renders it.
+   */
+  @IsOptional() @IsString() @MaxLength(120)
+  name?: string;
+
   @IsOptional() @IsString() @MaxLength(200)
   landingTitle?: string | null;
 
@@ -91,6 +102,15 @@ export class AdminBrandingController {
     // Explicit null through the DTO resolves to Prisma's null write
     // (Prisma accepts null for nullable columns).
     const data: Record<string, unknown> = {};
+    if (dto.name !== undefined) {
+      // organization.name is non-null on the schema; reject empty
+      // strings here rather than store a meaningless blank that
+      // would render as a gap in every nav/header/email.
+      const trimmed = dto.name.trim();
+      if (trimmed.length > 0) {
+        data.name = trimmed;
+      }
+    }
     if (dto.landingTitle !== undefined) {
       data.landingTitle = dto.landingTitle;
     }

--- a/apps/portal-web/src/app/admin/branding/branding-form.tsx
+++ b/apps/portal-web/src/app/admin/branding/branding-form.tsx
@@ -28,6 +28,10 @@ interface Props {
 
 export function BrandingForm({ initial }: Props) {
   const router = useRouter();
+  // Org name (#171). Required, so we render the value verbatim and
+  // refuse empty saves. Drives every "Acme Corp" surface across the
+  // portal, hence its own card at the top.
+  const [name, setName] = useState(initial.name);
   const [title, setTitle] = useState(initial.landingTitle ?? '');
   const [subtitle, setSubtitle] = useState(initial.landingSubtitle ?? '');
   const [heroImageUrl, setHeroImageUrl] = useState<string | null>(
@@ -52,6 +56,7 @@ export function BrandingForm({ initial }: Props) {
   // arrays covers every field. Feature ids compared as a normalized
   // space-less string so 'a, b' vs 'a,b' reads as no change.
   const dirty = useMemo(() => {
+    if (name.trim() !== initial.name && name.trim().length > 0) return true;
     if ((title.trim() || null) !== (initial.landingTitle ?? null)) return true;
     if ((subtitle.trim() || null) !== (initial.landingSubtitle ?? null))
       return true;
@@ -64,6 +69,7 @@ export function BrandingForm({ initial }: Props) {
     }
     return false;
   }, [
+    name,
     title,
     subtitle,
     heroImageUrl,
@@ -86,6 +92,15 @@ export function BrandingForm({ initial }: Props) {
         // any more: invalid pastes can't get into the state.
         landingFeaturedItemIds: featuredIds,
       };
+      // Only include name if it actually changed AND is non-empty.
+      // The server rejects empty strings (org.name is required)
+      // but it's friendlier to keep the field out of the patch
+      // entirely than to send an empty value and rely on the
+      // server's defense.
+      const trimmedName = name.trim();
+      if (trimmedName.length > 0 && trimmedName !== initial.name) {
+        body.name = trimmedName;
+      }
       const res = await fetch('/api/portal/admin/branding', {
         method: 'PATCH',
         headers: { 'content-type': 'application/json' },
@@ -106,6 +121,30 @@ export function BrandingForm({ initial }: Props) {
   return (
     <div className="space-y-5">
       <section className="space-y-4 rounded-lg border border-border bg-surface-1 p-5">
+        <div>
+          <label
+            htmlFor="org-name"
+            className="mb-1 block text-xs font-medium uppercase tracking-wide text-muted"
+          >
+            Organization name
+          </label>
+          <input
+            id="org-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Your organization"
+            maxLength={120}
+            required
+            className="h-10 w-full rounded-md border border-border bg-surface-1 px-3 text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
+          />
+          <p className="mt-1 text-[11px] text-muted">
+            The display name used in headers, navigation, emails,
+            and anywhere else your organization is named. Cannot be
+            empty.
+          </p>
+        </div>
+
         <div>
           <label
             htmlFor="landing-title"


### PR DESCRIPTION
Closes #171.

Adds an "Organization name" field at the top of the admin branding
page so admins can rename their org from the seeded "Acme Corp"
placeholder to their own company name. Drives every header / nav /
email surface that renders the org name.

### Surface

* `apps/portal-api/src/admin/admin-branding.controller.ts`: extend
  `UpdateBrandingDto` with an optional `name` field. Max length
  120, trimmed, empty strings dropped server-side
  (`organization.name` is non-null on the schema).
* `apps/portal-web/src/app/admin/branding/branding-form.tsx`: new
  state, dirty check, save body, and a required input above the
  existing Title section. Empty values are kept out of the patch
  payload to avoid relying on server defense.

The branding page's GET already returned `name`; the editor just
couldn't write to it. Save uses the same sparse-PATCH pattern the
other branding fields use.

### Quality gate

`pnpm typecheck` clean.
