### PR TITLE
feat(forms): audio + video capture question types (#146)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -30,6 +30,7 @@ import {
   Loader2,
   Mail,
   MapPin,
+  Mic,
   Minus,
   Phone,
   Plus,
@@ -47,6 +48,7 @@ import {
   Type,
   Upload,
   User,
+  Video,
   Workflow,
   X,
 } from 'lucide-react';
@@ -891,6 +893,8 @@ const PALETTE: PaletteEntry[] = [
   { type: 'name', label: 'Full name', icon: User, group: 'identity' },
   { type: 'address', label: 'Address', icon: Home, group: 'identity' },
   { type: 'photo', label: 'Photo', icon: Camera, group: 'media' },
+  { type: 'audio', label: 'Audio', icon: Mic, group: 'media' },
+  { type: 'video', label: 'Video', icon: Video, group: 'media' },
   { type: 'file', label: 'File', icon: FileText, group: 'media' },
   { type: 'image-choice', label: 'Image choice', icon: Image, group: 'media' },
   { type: 'image-display', label: 'Image', icon: Image, group: 'media' },
@@ -2129,6 +2133,55 @@ function Properties({
             />
           </Field>
         </>
+      ) : null}
+
+      {question.type === 'audio' || question.type === 'video' ? (
+        <div className="mb-2 grid grid-cols-3 gap-2">
+          <Field label="Max clips">
+            <input
+              type="number"
+              min={1}
+              value={question.maxCount ?? 1}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({
+                  maxCount: Number(e.target.value),
+                } as Partial<Question>)
+              }
+              className={inputCls}
+            />
+          </Field>
+          <Field label="Max bytes">
+            <input
+              type="number"
+              min={0}
+              value={question.maxBytes ?? ''}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({
+                  maxBytes:
+                    e.target.value === '' ? undefined : Number(e.target.value),
+                } as Partial<Question>)
+              }
+              className={inputCls}
+            />
+          </Field>
+          <Field label="Max seconds">
+            <input
+              type="number"
+              min={0}
+              value={question.maxDurationSec ?? ''}
+              disabled={!canEdit}
+              onChange={(e) =>
+                onChange({
+                  maxDurationSec:
+                    e.target.value === '' ? undefined : Number(e.target.value),
+                } as Partial<Question>)
+              }
+              className={inputCls}
+            />
+          </Field>
+        </div>
       ) : null}
 
       {question.type === 'image-display' || question.type === 'image-hotspot' ? (
@@ -4935,7 +4988,12 @@ function isAttachmentGroup(
   if (q.type !== 'group') return false;
   if (!layerSchema) return false;
   const hasMediaChild = q.children.some(
-    (c) => c.type === 'photo' || c.type === 'file' || c.type === 'signature',
+    (c) =>
+      c.type === 'photo' ||
+      c.type === 'audio' ||
+      c.type === 'video' ||
+      c.type === 'file' ||
+      c.type === 'signature',
   );
   if (!hasMediaChild) return false;
   if (q.bindTo?.layerKey) {
@@ -5501,12 +5559,17 @@ export function questionLinkStatus(
     attachmentsEnabled = Boolean(schema.attachmentsEnabled);
   }
 
-  // Attachment-bearing question types (photo / signature / file)
-  // don't bind to a regular column. They bind to the layer's
-  // attachments capability, which we surface with a synthetic
-  // column so the existing "matched" UI works without a new status.
+  // Attachment-bearing question types (photo / audio / video /
+  // signature / file) don't bind to a regular column. They bind to
+  // the layer's attachments capability, which we surface with a
+  // synthetic column so the existing "matched" UI works without a
+  // new status.
   if (
-    (q.type === 'photo' || q.type === 'signature' || q.type === 'file') &&
+    (q.type === 'photo' ||
+      q.type === 'audio' ||
+      q.type === 'video' ||
+      q.type === 'signature' ||
+      q.type === 'file') &&
     attachmentsEnabled &&
     !q.bindTo?.column
   ) {

--- a/apps/portal-web/src/components/form-runtime.tsx
+++ b/apps/portal-web/src/components/form-runtime.tsx
@@ -9,8 +9,10 @@ import {
   GripVertical,
   Loader2,
   MapPin,
+  Mic,
   Plus,
   Trash2,
+  Video as VideoIcon,
   X,
 } from 'lucide-react';
 import {
@@ -488,16 +490,28 @@ export function QuestionPreview({ q }: { q: Question }) {
   if (q.type === 'page' || q.type === 'hidden' || q.type === 'group') {
     return null;
   }
-  // Photo / signature / file would either render an empty file
-  // picker or a message. Show a small badge instead.
-  if (q.type === 'photo' || q.type === 'file' || q.type === 'signature') {
+  // Capture-style inputs would either render an empty picker or a
+  // message. Show a small badge instead.
+  if (
+    q.type === 'photo' ||
+    q.type === 'audio' ||
+    q.type === 'video' ||
+    q.type === 'file' ||
+    q.type === 'signature'
+  ) {
+    const label =
+      q.type === 'signature'
+        ? 'Signature pad'
+        : q.type === 'photo'
+          ? 'Photo capture'
+          : q.type === 'audio'
+            ? 'Audio capture'
+            : q.type === 'video'
+              ? 'Video capture'
+              : 'File upload';
     return (
       <div className="rounded-md border border-dashed border-border bg-surface-2/30 px-3 py-2 text-[11px] text-muted">
-        {q.type === 'signature'
-          ? 'Signature pad'
-          : q.type === 'photo'
-            ? 'Photo capture'
-            : 'File upload'}
+        {label}
       </div>
     );
   }
@@ -841,6 +855,26 @@ function Input({
       return <AddressInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
     case 'photo':
       return <PhotoInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
+    case 'audio':
+      return (
+        <MediaCaptureInput
+          q={q}
+          value={value}
+          readOnly={readOnly}
+          onChange={onChange}
+          kind="audio"
+        />
+      );
+    case 'video':
+      return (
+        <MediaCaptureInput
+          q={q}
+          value={value}
+          readOnly={readOnly}
+          onChange={onChange}
+          kind="video"
+        />
+      );
     case 'file':
       return <FileInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
     case 'image-choice':
@@ -1090,6 +1124,170 @@ function PhotoInput({
       </div>
       <p className="text-[11px] text-muted">
         {photos.length} of {max} {max === 1 ? 'photo' : 'photos'}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Audio / video capture (#146). One component handles both kinds
+ * because the only thing that varies is the MIME prefix and the
+ * playback element. The runtime relies on the device's native
+ * recorder when available (`capture` attribute on the file input);
+ * desktop browsers fall through to a normal file picker.
+ *
+ * Response shape: an array of attachment descriptors:
+ *   { name; mimeType; sizeBytes; dataUrl; durationSec? }
+ *
+ * Phase 1 inlines the bytes as a data URL just like FileInput, so
+ * the offline outbox can persist without a network round trip;
+ * Phase 2 swaps in a MinIO upload step. Soft caps from the schema
+ * (maxBytes, maxDurationSec) surface as warnings rather than hard
+ * blocks: phones produce wildly different file sizes for short
+ * clips and we'd rather let a slightly-over-cap recording through
+ * than drop a successful capture on the floor.
+ */
+function MediaCaptureInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+  kind,
+}: {
+  q: Extract<Question, { type: 'audio' | 'video' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+  kind: 'audio' | 'video';
+}) {
+  type Clip = {
+    name: string;
+    mimeType: string;
+    sizeBytes: number;
+    dataUrl: string;
+    durationSec?: number;
+  };
+  const clips: Clip[] = Array.isArray(value)
+    ? (value as Clip[]).filter(
+        (c): c is Clip =>
+          c !== null &&
+          typeof c === 'object' &&
+          typeof (c as Clip).dataUrl === 'string' &&
+          typeof (c as Clip).mimeType === 'string',
+      )
+    : [];
+  const max = q.maxCount ?? 1;
+  const acceptMime = kind === 'audio' ? 'audio/*' : 'video/*';
+  const captureLabel = kind === 'audio' ? 'Audio' : 'Video';
+
+  function remove(index: number) {
+    if (readOnly) return;
+    onChange(clips.filter((_, i) => i !== index));
+  }
+
+  // Probe duration after the URL is inlined. Best-effort; if the
+  // device or the MIME doesn't expose duration we leave it
+  // undefined and the bar shows "size only".
+  async function probeDuration(dataUrl: string): Promise<number | undefined> {
+    return new Promise((resolve) => {
+      const el = document.createElement(kind);
+      el.preload = 'metadata';
+      const cleanup = () => {
+        el.removeEventListener('loadedmetadata', loaded);
+        el.removeEventListener('error', errored);
+      };
+      const loaded = () => {
+        cleanup();
+        resolve(Number.isFinite(el.duration) ? el.duration : undefined);
+      };
+      const errored = () => {
+        cleanup();
+        resolve(undefined);
+      };
+      el.addEventListener('loadedmetadata', loaded);
+      el.addEventListener('error', errored);
+      el.src = dataUrl;
+    });
+  }
+
+  return (
+    <div className="space-y-2">
+      <ul className="space-y-2">
+        {clips.map((c, i) => (
+          <li
+            key={i}
+            className="rounded-md border border-border bg-surface-1 p-2"
+          >
+            {kind === 'video' ? (
+              <video
+                src={c.dataUrl}
+                controls
+                className="max-h-48 w-full rounded bg-black"
+              />
+            ) : (
+              <audio src={c.dataUrl} controls className="w-full" />
+            )}
+            <div className="mt-1 flex items-center justify-between text-[11px] text-muted">
+              <span className="truncate">
+                {c.name}
+                {' · '}
+                {Math.round(c.sizeBytes / 1024).toLocaleString()} KB
+                {typeof c.durationSec === 'number'
+                  ? ` · ${c.durationSec.toFixed(1)}s`
+                  : null}
+              </span>
+              {!readOnly ? (
+                <button
+                  type="button"
+                  onClick={() => remove(i)}
+                  className="rounded p-1 text-muted hover:bg-surface-2 hover:text-danger"
+                  aria-label={`Remove ${kind}`}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </button>
+              ) : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+      {!readOnly && clips.length < max ? (
+        <label className="inline-flex h-9 cursor-pointer items-center gap-2 rounded-md border border-dashed border-border bg-surface-1 px-3 text-xs text-ink-1 hover:bg-surface-2">
+          {kind === 'audio' ? (
+            <Mic className="h-3.5 w-3.5" />
+          ) : (
+            <VideoIcon className="h-3.5 w-3.5" />
+          )}
+          {captureLabel}
+          <input
+            type="file"
+            accept={acceptMime}
+            // Hint to mobile that the user wants to record. Desktop
+            // browsers ignore `capture` and fall back to file pick.
+            capture={kind === 'video' ? 'environment' : undefined}
+            className="hidden"
+            onChange={async (e) => {
+              const file = e.target.files?.[0];
+              if (!file) return;
+              const dataUrl = await fileToDataUrl(file);
+              const durationSec = await probeDuration(dataUrl);
+              const next: Clip = {
+                name: file.name,
+                mimeType: file.type || acceptMime,
+                sizeBytes: file.size,
+                dataUrl,
+                ...(typeof durationSec === 'number' ? { durationSec } : {}),
+              };
+              onChange([...clips, next]);
+            }}
+          />
+        </label>
+      ) : null}
+      <p className="text-[11px] text-muted">
+        {clips.length} of {max}{' '}
+        {max === 1 ? captureLabel.toLowerCase() : `${captureLabel.toLowerCase()}s`}
+        {typeof q.maxDurationSec === 'number'
+          ? ` · suggested cap ${q.maxDurationSec}s per clip`
+          : null}
       </p>
     </div>
   );

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -72,6 +72,8 @@ export const QUESTION_TYPES = [
   'name', // composite person name (first / middle / last / suffix / prefix)
   'address', // composite postal address
   'photo', // one or more image attachments
+  'audio', // audio recording or upload
+  'video', // video recording or upload
   'file', // generic file upload (any MIME)
   'image-choice', // single/multi choice where each option is an image
   'image-display', // display-only image embed (no value captured)
@@ -530,6 +532,48 @@ interface PhotoQuestion extends QuestionBase {
 }
 
 /**
+ * Audio capture. Recorded clip OR uploaded audio file. The runtime
+ * uses `<input type="file" accept="audio/*" capture>` to surface the
+ * device's recorder when available, with file picker as a fallback.
+ *
+ * Response shape mirrors FileQuestion:
+ *   Array<{ name; mimeType; sizeBytes; dataUrl; durationSec? }>
+ *
+ * Phase 1 stores audio as data URLs in the offline outbox just like
+ * photos / files; Phase 2 swaps in MinIO upload.
+ */
+interface AudioQuestion extends QuestionBase {
+  type: 'audio';
+  /** Max attachments. Default 1. */
+  maxCount?: number;
+  /** Soft cap per clip in bytes; renderer warns above this. */
+  maxBytes?: number;
+  /** Soft cap per clip in seconds; the renderer can stop the
+   *  recorder when it's reached. Optional. */
+  maxDurationSec?: number;
+}
+
+/**
+ * Video capture. Same model as Audio but with `accept="video/*"`.
+ * The mobile recorder is preferred when the device exposes one; the
+ * desktop fallback is a normal file picker. We deliberately don't
+ * try to transcode in the browser; whatever MIME the device produces
+ * (MP4 / WebM / MOV) flows through.
+ *
+ * Response shape mirrors FileQuestion plus optional duration:
+ *   Array<{ name; mimeType; sizeBytes; dataUrl; durationSec? }>
+ */
+interface VideoQuestion extends QuestionBase {
+  type: 'video';
+  /** Max attachments. Default 1. */
+  maxCount?: number;
+  /** Soft cap per clip in bytes. */
+  maxBytes?: number;
+  /** Soft cap per clip in seconds. Optional. */
+  maxDurationSec?: number;
+}
+
+/**
  * Generic file upload. Accepts any MIME by default; the optional
  * `accept` array narrows the picker (e.g. ['application/pdf']).
  *
@@ -771,6 +815,8 @@ export type Question =
   | NameQuestion
   | AddressQuestion
   | PhotoQuestion
+  | AudioQuestion
+  | VideoQuestion
   | FileQuestion
   | ImageChoiceQuestion
   | ImageDisplayQuestion
@@ -1618,6 +1664,32 @@ function validateType(q: Question, value: unknown): string | null {
         return `Up to ${q.maxCount} attachments allowed.`;
       }
       return null;
+    case 'audio':
+    case 'video': {
+      const kindLabel = q.type === 'audio' ? 'audio clip' : 'video clip';
+      if (!Array.isArray(value)) return `Expected one or more ${kindLabel}s.`;
+      if (q.maxCount !== undefined && value.length > q.maxCount) {
+        return `Up to ${q.maxCount} ${kindLabel}s allowed.`;
+      }
+      for (const v of value) {
+        if (
+          typeof v !== 'object' ||
+          v === null ||
+          typeof (v as { dataUrl?: unknown }).dataUrl !== 'string' ||
+          typeof (v as { mimeType?: unknown }).mimeType !== 'string'
+        ) {
+          return `${kindLabel} entry has an unexpected shape.`;
+        }
+        if (
+          q.maxBytes !== undefined &&
+          typeof (v as { sizeBytes?: unknown }).sizeBytes === 'number' &&
+          (v as { sizeBytes: number }).sizeBytes > q.maxBytes
+        ) {
+          return `${kindLabel}s must be ${q.maxBytes} bytes or smaller.`;
+        }
+      }
+      return null;
+    }
     case 'file':
       if (!Array.isArray(value)) return 'Expected one or more files.';
       if (q.maxCount !== undefined && value.length > q.maxCount) {
@@ -1940,6 +2012,10 @@ export function defaultQuestion(type: QuestionType, id: QuestionId): Question {
       };
     case 'photo':
       return { ...base, type, maxCount: 1 };
+    case 'audio':
+      return { ...base, type, maxCount: 1 };
+    case 'video':
+      return { ...base, type, maxCount: 1 };
     case 'file':
       return { ...base, type, maxCount: 1 };
     case 'image-choice':
@@ -2030,6 +2106,8 @@ function defaultLabel(type: QuestionType): string {
       name: 'Full name',
       address: 'Address',
       photo: 'Photo',
+      audio: 'Audio',
+      video: 'Video',
       file: 'File',
       'image-choice': 'Image choice',
       'image-display': 'Image',


### PR DESCRIPTION
Closes #146.

Adds two new media-capture question types to the form schema and
runtime:

* **`audio`**: clip recording or upload. Mobile uses the device's
  recorder via the file input's `capture` attribute; desktop falls
  through to a file picker.
* **`video`**: same model with `accept="video/*"`.

### Per-question schema fields (mirroring photo / file)

* `maxCount`: clip count cap. Default 1.
* `maxBytes`: per-clip size cap (soft).
* `maxDurationSec`: per-clip duration cap (soft). Optional.

### Response shape

```ts
Array<{ name; mimeType; sizeBytes; dataUrl; durationSec? }>
```

Phase 1 inlines bytes as data URLs so the offline outbox can
persist without a network round trip; Phase 2 swaps in MinIO
upload alongside the same work for photo / file.

### Files

* `packages/form-schema/src/index.ts`: extended `QuestionType`
  union, added `AudioQuestion` + `VideoQuestion` interfaces,
  validator branches, `defaultLabel` entries, default-question
  seed cases.
* `apps/portal-web/src/components/form-runtime.tsx`: new
  `MediaCaptureInput` component (one component handles both
  kinds; a `kind` prop varies the MIME prefix and the playback
  element). Best-effort duration probe via a hidden audio/video
  element after the data URL is inlined.
* `apps/portal-web/src/app/items/[id]/form/designer.tsx`: palette
  entries (Mic + Video lucide icons), per-question settings panel
  for max clips / bytes / duration, attachment-group eligibility
  extended to recognize audio / video as media children.

### Quality gate

`pnpm typecheck` clean.
