### PR TITLE
feat(forms): barcode + sketch question types (#147)

### DIFF
--- a/apps/portal-web/src/app/items/[id]/form/designer.tsx
+++ b/apps/portal-web/src/app/items/[id]/form/designer.tsx
@@ -32,9 +32,11 @@ import {
   MapPin,
   Mic,
   Minus,
+  Pencil,
   Phone,
   Plus,
   Regex,
+  ScanLine,
   Search,
   ShieldCheck,
   Save,
@@ -895,6 +897,8 @@ const PALETTE: PaletteEntry[] = [
   { type: 'photo', label: 'Photo', icon: Camera, group: 'media' },
   { type: 'audio', label: 'Audio', icon: Mic, group: 'media' },
   { type: 'video', label: 'Video', icon: Video, group: 'media' },
+  { type: 'barcode', label: 'Barcode / QR', icon: ScanLine, group: 'media' },
+  { type: 'sketch', label: 'Sketch', icon: Pencil, group: 'media' },
   { type: 'file', label: 'File', icon: FileText, group: 'media' },
   { type: 'image-choice', label: 'Image choice', icon: Image, group: 'media' },
   { type: 'image-display', label: 'Image', icon: Image, group: 'media' },
@@ -4992,6 +4996,7 @@ function isAttachmentGroup(
       c.type === 'photo' ||
       c.type === 'audio' ||
       c.type === 'video' ||
+      c.type === 'sketch' ||
       c.type === 'file' ||
       c.type === 'signature',
   );
@@ -5568,6 +5573,7 @@ export function questionLinkStatus(
     (q.type === 'photo' ||
       q.type === 'audio' ||
       q.type === 'video' ||
+      q.type === 'sketch' ||
       q.type === 'signature' ||
       q.type === 'file') &&
     attachmentsEnabled &&

--- a/apps/portal-web/src/components/form-runtime.tsx
+++ b/apps/portal-web/src/components/form-runtime.tsx
@@ -496,6 +496,7 @@ export function QuestionPreview({ q }: { q: Question }) {
     q.type === 'photo' ||
     q.type === 'audio' ||
     q.type === 'video' ||
+    q.type === 'sketch' ||
     q.type === 'file' ||
     q.type === 'signature'
   ) {
@@ -508,7 +509,9 @@ export function QuestionPreview({ q }: { q: Question }) {
             ? 'Audio capture'
             : q.type === 'video'
               ? 'Video capture'
-              : 'File upload';
+              : q.type === 'sketch'
+                ? 'Sketch canvas'
+                : 'File upload';
     return (
       <div className="rounded-md border border-dashed border-border bg-surface-2/30 px-3 py-2 text-[11px] text-muted">
         {label}
@@ -875,6 +878,10 @@ function Input({
           kind="video"
         />
       );
+    case 'barcode':
+      return <BarcodeInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
+    case 'sketch':
+      return <SketchInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
     case 'file':
       return <FileInput q={q} value={value} readOnly={readOnly} onChange={onChange} />;
     case 'image-choice':
@@ -1289,6 +1296,226 @@ function MediaCaptureInput({
           ? ` · suggested cap ${q.maxDurationSec}s per clip`
           : null}
       </p>
+    </div>
+  );
+}
+
+/**
+ * Barcode / QR capture (#147). Phase 1 ships the manual-entry
+ * fallback only: a plain text field that respondents can type into,
+ * plus a hint that hardware scanners (USB / Bluetooth) input via
+ * keyboard so they "just work" for warehouse / asset workflows
+ * without us bundling a decoder yet. Phases 2+ add camera-based
+ * decoding via BarcodeDetector / zxing-wasm.
+ *
+ * Response: a string (or null when empty).
+ */
+function BarcodeInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'barcode' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  const v = typeof value === 'string' ? value : '';
+  const formats = q.formats?.length ? q.formats.join(' / ') : 'any format';
+  return (
+    <div className="space-y-1.5">
+      <input
+        id={q.id}
+        type="text"
+        inputMode="text"
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        value={v}
+        disabled={readOnly}
+        placeholder="Scan or type the code"
+        onChange={(e) => onChange(e.target.value || null)}
+        className="h-11 w-full rounded-md border border-border bg-surface-1 px-3 font-mono text-sm focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30 disabled:opacity-60"
+      />
+      <p className="text-[11px] text-muted">
+        Hardware scanners (USB / Bluetooth) type into this field
+        like a keyboard. Camera-based scanning will be added in a
+        future release. Accepted: {formats}.
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Sketch canvas (#147). Free-form drawing with mouse / pen / touch.
+ * Distinguished from Signature by being multi-stroke and optionally
+ * sitting on top of a reference image (a floor plan, an aerial
+ * tile, an annotated diagram).
+ *
+ * The respondent draws; the canvas is exported as a PNG data URL on
+ * each stroke end and pushed to the response. Cleared via a single
+ * "Clear" button. Phase 1 supports a single ink color (black) and
+ * a fixed stroke width; per-stroke color / width controls land in
+ * a Phase 2 polish pass.
+ *
+ * Response: PNG data URL (or null when blank).
+ */
+function SketchInput({
+  q,
+  value,
+  readOnly,
+  onChange,
+}: {
+  q: Extract<Question, { type: 'sketch' }>;
+  value: unknown;
+  readOnly: boolean;
+  onChange: (v: unknown) => void;
+}) {
+  const canvasRef = useMemo<{
+    el: HTMLCanvasElement | null;
+    drawing: boolean;
+    last: { x: number; y: number } | null;
+  }>(() => ({ el: null, drawing: false, last: null }), []);
+  const aspect = q.aspectRatio ?? 16 / 9;
+  const initial = typeof value === 'string' ? value : null;
+
+  // Paint the existing value (and optional background image) when
+  // the canvas is mounted or when the underlying value reference
+  // changes. Re-running on every render would clobber an in-progress
+  // stroke; we depend on the saved value only.
+  useEffect(() => {
+    const c = canvasRef.el;
+    if (!c) return;
+    const ctx = c.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, c.width, c.height);
+    if (q.backgroundImageUrl) {
+      const bg = new Image();
+      bg.crossOrigin = 'anonymous';
+      bg.onload = () => {
+        ctx.drawImage(bg, 0, 0, c.width, c.height);
+        if (initial) {
+          const img = new Image();
+          img.onload = () => ctx.drawImage(img, 0, 0, c.width, c.height);
+          img.src = initial;
+        }
+      };
+      bg.src = q.backgroundImageUrl;
+    } else if (initial) {
+      const img = new Image();
+      img.onload = () => ctx.drawImage(img, 0, 0, c.width, c.height);
+      img.src = initial;
+    }
+    // The element ref is stable across renders; we explicitly want
+    // to re-init only when the saved value or the background URL
+    // changes. The disable-comment below silences the missing-deps
+    // warning for canvasRef (it's a memo, not a state).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initial, q.backgroundImageUrl]);
+
+  function pointerToCanvas(e: React.PointerEvent<HTMLCanvasElement>): {
+    x: number;
+    y: number;
+  } {
+    const c = canvasRef.el;
+    if (!c) return { x: 0, y: 0 };
+    const rect = c.getBoundingClientRect();
+    return {
+      x: ((e.clientX - rect.left) / rect.width) * c.width,
+      y: ((e.clientY - rect.top) / rect.height) * c.height,
+    };
+  }
+
+  function start(e: React.PointerEvent<HTMLCanvasElement>) {
+    if (readOnly) return;
+    canvasRef.drawing = true;
+    canvasRef.last = pointerToCanvas(e);
+    (e.target as HTMLCanvasElement).setPointerCapture(e.pointerId);
+  }
+
+  function move(e: React.PointerEvent<HTMLCanvasElement>) {
+    if (readOnly || !canvasRef.drawing) return;
+    const c = canvasRef.el;
+    if (!c) return;
+    const ctx = c.getContext('2d');
+    if (!ctx) return;
+    const next = pointerToCanvas(e);
+    if (canvasRef.last) {
+      ctx.strokeStyle = '#111827';
+      ctx.lineWidth = 2;
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+      ctx.beginPath();
+      ctx.moveTo(canvasRef.last.x, canvasRef.last.y);
+      ctx.lineTo(next.x, next.y);
+      ctx.stroke();
+    }
+    canvasRef.last = next;
+  }
+
+  function end() {
+    if (!canvasRef.drawing) return;
+    canvasRef.drawing = false;
+    canvasRef.last = null;
+    const c = canvasRef.el;
+    if (!c) return;
+    onChange(c.toDataURL('image/png'));
+  }
+
+  function clear() {
+    const c = canvasRef.el;
+    if (!c) return;
+    const ctx = c.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, c.width, c.height);
+    if (q.backgroundImageUrl) {
+      // Re-paint the background so the canvas isn't blank-blank.
+      const bg = new Image();
+      bg.crossOrigin = 'anonymous';
+      bg.onload = () => ctx.drawImage(bg, 0, 0, c.width, c.height);
+      bg.src = q.backgroundImageUrl;
+    }
+    onChange(null);
+  }
+
+  // Use a 1024-wide internal buffer; the CSS `aspect-ratio` keeps
+  // the rendered box correctly proportioned no matter the container
+  // width. 1024px gives a sketch with enough fidelity to be useful
+  // when zoomed but is small enough to keep PNG payloads under a
+  // few hundred KB at typical line densities.
+  const w = 1024;
+  const h = Math.round(w / aspect);
+
+  return (
+    <div className="space-y-2">
+      <canvas
+        ref={(el) => {
+          canvasRef.el = el;
+        }}
+        width={w}
+        height={h}
+        onPointerDown={start}
+        onPointerMove={move}
+        onPointerUp={end}
+        onPointerCancel={end}
+        onPointerLeave={end}
+        style={{ aspectRatio: String(aspect), touchAction: 'none' }}
+        className="block w-full cursor-crosshair rounded-md border border-border bg-surface-1"
+      />
+      {!readOnly ? (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={clear}
+            className="inline-flex h-8 items-center gap-1 rounded-md border border-border bg-surface-1 px-2.5 text-xs font-medium text-ink-1 hover:bg-surface-2"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            Clear
+          </button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/packages/form-schema/src/index.ts
+++ b/packages/form-schema/src/index.ts
@@ -74,6 +74,8 @@ export const QUESTION_TYPES = [
   'photo', // one or more image attachments
   'audio', // audio recording or upload
   'video', // video recording or upload
+  'barcode', // scan or type a barcode / QR
+  'sketch', // free-form drawing on a canvas
   'file', // generic file upload (any MIME)
   'image-choice', // single/multi choice where each option is an image
   'image-display', // display-only image embed (no value captured)
@@ -554,6 +556,75 @@ interface AudioQuestion extends QuestionBase {
 }
 
 /**
+ * Barcode / QR capture (#147). Captures a single string value.
+ * The runtime uses three strategies in priority order:
+ *   1. The browser's BarcodeDetector API when available (modern
+ *      Chrome / Edge / Android). Decodes from the live camera
+ *      feed.
+ *   2. The device camera via `<input type="file" capture>` plus a
+ *      decoder (zxing-wasm or similar) on the captured frame. Used
+ *      when BarcodeDetector is missing.
+ *   3. A plain text input fallback so respondents can type the
+ *      number off the label when the camera isn't available.
+ *
+ * Phase 1 ships strategy 3 only (typed input) so we don't bundle
+ * a decoder yet. Phases 2 / 3 add the camera paths.
+ *
+ * Response shape: string (the decoded or typed value).
+ */
+interface BarcodeQuestion extends QuestionBase {
+  type: 'barcode';
+  /**
+   * Restrict accepted barcode formats. Empty / undefined means
+   * "any format the decoder supports". The standard symbologies
+   * GIS workflows tend to need (asset tags, inventory) are EAN /
+   * Code128 / QR, but expose the full list for completeness.
+   */
+  formats?: Array<
+    | 'qr'
+    | 'aztec'
+    | 'code128'
+    | 'code39'
+    | 'code93'
+    | 'codabar'
+    | 'datamatrix'
+    | 'ean13'
+    | 'ean8'
+    | 'itf'
+    | 'pdf417'
+    | 'upca'
+    | 'upce'
+  >;
+  /** Allow keyboard fallback even on devices that have a camera.
+   *  Default true: respondents with poor light or a glitchy
+   *  decoder can always type the number. */
+  allowManualEntry?: boolean;
+}
+
+/**
+ * Sketch (#147). A free-form drawing canvas. Distinguished from
+ * Signature by being a multi-stroke / general-purpose drawing
+ * surface (think "sketch the location of the damage on this
+ * diagram") rather than a one-shot ink-and-confirm. Optionally
+ * loads a background image so the sketch sits on top of a
+ * reference (a site map, a building floor plan, etc.).
+ *
+ * Response shape: a PNG data URL of the canvas contents.
+ */
+interface SketchQuestion extends QuestionBase {
+  type: 'sketch';
+  /** Optional image painted underneath the user's strokes.
+   *  Useful for "annotate this floor plan" workflows. */
+  backgroundImageUrl?: string;
+  /** Aspect ratio width / height; defaults to 16:9 for the canvas
+   *  view. The renderer uses CSS aspect-ratio to keep the canvas
+   *  responsive without distorting strokes. */
+  aspectRatio?: number;
+  /** Soft cap per saved drawing in bytes. */
+  maxBytes?: number;
+}
+
+/**
  * Video capture. Same model as Audio but with `accept="video/*"`.
  * The mobile recorder is preferred when the device exposes one; the
  * desktop fallback is a normal file picker. We deliberately don't
@@ -817,6 +888,8 @@ export type Question =
   | PhotoQuestion
   | AudioQuestion
   | VideoQuestion
+  | BarcodeQuestion
+  | SketchQuestion
   | FileQuestion
   | ImageChoiceQuestion
   | ImageDisplayQuestion
@@ -1664,6 +1737,20 @@ function validateType(q: Question, value: unknown): string | null {
         return `Up to ${q.maxCount} attachments allowed.`;
       }
       return null;
+    case 'barcode':
+      if (typeof value !== 'string') return 'Expected a barcode value.';
+      return null;
+    case 'sketch':
+      if (typeof value !== 'string') return 'Expected a sketch image.';
+      if (
+        q.maxBytes !== undefined &&
+        // data URLs are roughly 4/3 the size of the raw bytes; this
+        // is a rough check, fine for a soft cap.
+        value.length * 0.75 > q.maxBytes
+      ) {
+        return `Sketch must be ${q.maxBytes} bytes or smaller.`;
+      }
+      return null;
     case 'audio':
     case 'video': {
       const kindLabel = q.type === 'audio' ? 'audio clip' : 'video clip';
@@ -2016,6 +2103,10 @@ export function defaultQuestion(type: QuestionType, id: QuestionId): Question {
       return { ...base, type, maxCount: 1 };
     case 'video':
       return { ...base, type, maxCount: 1 };
+    case 'barcode':
+      return { ...base, type, allowManualEntry: true };
+    case 'sketch':
+      return { ...base, type, aspectRatio: 16 / 9 };
     case 'file':
       return { ...base, type, maxCount: 1 };
     case 'image-choice':
@@ -2108,6 +2199,8 @@ function defaultLabel(type: QuestionType): string {
       photo: 'Photo',
       audio: 'Audio',
       video: 'Video',
+      barcode: 'Barcode / QR',
+      sketch: 'Sketch',
       file: 'File',
       'image-choice': 'Image choice',
       'image-display': 'Image',


### PR DESCRIPTION
Closes #147.

Two more capture-flavored question types:

### `barcode`

Scan-or-type barcode / QR. Phase 1 ships the manual-entry fallback
only: a plain text field that hardware scanners on USB / Bluetooth
populate by typing keystrokes (covers the common warehouse /
asset-tag workflow without bundling a decoder). Camera-based
decoding via `BarcodeDetector` / zxing-wasm lands in a follow-up.

Schema: optional `formats` array (qr, code128, ean13, etc.),
`allowManualEntry` (default true).

### `sketch`

Free-form drawing canvas. Distinguished from Signature by being
multi-stroke and by optionally sitting on top of a reference image
(a floor plan, an aerial tile, an annotated diagram). Pointer-
based drawing works with mouse / pen / touch.

Schema: `backgroundImageUrl`, `aspectRatio` (default 16:9),
`maxBytes` (soft cap on the saved PNG).

### Files

* `packages/form-schema/src/index.ts`: extended `QuestionType`,
  added `BarcodeQuestion` + `SketchQuestion`, validator branches,
  `defaultLabel` entries, default-question seed cases.
* `apps/portal-web/src/components/form-runtime.tsx`: new
  `BarcodeInput` and `SketchInput` components. The sketch canvas
  uses a 1024-wide internal buffer with CSS `aspect-ratio` so it
  stays responsive without distorting strokes; PNG data URL
  exported on each stroke end. `QuestionPreview` placeholder
  branch extended to include sketch.
* `apps/portal-web/src/app/items/[id]/form/designer.tsx`: palette
  entries (`ScanLine` + `Pencil` lucide icons), attachment-group
  eligibility extended to include sketch as a media child.

### Quality gate

`pnpm typecheck` clean.
