### PR TITLE
feat(derived-layers): new analysis item type with buffer tool

### DIFF
--- a/apps/portal-api/jest.config.cjs
+++ b/apps/portal-api/jest.config.cjs
@@ -1,0 +1,25 @@
+// Jest configuration for portal-api unit tests.
+//
+// The codebase uses TypeScript with `.js`-suffixed imports
+// (Node's "node16-esm-style" convention) but the runtime module
+// setting is CommonJS. ts-jest's `useESM: false` plus the moduleNameMapper
+// rewrite below lets a test like `import './foo.js'` resolve to the
+// underlying `./foo.ts` without requiring real ESM at test time.
+//
+// Workspace packages (`@gratis-gis/shared-types`, etc.) are pointed
+// directly at their `src/` entry so a test never has to wait for the
+// dependent package's build.
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  rootDir: '.',
+  testMatch: ['<rootDir>/src/**/*.spec.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@gratis-gis/shared-types$': '<rootDir>/../../packages/shared-types/src/index.ts',
+    '^@gratis-gis/form-schema$': '<rootDir>/../../packages/form-schema/src/index.ts',
+  },
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.json' }],
+  },
+};

--- a/apps/portal-api/prisma/migrations/20260428220000_derived_layer_item_type/migration.sql
+++ b/apps/portal-api/prisma/migrations/20260428220000_derived_layer_item_type/migration.sql
@@ -1,0 +1,8 @@
+-- Add the `derived-layer` variant to ItemType. A derived_layer item
+-- holds a recipe (source data_layer + ordered tool pipeline) and
+-- computes its features at read time on top of the source's PostGIS
+-- table. v1 ships with one tool (buffer); the registry is designed
+-- so future tools (dissolve, intersect, centroid, ...) plug in
+-- without further enum migrations.
+-- Enum alters run standalone per Postgres rules.
+ALTER TYPE "ItemType" ADD VALUE 'derived-layer';

--- a/apps/portal-api/prisma/schema.prisma
+++ b/apps/portal-api/prisma/schema.prisma
@@ -106,6 +106,7 @@ enum NotificationStatus {
 enum ItemType {
   map
   data_layer                 @map("data-layer")
+  derived_layer              @map("derived-layer")
   arcgis_service             @map("arcgis-service")
   form
   form_submission_collection @map("form-submission-collection")

--- a/apps/portal-api/src/derived-layers/derived-layers.module.ts
+++ b/apps/portal-api/src/derived-layers/derived-layers.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+
+import { PrismaModule } from '../prisma/prisma.module.js';
+import { DerivedLayersService } from './derived-layers.service.js';
+
+/**
+ * Derived layers live in their own module so the analysis surface
+ * area (tools, generators, future tool-builder integration) gets a
+ * clear home rather than crowding `items/`. The service is exported
+ * so items.service can call it for validation on save and for read
+ * routing on getGeoJson.
+ *
+ * The module imports only PrismaModule, NOT ItemsModule. The flow
+ * is one-directional: items.service depends on derived-layers.service,
+ * never the other way. Per-user authorization (can the caller read
+ * the source data layer?) lives in items.service, which already
+ * holds the SharingService.
+ */
+@Module({
+  imports: [PrismaModule],
+  providers: [DerivedLayersService],
+  exports: [DerivedLayersService],
+})
+export class DerivedLayersModule {}

--- a/apps/portal-api/src/derived-layers/derived-layers.service.spec.ts
+++ b/apps/portal-api/src/derived-layers/derived-layers.service.spec.ts
@@ -8,6 +8,8 @@ import {
   DerivedLayersService,
   padBboxByMeters,
   readSourceSchema,
+  readSourceVersion,
+  resolveSublayer,
 } from './derived-layers.service.js';
 
 // The service we test here only exercises pure / DB-free helpers.
@@ -26,13 +28,43 @@ const STRING_FIELD: FeatureField = {
 function makeSource(
   overrides: Partial<Item> = {},
 ): Pick<Item, 'id' | 'type' | 'data' | 'bbox'> {
+  // Default fixture is a v2 single-table source. v3 multi-layer
+  // tests construct their own data inline via makeV3Source below
+  // so each one is explicit about which sublayer it's exercising.
   return {
     id: '11111111-1111-1111-1111-111111111111',
     type: 'data_layer' as Item['type'],
     data: {
+      version: 2,
       storageType: 'postgis',
-      version: 3,
       fields: [STRING_FIELD],
+    } as unknown as Item['data'],
+    bbox: [-122.5, 37.5, -122.0, 38.0] as Item['bbox'],
+    ...overrides,
+  };
+}
+
+function makeV3Source(
+  layerId: string,
+  overrides: Partial<Item> = {},
+): Pick<Item, 'id' | 'type' | 'data' | 'bbox'> {
+  return {
+    id: '22222222-2222-2222-2222-222222222222',
+    type: 'data_layer' as Item['type'],
+    data: {
+      version: 3,
+      storageType: 'postgis',
+      layers: [
+        {
+          id: layerId,
+          label: layerId,
+          name: layerId,
+          geometryType: 'point',
+          fields: [STRING_FIELD],
+          editingEnabled: true,
+          attachmentsEnabled: false,
+        },
+      ],
     } as unknown as Item['data'],
     bbox: [-122.5, 37.5, -122.0, 38.0] as Item['bbox'],
     ...overrides,
@@ -68,17 +100,86 @@ describe('readSourceSchema', () => {
     expect(fields).toEqual([STRING_FIELD]);
   });
 
-  it('merges fields from a v3 multi-layer payload', () => {
-    const merged = readSourceSchema({
-      layers: [{ fields: [STRING_FIELD] }, { fields: [STRING_FIELD] }],
-    });
-    expect(merged).toHaveLength(2);
-  });
-
   it('returns an empty array for unrecognized shapes', () => {
     expect(readSourceSchema(null)).toEqual([]);
     expect(readSourceSchema('not an object')).toEqual([]);
     expect(readSourceSchema({})).toEqual([]);
+  });
+});
+
+describe('readSourceVersion', () => {
+  it('reads a numeric version off the data blob', () => {
+    expect(readSourceVersion({ version: 3 })).toBe(3);
+    expect(readSourceVersion({ version: 1 })).toBe(1);
+  });
+
+  it('returns 0 for unknown shapes', () => {
+    expect(readSourceVersion(null)).toBe(0);
+    expect(readSourceVersion({})).toBe(0);
+    expect(readSourceVersion({ version: '3' })).toBe(0);
+  });
+});
+
+describe('resolveSublayer', () => {
+  it('returns null for v2 with no layerKey', () => {
+    expect(resolveSublayer({ fields: [STRING_FIELD] }, 2, undefined)).toBeNull();
+  });
+
+  it('rejects layerKey on a v2 source', () => {
+    expect(() =>
+      resolveSublayer({ fields: [STRING_FIELD] }, 2, 'L1'),
+    ).toThrow(/only valid against v3/);
+  });
+
+  it('auto-selects the only spatial sublayer of a v3 source', () => {
+    const data = {
+      version: 3,
+      layers: [
+        {
+          id: 'L1',
+          geometryType: 'point',
+          fields: [STRING_FIELD],
+        },
+      ],
+    };
+    const r = resolveSublayer(data, 3, undefined);
+    expect(r?.id).toBe('L1');
+    expect(r?.fields).toEqual([STRING_FIELD]);
+  });
+
+  it('requires layerKey when there are multiple spatial sublayers', () => {
+    const data = {
+      version: 3,
+      layers: [
+        { id: 'A', geometryType: 'point', fields: [] },
+        { id: 'B', geometryType: 'polygon', fields: [] },
+      ],
+    };
+    expect(() => resolveSublayer(data, 3, undefined)).toThrow(
+      /required because the source has multiple sublayers/,
+    );
+  });
+
+  it('rejects an unknown layerKey', () => {
+    const data = {
+      version: 3,
+      layers: [{ id: 'A', geometryType: 'point', fields: [] }],
+    };
+    expect(() => resolveSublayer(data, 3, 'B')).toThrow(
+      /does not match any sublayer/,
+    );
+  });
+
+  it('drops attribute-only sublayers from consideration', () => {
+    const data = {
+      version: 3,
+      layers: [
+        { id: 'related', geometryType: null, fields: [] },
+      ],
+    };
+    expect(() => resolveSublayer(data, 3, undefined)).toThrow(
+      /no spatial sublayers/,
+    );
   });
 });
 
@@ -210,6 +311,29 @@ describe('DerivedLayersService.buildReadSql', () => {
     // Default temporal filter is `valid_to IS NULL`.
     expect(sql).toMatch(/valid_to IS NULL/);
     expect(params).toEqual([250, 1000]);
+  });
+
+  it('uses the v3 per-sublayer table name when source.layerKey is set', () => {
+    const source = makeV3Source('sites');
+    const data: DerivedLayerData = {
+      version: 1,
+      source: {
+        kind: 'data_layer',
+        itemId: source.id,
+        layerKey: 'sites',
+      },
+      pipeline: [
+        { tool: 'buffer', params: { distance: 25, unit: 'meters' } },
+      ],
+      featureLimit: 100,
+      outputSchema: [STRING_FIELD],
+      bbox: [],
+    };
+    const item = makeDerivedItem(data);
+    const { sql } = service.buildReadSql(item, source);
+    expect(sql).toMatch(
+      /"fs_22222222222222222222222222222222_sites"/,
+    );
   });
 
   it('expands the request bbox by the pipeline reach for buffer halos', () => {

--- a/apps/portal-api/src/derived-layers/derived-layers.service.spec.ts
+++ b/apps/portal-api/src/derived-layers/derived-layers.service.spec.ts
@@ -1,0 +1,240 @@
+import type { Item } from '@prisma/client';
+import {
+  type DerivedLayerData,
+  type FeatureField,
+} from '@gratis-gis/shared-types';
+
+import {
+  DerivedLayersService,
+  padBboxByMeters,
+  readSourceSchema,
+} from './derived-layers.service.js';
+
+// The service we test here only exercises pure / DB-free helpers.
+// `validateAndEnrich` and `buildReadSql` need a fake Prisma object so
+// the constructor is satisfied; neither helper actually queries.
+const fakePrisma = {} as never;
+const service = new DerivedLayersService(fakePrisma);
+
+const STRING_FIELD: FeatureField = {
+  name: 'name',
+  label: 'Name',
+  type: 'string',
+  nullable: false,
+};
+
+function makeSource(
+  overrides: Partial<Item> = {},
+): Pick<Item, 'id' | 'type' | 'data' | 'bbox'> {
+  return {
+    id: '11111111-1111-1111-1111-111111111111',
+    type: 'data_layer' as Item['type'],
+    data: {
+      storageType: 'postgis',
+      version: 3,
+      fields: [STRING_FIELD],
+    } as unknown as Item['data'],
+    bbox: [-122.5, 37.5, -122.0, 38.0] as Item['bbox'],
+    ...overrides,
+  };
+}
+
+function makeDerivedItem(data: DerivedLayerData): Item {
+  return {
+    id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+    orgId: 'oooooooo-oooo-oooo-oooo-oooooooooooo',
+    ownerId: 'uuuuuuuu-uuuu-uuuu-uuuu-uuuuuuuuuuuu',
+    type: 'derived_layer' as Item['type'],
+    title: 'Test',
+    description: '',
+    tags: [],
+    thumbnailUrl: null,
+    license: null,
+    data: data as unknown as Item['data'],
+    storageRef: null,
+    access: 'private' as Item['access'],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+    bbox: data.bbox,
+    bboxSrs: 'EPSG:4326',
+    lastUsageAt: null,
+  };
+}
+
+describe('readSourceSchema', () => {
+  it('reads top-level fields when present', () => {
+    const fields = readSourceSchema({ fields: [STRING_FIELD] });
+    expect(fields).toEqual([STRING_FIELD]);
+  });
+
+  it('merges fields from a v3 multi-layer payload', () => {
+    const merged = readSourceSchema({
+      layers: [{ fields: [STRING_FIELD] }, { fields: [STRING_FIELD] }],
+    });
+    expect(merged).toHaveLength(2);
+  });
+
+  it('returns an empty array for unrecognized shapes', () => {
+    expect(readSourceSchema(null)).toEqual([]);
+    expect(readSourceSchema('not an object')).toEqual([]);
+    expect(readSourceSchema({})).toEqual([]);
+  });
+});
+
+describe('padBboxByMeters', () => {
+  it('returns an empty array when bbox is empty', () => {
+    expect(padBboxByMeters([], 100)).toEqual([]);
+  });
+
+  it('returns the bbox unchanged when reach is zero', () => {
+    expect(padBboxByMeters([0, 0, 1, 1], 0)).toEqual([0, 0, 1, 1]);
+  });
+
+  it('pads outward in degrees proportional to meters', () => {
+    const padded = padBboxByMeters([0, 0, 1, 1], 11132);
+    // 11132m / 111320 m/deg ~= 0.1 deg
+    expect(padded[0]).toBeCloseTo(-0.1, 5);
+    expect(padded[1]).toBeCloseTo(-0.1, 5);
+    expect(padded[2]).toBeCloseTo(1.1, 5);
+    expect(padded[3]).toBeCloseTo(1.1, 5);
+  });
+
+  it('treats malformed bboxes as empty', () => {
+    expect(padBboxByMeters([0, 0, 1] as unknown as number[], 100)).toEqual([]);
+    expect(padBboxByMeters([0, 0, 1, NaN], 100)).toEqual([]);
+  });
+});
+
+describe('DerivedLayersService.validateAndEnrich', () => {
+  it('rejects non-object data', () => {
+    expect(() =>
+      service.validateAndEnrich(null, makeSource()),
+    ).toThrow(/must be an object/);
+  });
+
+  it('rejects an empty pipeline', () => {
+    expect(() =>
+      service.validateAndEnrich(
+        {
+          version: 1,
+          source: { kind: 'data_layer', itemId: makeSource().id },
+          pipeline: [],
+          featureLimit: 1000,
+          outputSchema: [],
+          bbox: [],
+        },
+        makeSource(),
+      ),
+    ).toThrow(/non-empty array/);
+  });
+
+  it('rejects a mismatched source.itemId vs the resolved source', () => {
+    const source = makeSource();
+    expect(() =>
+      service.validateAndEnrich(
+        {
+          version: 1,
+          source: {
+            kind: 'data_layer',
+            itemId: '00000000-0000-0000-0000-000000000000',
+          },
+          pipeline: [{ tool: 'buffer', params: { distance: 1, unit: 'meters' } }],
+        },
+        source,
+      ),
+    ).toThrow(/match the resolved source/);
+  });
+
+  it('produces an enriched DerivedLayerData with bbox padded by reach', () => {
+    const source = makeSource();
+    const enriched = service.validateAndEnrich(
+      {
+        version: 1,
+        source: { kind: 'data_layer', itemId: source.id },
+        pipeline: [
+          { tool: 'buffer', params: { distance: 11132, unit: 'meters' } },
+        ],
+      },
+      source,
+    );
+    expect(enriched.featureLimit).toBe(1000);
+    expect(enriched.outputSchema).toEqual([STRING_FIELD]);
+    // bbox padded by ~0.1 deg in each axis
+    expect(enriched.bbox[0]).toBeCloseTo(-122.6, 4);
+    expect(enriched.bbox[3]).toBeCloseTo(38.1, 4);
+  });
+
+  it('rejects featureLimit values outside the allowed range', () => {
+    const source = makeSource();
+    expect(() =>
+      service.validateAndEnrich(
+        {
+          version: 1,
+          source: { kind: 'data_layer', itemId: source.id },
+          pipeline: [
+            { tool: 'buffer', params: { distance: 1, unit: 'meters' } },
+          ],
+          featureLimit: 0,
+        },
+        source,
+      ),
+    ).toThrow(/positive integer/);
+  });
+});
+
+describe('DerivedLayersService.buildReadSql', () => {
+  it('wraps the source PostGIS table in a CTE and chains buffer downstream', () => {
+    const source = makeSource();
+    const data: DerivedLayerData = {
+      version: 1,
+      source: { kind: 'data_layer', itemId: source.id },
+      pipeline: [
+        { tool: 'buffer', params: { distance: 250, unit: 'meters' } },
+      ],
+      featureLimit: 1000,
+      outputSchema: [STRING_FIELD],
+      bbox: [-122.6, 37.4, -121.9, 38.1],
+    };
+    const item = makeDerivedItem(data);
+    const { sql, params } = service.buildReadSql(item, source);
+    // Source CTE references the well-known table name.
+    expect(sql).toMatch(
+      /"fs_11111111111111111111111111111111"/,
+    );
+    // Pipeline produces step_1.
+    expect(sql).toMatch(/step_1 AS \(/);
+    // Final SELECT consumes the last step.
+    expect(sql).toMatch(/FROM step_1/);
+    expect(sql).toMatch(/LIMIT \$2/);
+    // Default temporal filter is `valid_to IS NULL`.
+    expect(sql).toMatch(/valid_to IS NULL/);
+    expect(params).toEqual([250, 1000]);
+  });
+
+  it('expands the request bbox by the pipeline reach for buffer halos', () => {
+    const source = makeSource();
+    const data: DerivedLayerData = {
+      version: 1,
+      source: { kind: 'data_layer', itemId: source.id },
+      pipeline: [
+        { tool: 'buffer', params: { distance: 11132, unit: 'meters' } },
+      ],
+      featureLimit: 500,
+      outputSchema: [STRING_FIELD],
+      bbox: [],
+    };
+    const item = makeDerivedItem(data);
+    const { params } = service.buildReadSql(item, source, {
+      bbox: [0, 0, 1, 1],
+    });
+    // Order: padded bbox (4 numbers), then buffer distance, then limit.
+    expect(params).toHaveLength(6);
+    expect(params[0]).toBeCloseTo(-0.1, 5);
+    expect(params[1]).toBeCloseTo(-0.1, 5);
+    expect(params[2]).toBeCloseTo(1.1, 5);
+    expect(params[3]).toBeCloseTo(1.1, 5);
+    expect(params[4]).toBe(11132);
+    expect(params[5]).toBe(500);
+  });
+});

--- a/apps/portal-api/src/derived-layers/derived-layers.service.ts
+++ b/apps/portal-api/src/derived-layers/derived-layers.service.ts
@@ -8,6 +8,7 @@ import {
 } from '@gratis-gis/shared-types';
 
 import { PrismaService } from '../prisma/prisma.service.js';
+import { toV3TableName } from '../features-v3/v3-tables.service.js';
 import { getGeneratorForStep } from './tools/registry.js';
 
 /**
@@ -101,6 +102,21 @@ export class DerivedLayersService {
       );
     }
 
+    // v3 multi-layer items split features across one PostGIS table per
+    // sublayer, so the recipe MUST name which sublayer to derive from.
+    // v2 single-table items have no sublayer, so layerKey must be
+    // absent. Reject both directions explicitly: a missing layerKey
+    // on a v3 source would silently query a non-existent table, and
+    // a layerKey on a v2 source would imply structure that isn't
+    // there. The check runs before tool validation so a mismatched
+    // recipe never reaches the generators.
+    const sourceVersion = readSourceVersion(sourceItem.data);
+    const sublayer = resolveSublayer(
+      sourceItem.data,
+      sourceVersion,
+      typeof source.layerKey === 'string' ? source.layerKey : undefined,
+    );
+
     const pipeline = d.pipeline;
     if (!Array.isArray(pipeline) || pipeline.length === 0) {
       throw new BadRequestException(
@@ -135,8 +151,11 @@ export class DerivedLayersService {
 
     // Validate each step's params, threading the schema forward so a
     // step that changes the column shape (future: dissolve) yields
-    // the right input schema for the next step.
-    const sourceSchema = readSourceSchema(sourceItem.data);
+    // the right input schema for the next step. The schema comes
+    // from the resolved sublayer for v3, or top-level fields for v2.
+    const sourceSchema = sublayer
+      ? sublayer.fields
+      : readSourceSchema(sourceItem.data);
     let schema: FeatureField[] = sourceSchema;
     let totalReachMeters = 0;
     const validatedPipeline: ToolStep[] = [];
@@ -175,9 +194,7 @@ export class DerivedLayersService {
       source: {
         kind: 'data_layer',
         itemId: source.itemId as string,
-        ...(typeof source.layerKey === 'string'
-          ? { layerKey: source.layerKey }
-          : {}),
+        ...(sublayer ? { layerKey: sublayer.id } : {}),
       },
       pipeline: validatedPipeline,
       featureLimit,
@@ -240,7 +257,9 @@ export class DerivedLayersService {
       );
     }
 
-    const tbl = `fs_${data.source.itemId.replace(/-/g, '')}`;
+    const tbl = data.source.layerKey
+      ? toV3TableName(data.source.itemId, data.source.layerKey)
+      : `fs_${data.source.itemId.replace(/-/g, '')}`;
     const queryParams: unknown[] = [];
     const sourceConditions: string[] = [];
 
@@ -387,7 +406,9 @@ export class DerivedLayersService {
         generator.validate(step.params),
       );
     }
-    const tbl = `fs_${sourceItem.id.replace(/-/g, '')}`;
+    const tbl = data.source.layerKey
+      ? toV3TableName(sourceItem.id, data.source.layerKey)
+      : `fs_${sourceItem.id.replace(/-/g, '')}`;
     const queryParams: unknown[] = [];
     const sourceConditions: string[] = [];
 
@@ -462,39 +483,102 @@ export class DerivedLayersService {
 // -----------------------------------------------------------------
 
 /**
- * Read the FeatureField list from a data_layer item's `data` blob.
- * v1/v2 store fields top-level; v3 multi-layer items store fields
- * per-layer. For v1 buffer this just needs to know "the columns
- * coming through" so we collect from whichever shape is present;
- * future tools that need per-sublayer routing can read the layerKey
- * off `source` and walk into a single layer.
+ * Read the schema version off a data_layer's `data` blob. v1 and v2
+ * are flat (fields at the top level), v3 is multi-layer (fields per
+ * sublayer). Falls back to 0 for unknown / malformed shapes so the
+ * caller can branch defensively. Returns just the version number;
+ * callers that need to dispatch on it are expected to compare by
+ * value rather than rely on a typed union here (the data blob is
+ * Prisma `JsonValue`, narrowing to a discriminated union would
+ * require zod / class-validator for no real win).
+ */
+export function readSourceVersion(data: unknown): number {
+  if (!data || typeof data !== 'object') return 0;
+  const v = (data as { version?: unknown }).version;
+  return typeof v === 'number' ? v : 0;
+}
+
+/**
+ * Resolve which sublayer the recipe targets, or `null` for a v1 / v2
+ * single-table item.
+ *
+ * Rules:
+ *   - v3 source REQUIRES `layerKey`. Missing or unknown key throws.
+ *     A v3 item with exactly one spatial sublayer is allowed to
+ *     auto-select; we do that here so the wizard doesn't have to.
+ *   - v2 source FORBIDS `layerKey`. Passing one means the recipe is
+ *     pointed at structure that doesn't exist; throw rather than
+ *     silently ignore.
+ *   - v1 (inline GeoJSON) returns null and lets the caller's
+ *     storageType check reject it later.
+ *
+ * Returns the sublayer object when one is selected, or `null` when
+ * the source is single-table.
+ */
+export function resolveSublayer(
+  data: unknown,
+  version: number,
+  layerKey: string | undefined,
+): { id: string; fields: FeatureField[] } | null {
+  if (version !== 3) {
+    if (layerKey !== undefined) {
+      throw new BadRequestException(
+        'derived_layer.source.layerKey is only valid against v3 multi-layer data layers',
+      );
+    }
+    return null;
+  }
+  // v3 path
+  const layers = (data as { layers?: unknown }).layers;
+  if (!Array.isArray(layers) || layers.length === 0) {
+    throw new BadRequestException(
+      'Source data layer has no sublayers; add a layer in the data layer builder first',
+    );
+  }
+  const spatialLayers = layers.filter((l) => {
+    if (!l || typeof l !== 'object') return false;
+    const id = (l as { id?: unknown }).id;
+    const geom = (l as { geometryType?: unknown }).geometryType;
+    return typeof id === 'string' && id.length > 0 && typeof geom === 'string';
+  }) as Array<{ id: string; geometryType: string; fields?: FeatureField[] }>;
+  if (spatialLayers.length === 0) {
+    throw new BadRequestException(
+      'Source data layer has no spatial sublayers; buffer needs geometry to operate on',
+    );
+  }
+  if (layerKey === undefined) {
+    if (spatialLayers.length === 1) {
+      const only = spatialLayers[0]!;
+      return { id: only.id, fields: only.fields ?? [] };
+    }
+    throw new BadRequestException(
+      'derived_layer.source.layerKey is required because the source has multiple sublayers',
+    );
+  }
+  const match = spatialLayers.find((l) => l.id === layerKey);
+  if (!match) {
+    throw new BadRequestException(
+      `derived_layer.source.layerKey "${layerKey}" does not match any sublayer of the source`,
+    );
+  }
+  return { id: match.id, fields: match.fields ?? [] };
+}
+
+/**
+ * Read the FeatureField list from a v1 / v2 data_layer's `data`
+ * blob. v3 sources do NOT come through here; they go through
+ * `resolveSublayer` so the schema is read from the specific
+ * sublayer the recipe targets. Kept on the v2 path because top-
+ * level `fields` is the canonical place that schema lives in v2.
  */
 export function readSourceSchema(data: unknown): FeatureField[] {
   if (!data || typeof data !== 'object') return [];
-  const d = data as { fields?: unknown; layers?: unknown };
+  const d = data as { fields?: unknown };
   if (Array.isArray(d.fields)) {
     return d.fields.filter(
       (f): f is FeatureField =>
         !!f && typeof f === 'object' && typeof (f as { name?: unknown }).name === 'string',
     );
-  }
-  if (Array.isArray(d.layers) && d.layers.length > 0) {
-    const merged: FeatureField[] = [];
-    for (const layer of d.layers) {
-      const fields = (layer as { fields?: unknown }).fields;
-      if (Array.isArray(fields)) {
-        for (const f of fields) {
-          if (
-            f &&
-            typeof f === 'object' &&
-            typeof (f as { name?: unknown }).name === 'string'
-          ) {
-            merged.push(f as FeatureField);
-          }
-        }
-      }
-    }
-    return merged;
   }
   return [];
 }

--- a/apps/portal-api/src/derived-layers/derived-layers.service.ts
+++ b/apps/portal-api/src/derived-layers/derived-layers.service.ts
@@ -1,0 +1,527 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import type { Item } from '@prisma/client';
+import {
+  DEFAULT_DERIVED_LAYER_FEATURE_LIMIT,
+  type DerivedLayerData,
+  type FeatureField,
+  type ToolStep,
+} from '@gratis-gis/shared-types';
+
+import { PrismaService } from '../prisma/prisma.service.js';
+import { getGeneratorForStep } from './tools/registry.js';
+
+/**
+ * Maximum allowed pipeline length. Long pipelines are inherently
+ * suspect (each step is a sub-CTE; planning cost climbs) and v1's
+ * single tool gives no reason to need more than a handful. Easy to
+ * lift later. Set high enough that legitimate stacking (a future
+ * `simplify -> buffer -> dissolve`) doesn't bump into it.
+ */
+const MAX_PIPELINE_STEPS = 8;
+
+/**
+ * Hard cap on the user-overridable feature limit. The default sits
+ * at 1000 (see DEFAULT_DERIVED_LAYER_FEATURE_LIMIT) but power users
+ * can raise it; this is the ceiling. Keeps a misconfigured layer
+ * from being a denial-of-service path.
+ */
+const MAX_FEATURE_LIMIT = 50_000;
+
+/**
+ * Approximate degrees of latitude per meter at the equator. Used
+ * once when expanding a request bbox by the pipeline's outward
+ * reach so features near the edge keep their halo. The value is
+ * deliberately a constant (1 / 111_320) rather than a per-latitude
+ * approximation: at high latitudes the longitudinal expansion would
+ * need to be larger, so we use the SAME meters-per-degree on both
+ * axes (treating the latitude axis as the worst case). This
+ * over-includes longitudinal features near the poles, which is fine
+ * for a pre-filter that exists only to limit work.
+ */
+const DEGREES_PER_METER = 1 / 111_320;
+
+/**
+ * Mechanics for derived_layer items: validation + read-path SQL
+ * composition. Per-user authorization (can the caller read the
+ * source data layer?) lives in items.service so this module
+ * doesn't import the items module and we keep the dependency graph
+ * one-directional. Callers pass the already-authorized source
+ * Item into both methods.
+ */
+@Injectable()
+export class DerivedLayersService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  // ---------------------------------------------------------------
+  // Validation + enrichment (called by items.service on save)
+  // ---------------------------------------------------------------
+
+  /**
+   * Validate a derived_layer's `data` payload, run each tool's
+   * validator, and compute the cached `outputSchema` and `bbox` from
+   * the source. Returns the enriched, persistable data. Throws
+   * `BadRequestException` for any validation failure.
+   *
+   * The caller is expected to have already authorized the user
+   * against `sourceItem`. This method only verifies the source's
+   * type and shape.
+   */
+  validateAndEnrich(
+    rawData: unknown,
+    sourceItem: Pick<Item, 'id' | 'type' | 'data' | 'bbox'>,
+  ): DerivedLayerData {
+    if (!rawData || typeof rawData !== 'object') {
+      throw new BadRequestException('derived_layer data must be an object');
+    }
+    const d = rawData as Record<string, unknown>;
+    if (d.version !== 1) {
+      throw new BadRequestException(
+        'derived_layer.version must be 1 (this is the only supported version)',
+      );
+    }
+    const source = d.source as Record<string, unknown> | undefined;
+    if (
+      !source ||
+      source.kind !== 'data_layer' ||
+      typeof source.itemId !== 'string' ||
+      source.itemId.length === 0
+    ) {
+      throw new BadRequestException(
+        'derived_layer.source must be { kind: "data_layer", itemId: <uuid> }',
+      );
+    }
+    if (source.itemId !== sourceItem.id) {
+      throw new BadRequestException(
+        'derived_layer.source.itemId must match the resolved source item',
+      );
+    }
+    if (sourceItem.type !== 'data_layer') {
+      throw new BadRequestException(
+        'derived_layer.source.itemId must reference a data_layer item',
+      );
+    }
+
+    const pipeline = d.pipeline;
+    if (!Array.isArray(pipeline) || pipeline.length === 0) {
+      throw new BadRequestException(
+        'derived_layer.pipeline must be a non-empty array of tool steps',
+      );
+    }
+    if (pipeline.length > MAX_PIPELINE_STEPS) {
+      throw new BadRequestException(
+        `derived_layer.pipeline must not exceed ${MAX_PIPELINE_STEPS} steps`,
+      );
+    }
+
+    const featureLimitRaw = d.featureLimit;
+    let featureLimit = DEFAULT_DERIVED_LAYER_FEATURE_LIMIT;
+    if (typeof featureLimitRaw === 'number') {
+      if (
+        !Number.isFinite(featureLimitRaw) ||
+        featureLimitRaw <= 0 ||
+        !Number.isInteger(featureLimitRaw)
+      ) {
+        throw new BadRequestException(
+          'derived_layer.featureLimit must be a positive integer',
+        );
+      }
+      if (featureLimitRaw > MAX_FEATURE_LIMIT) {
+        throw new BadRequestException(
+          `derived_layer.featureLimit must not exceed ${MAX_FEATURE_LIMIT}`,
+        );
+      }
+      featureLimit = featureLimitRaw;
+    }
+
+    // Validate each step's params, threading the schema forward so a
+    // step that changes the column shape (future: dissolve) yields
+    // the right input schema for the next step.
+    const sourceSchema = readSourceSchema(sourceItem.data);
+    let schema: FeatureField[] = sourceSchema;
+    let totalReachMeters = 0;
+    const validatedPipeline: ToolStep[] = [];
+    for (let i = 0; i < pipeline.length; i++) {
+      const stepRaw = pipeline[i];
+      if (!stepRaw || typeof stepRaw !== 'object') {
+        throw new BadRequestException(
+          `derived_layer.pipeline[${i}] must be an object`,
+        );
+      }
+      const tool = (stepRaw as { tool?: unknown }).tool;
+      if (typeof tool !== 'string') {
+        throw new BadRequestException(
+          `derived_layer.pipeline[${i}].tool must be a string`,
+        );
+      }
+      const generator = getGeneratorForStep({
+        tool,
+        params: (stepRaw as { params?: unknown }).params,
+      } as ToolStep);
+      const params = generator.validate(
+        (stepRaw as { params?: unknown }).params,
+      );
+      schema = generator.outputSchema(schema, params);
+      totalReachMeters += generator.outwardReachMeters(params);
+      validatedPipeline.push({ tool, params } as ToolStep);
+    }
+
+    const bbox = padBboxByMeters(
+      Array.isArray(sourceItem.bbox) ? sourceItem.bbox : [],
+      totalReachMeters,
+    );
+
+    return {
+      version: 1,
+      source: {
+        kind: 'data_layer',
+        itemId: source.itemId as string,
+        ...(typeof source.layerKey === 'string'
+          ? { layerKey: source.layerKey }
+          : {}),
+      },
+      pipeline: validatedPipeline,
+      featureLimit,
+      outputSchema: schema,
+      bbox,
+    };
+  }
+
+  // ---------------------------------------------------------------
+  // Read path (called by items.service.getGeoJson)
+  // ---------------------------------------------------------------
+
+  /**
+   * Compose a chained CTE over the source's PostGIS table and stream
+   * the result as GeoJSON. The caller has already passed an ACL
+   * check on both the derived layer AND the source data layer. A
+   * mismatched / wrong-type / missing source returns an empty
+   * FeatureCollection so a momentary inconsistency degrades
+   * gracefully.
+   */
+  async getGeoJson(
+    item: Item,
+    sourceItem: Pick<Item, 'id' | 'type' | 'data'> | null,
+    opts: {
+      bbox?: [number, number, number, number];
+      at?: string;
+      boundaryClipId?: string;
+    } = {},
+  ): Promise<{ type: 'FeatureCollection'; features: unknown[] }> {
+    const data = item.data as unknown as DerivedLayerData | null;
+    if (!data || data.version !== 1) {
+      // Older shape we don't recognize; safest is empty.
+      return { type: 'FeatureCollection', features: [] };
+    }
+    if (
+      !sourceItem ||
+      sourceItem.type !== 'data_layer' ||
+      sourceItem.id !== data.source.itemId
+    ) {
+      return { type: 'FeatureCollection', features: [] };
+    }
+
+    const storageType = (sourceItem.data as { storageType?: string } | null)
+      ?.storageType;
+    if (storageType !== 'postgis') {
+      // v1 inline-GeoJSON data layers don't have a PostGIS table to
+      // join against. Future work could lift the GeoJSON into a
+      // temp CTE for these; for now, empty.
+      return { type: 'FeatureCollection', features: [] };
+    }
+
+    // Total outward reach across the pipeline, used to expand the
+    // request bbox before querying the source so features near the
+    // edge keep their buffer halo.
+    let totalReachMeters = 0;
+    for (const step of data.pipeline) {
+      const generator = getGeneratorForStep(step);
+      totalReachMeters += generator.outwardReachMeters(
+        generator.validate(step.params),
+      );
+    }
+
+    const tbl = `fs_${data.source.itemId.replace(/-/g, '')}`;
+    const queryParams: unknown[] = [];
+    const sourceConditions: string[] = [];
+
+    // Temporal: matches items.service.getGeoJson exactly so a
+    // derived layer's "as of" answers are consistent with the
+    // source's.
+    if (opts.at) {
+      const ts = new Date(opts.at);
+      if (!isNaN(ts.getTime())) {
+        queryParams.push(ts.toISOString());
+        const p = queryParams.length;
+        sourceConditions.push(
+          `valid_from <= $${p}::timestamptz AND (valid_to IS NULL OR valid_to > $${p}::timestamptz)`,
+        );
+      }
+    } else {
+      sourceConditions.push('valid_to IS NULL');
+    }
+
+    // Bbox prefilter on the source, expanded by the pipeline's
+    // outward reach. The expansion uses a single meters-per-degree
+    // approximation (see DEGREES_PER_METER comment) so we err
+    // wider at high latitudes.
+    if (opts.bbox) {
+      const padding = totalReachMeters * DEGREES_PER_METER;
+      const [minX, minY, maxX, maxY] = opts.bbox;
+      queryParams.push(
+        minX - padding,
+        minY - padding,
+        maxX + padding,
+        maxY + padding,
+      );
+      const b = queryParams.length;
+      sourceConditions.push(
+        `geom IS NOT NULL AND ST_Intersects(geom, ST_MakeEnvelope($${b - 3}, $${b - 2}, $${b - 1}, $${b}, 4326))`,
+      );
+    }
+
+    if (opts.boundaryClipId) {
+      // Boundary clip resolves through a single read of the
+      // geo_boundary item. Mirrors items.service.getGeoJson; the
+      // boundary geometry is treated as authoritative regardless of
+      // the calling user's per-boundary permissions because the
+      // map author already chose to clip to it.
+      const boundary = await this.prisma.item.findFirst({
+        where: {
+          id: opts.boundaryClipId,
+          type: 'geo_boundary',
+          deletedAt: null,
+        },
+        select: { data: true },
+      });
+      const g = (boundary?.data as { geometry?: unknown } | null)?.geometry;
+      if (g && typeof g === 'object') {
+        queryParams.push(JSON.stringify(g));
+        const p = queryParams.length;
+        sourceConditions.push(
+          `geom IS NOT NULL AND ST_Intersects(geom, ST_SetSRID(ST_GeomFromGeoJSON($${p}::text), 4326))`,
+        );
+      }
+    }
+
+    // Build the full chained CTE. Step CTE names are 1-indexed so a
+    // glance at the SQL maps directly to user-facing step ordering.
+    const sourceWhere =
+      sourceConditions.length > 0
+        ? `WHERE ${sourceConditions.join(' AND ')}`
+        : '';
+    const ctes: string[] = [
+      `source AS (
+        SELECT global_id, geom, properties
+        FROM "${tbl}"
+        ${sourceWhere}
+      )`,
+    ];
+    let inputAlias = 'source';
+    for (let i = 0; i < data.pipeline.length; i++) {
+      const step = data.pipeline[i]!;
+      const generator = getGeneratorForStep(step);
+      const params = generator.validate(step.params);
+      const fragment = generator.toSql(
+        inputAlias,
+        params,
+        queryParams.length,
+      );
+      const cteName = `step_${i + 1}`;
+      ctes.push(`${cteName} AS (${fragment.sql})`);
+      queryParams.push(...fragment.params);
+      inputAlias = cteName;
+    }
+
+    queryParams.push(data.featureLimit);
+    const limitParam = queryParams.length;
+
+    const sql = `
+      WITH ${ctes.join(', ')}
+      SELECT global_id, ST_AsGeoJSON(geom) AS geom, properties
+      FROM ${inputAlias}
+      WHERE geom IS NOT NULL
+      LIMIT $${limitParam}
+    `;
+
+    type RawRow = {
+      global_id: string;
+      geom: string | null;
+      properties: Record<string, unknown> | null;
+    };
+    const rows = await this.prisma.$queryRawUnsafe<RawRow[]>(
+      sql,
+      ...queryParams,
+    );
+
+    return {
+      type: 'FeatureCollection',
+      features: rows.map((r) => ({
+        type: 'Feature',
+        id: r.global_id,
+        geometry: r.geom ? JSON.parse(r.geom) : null,
+        properties: r.properties ?? {},
+      })),
+    };
+  }
+
+  /**
+   * Build the same CTE/SQL the read path uses, but return it as a
+   * string with parameters rather than executing. Used by tests so
+   * we can assert SQL shape without a live database, and used by
+   * the future "explain plan" admin tool. Pure: takes the resolved
+   * source instead of looking it up.
+   */
+  buildReadSql(
+    item: Item,
+    sourceItem: Pick<Item, 'id' | 'data'>,
+    opts: {
+      bbox?: [number, number, number, number];
+      at?: string;
+    } = {},
+  ): { sql: string; params: unknown[] } {
+    const data = item.data as unknown as DerivedLayerData;
+    let totalReachMeters = 0;
+    for (const step of data.pipeline) {
+      const generator = getGeneratorForStep(step);
+      totalReachMeters += generator.outwardReachMeters(
+        generator.validate(step.params),
+      );
+    }
+    const tbl = `fs_${sourceItem.id.replace(/-/g, '')}`;
+    const queryParams: unknown[] = [];
+    const sourceConditions: string[] = [];
+
+    if (opts.at) {
+      queryParams.push(opts.at);
+      const p = queryParams.length;
+      sourceConditions.push(
+        `valid_from <= $${p}::timestamptz AND (valid_to IS NULL OR valid_to > $${p}::timestamptz)`,
+      );
+    } else {
+      sourceConditions.push('valid_to IS NULL');
+    }
+
+    if (opts.bbox) {
+      const padding = totalReachMeters * DEGREES_PER_METER;
+      const [minX, minY, maxX, maxY] = opts.bbox;
+      queryParams.push(
+        minX - padding,
+        minY - padding,
+        maxX + padding,
+        maxY + padding,
+      );
+      const b = queryParams.length;
+      sourceConditions.push(
+        `geom IS NOT NULL AND ST_Intersects(geom, ST_MakeEnvelope($${b - 3}, $${b - 2}, $${b - 1}, $${b}, 4326))`,
+      );
+    }
+
+    const sourceWhere =
+      sourceConditions.length > 0
+        ? `WHERE ${sourceConditions.join(' AND ')}`
+        : '';
+    const ctes: string[] = [
+      `source AS (
+        SELECT global_id, geom, properties
+        FROM "${tbl}"
+        ${sourceWhere}
+      )`,
+    ];
+    let inputAlias = 'source';
+    for (let i = 0; i < data.pipeline.length; i++) {
+      const step = data.pipeline[i]!;
+      const generator = getGeneratorForStep(step);
+      const params = generator.validate(step.params);
+      const fragment = generator.toSql(
+        inputAlias,
+        params,
+        queryParams.length,
+      );
+      const cteName = `step_${i + 1}`;
+      ctes.push(`${cteName} AS (${fragment.sql})`);
+      queryParams.push(...fragment.params);
+      inputAlias = cteName;
+    }
+
+    queryParams.push(data.featureLimit);
+    const limitParam = queryParams.length;
+
+    const sql = `
+      WITH ${ctes.join(', ')}
+      SELECT global_id, ST_AsGeoJSON(geom) AS geom, properties
+      FROM ${inputAlias}
+      WHERE geom IS NOT NULL
+      LIMIT $${limitParam}
+    `;
+    return { sql, params: queryParams };
+  }
+}
+
+// -----------------------------------------------------------------
+// Helpers (pure; lifted out so tests can poke them directly)
+// -----------------------------------------------------------------
+
+/**
+ * Read the FeatureField list from a data_layer item's `data` blob.
+ * v1/v2 store fields top-level; v3 multi-layer items store fields
+ * per-layer. For v1 buffer this just needs to know "the columns
+ * coming through" so we collect from whichever shape is present;
+ * future tools that need per-sublayer routing can read the layerKey
+ * off `source` and walk into a single layer.
+ */
+export function readSourceSchema(data: unknown): FeatureField[] {
+  if (!data || typeof data !== 'object') return [];
+  const d = data as { fields?: unknown; layers?: unknown };
+  if (Array.isArray(d.fields)) {
+    return d.fields.filter(
+      (f): f is FeatureField =>
+        !!f && typeof f === 'object' && typeof (f as { name?: unknown }).name === 'string',
+    );
+  }
+  if (Array.isArray(d.layers) && d.layers.length > 0) {
+    const merged: FeatureField[] = [];
+    for (const layer of d.layers) {
+      const fields = (layer as { fields?: unknown }).fields;
+      if (Array.isArray(fields)) {
+        for (const f of fields) {
+          if (
+            f &&
+            typeof f === 'object' &&
+            typeof (f as { name?: unknown }).name === 'string'
+          ) {
+            merged.push(f as FeatureField);
+          }
+        }
+      }
+    }
+    return merged;
+  }
+  return [];
+}
+
+/**
+ * Pad a [west, south, east, north] bbox outward by `reachMeters`,
+ * approximating using a single meters-per-degree constant. Returns
+ * empty array when the input bbox is empty / malformed (matching the
+ * `Item.bbox` convention for "no spatial footprint yet").
+ */
+export function padBboxByMeters(
+  bbox: number[],
+  reachMeters: number,
+): number[] {
+  if (
+    !Array.isArray(bbox) ||
+    bbox.length !== 4 ||
+    !bbox.every((n) => Number.isFinite(n))
+  ) {
+    return [];
+  }
+  if (reachMeters <= 0) return [...bbox];
+  const padding = reachMeters * DEGREES_PER_METER;
+  return [
+    bbox[0]! - padding,
+    bbox[1]! - padding,
+    bbox[2]! + padding,
+    bbox[3]! + padding,
+  ];
+}

--- a/apps/portal-api/src/derived-layers/tools/buffer.spec.ts
+++ b/apps/portal-api/src/derived-layers/tools/buffer.spec.ts
@@ -1,0 +1,99 @@
+import { BadRequestException } from '@nestjs/common';
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import { bufferGenerator } from './buffer.js';
+
+describe('bufferGenerator.validate', () => {
+  it('accepts a positive distance in meters', () => {
+    const result = bufferGenerator.validate({ distance: 100, unit: 'meters' });
+    expect(result).toEqual({ distance: 100, unit: 'meters' });
+  });
+
+  it('rejects a non-object', () => {
+    expect(() => bufferGenerator.validate(null)).toThrow(BadRequestException);
+    expect(() => bufferGenerator.validate('100m')).toThrow(BadRequestException);
+  });
+
+  it('rejects a non-number distance', () => {
+    expect(() =>
+      bufferGenerator.validate({ distance: '100', unit: 'meters' }),
+    ).toThrow(/finite number/);
+  });
+
+  it('rejects zero or negative distances', () => {
+    expect(() =>
+      bufferGenerator.validate({ distance: 0, unit: 'meters' }),
+    ).toThrow(/greater than 0/);
+    expect(() =>
+      bufferGenerator.validate({ distance: -5, unit: 'meters' }),
+    ).toThrow(/greater than 0/);
+  });
+
+  it('rejects distances above the world-spanning ceiling', () => {
+    expect(() =>
+      bufferGenerator.validate({ distance: 1_000_000, unit: 'meters' }),
+    ).toThrow(/must not exceed/);
+  });
+
+  it('rejects unknown units', () => {
+    expect(() =>
+      bufferGenerator.validate({ distance: 100, unit: 'feet' }),
+    ).toThrow(/unit must be "meters"/);
+  });
+});
+
+describe('bufferGenerator.outputSchema', () => {
+  it('passes through the source schema unchanged', () => {
+    const fields: FeatureField[] = [
+      { name: 'name', label: 'Name', type: 'string', nullable: false },
+      { name: 'population', label: 'Pop.', type: 'number', nullable: true },
+    ];
+    expect(
+      bufferGenerator.outputSchema(fields, { distance: 100, unit: 'meters' }),
+    ).toBe(fields);
+  });
+});
+
+describe('bufferGenerator.outwardReachMeters', () => {
+  it('returns the buffer distance', () => {
+    expect(
+      bufferGenerator.outwardReachMeters({ distance: 250, unit: 'meters' }),
+    ).toBe(250);
+  });
+});
+
+describe('bufferGenerator.extractDependencies', () => {
+  it('returns no item or url references in v1', () => {
+    expect(
+      bufferGenerator.extractDependencies({ distance: 100, unit: 'meters' }),
+    ).toEqual({ itemIds: [], urls: [] });
+  });
+});
+
+describe('bufferGenerator.toSql', () => {
+  it('emits a CTE body that buffers via geography casting', () => {
+    const fragment = bufferGenerator.toSql(
+      'source',
+      { distance: 250, unit: 'meters' },
+      0,
+    );
+    expect(fragment.params).toEqual([250]);
+    expect(fragment.sql).toMatch(/ST_Buffer\(geom::geography, \$1\)/);
+    expect(fragment.sql).toMatch(/ST_SetSRID\(/);
+    expect(fragment.sql).toMatch(/4326/);
+    expect(fragment.sql).toMatch(/FROM source/);
+    expect(fragment.sql).toMatch(/WHERE geom IS NOT NULL/);
+  });
+
+  it('honors paramOffset so multi-step pipelines stay parameter-safe', () => {
+    const fragment = bufferGenerator.toSql(
+      'step_1',
+      { distance: 50, unit: 'meters' },
+      4,
+    );
+    // First placeholder a step at offset 4 should emit is $5.
+    expect(fragment.sql).toMatch(/\$5/);
+    expect(fragment.sql).not.toMatch(/\$1\b/);
+    expect(fragment.params).toEqual([50]);
+  });
+});

--- a/apps/portal-api/src/derived-layers/tools/buffer.ts
+++ b/apps/portal-api/src/derived-layers/tools/buffer.ts
@@ -1,0 +1,108 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  MAX_BUFFER_DISTANCE_METERS,
+  type FeatureField,
+} from '@gratis-gis/shared-types';
+
+import type { ToolGenerator } from './types.js';
+
+/**
+ * Validated buffer params after `validate(...)` returns. Mirrors
+ * `BufferStep['params']` from shared-types but lives here too so the
+ * generator's signature doesn't bleed shared-types' wider unions
+ * (additional tools, sublayer hints) into the buffer code path.
+ */
+export interface BufferParams {
+  distance: number;
+  unit: 'meters';
+}
+
+/**
+ * Buffer generator. Wraps `ST_Buffer(geom::geography, distance)` so
+ * the distance is interpreted in meters globally regardless of
+ * longitude. Output is cast back to `geometry` (SRID 4326) so it
+ * round-trips through the same pipeline machinery as every other
+ * step.
+ *
+ * The `geography` cast is the v1 simplification: it's accurate within
+ * a few meters at typical urban / regional scales and avoids the
+ * "what CRS is the input in?" question that blocks raw projected
+ * buffers. Future tools that need precise geodesic results can pick
+ * a different strategy (project to UTM, buffer, project back) under
+ * a separate `tool` kind.
+ */
+export const bufferGenerator: ToolGenerator<BufferParams> = {
+  kind: 'buffer',
+
+  validate(raw: unknown): BufferParams {
+    if (!raw || typeof raw !== 'object') {
+      throw new BadRequestException('buffer.params must be an object');
+    }
+    const r = raw as Record<string, unknown>;
+    const distance = r.distance;
+    if (typeof distance !== 'number' || !Number.isFinite(distance)) {
+      throw new BadRequestException(
+        'buffer.params.distance must be a finite number',
+      );
+    }
+    if (distance <= 0) {
+      throw new BadRequestException(
+        'buffer.params.distance must be greater than 0',
+      );
+    }
+    if (distance > MAX_BUFFER_DISTANCE_METERS) {
+      throw new BadRequestException(
+        `buffer.params.distance must not exceed ${MAX_BUFFER_DISTANCE_METERS} meters`,
+      );
+    }
+    if (r.unit !== 'meters') {
+      // v1 ships meters only; reject anything else loudly so callers
+      // notice rather than silently treating their value as meters.
+      throw new BadRequestException(
+        'buffer.params.unit must be "meters" in v1',
+      );
+    }
+    return { distance, unit: 'meters' };
+  },
+
+  outputSchema(input: FeatureField[]): FeatureField[] {
+    // Buffer keeps every attribute and changes only the geometry.
+    // Returning the same array keeps the cached `outputSchema` shape
+    // identical to the source's so dashboards / apps that bound to
+    // the source keep binding cleanly.
+    return input;
+  },
+
+  outwardReachMeters(params: BufferParams): number {
+    return params.distance;
+  },
+
+  extractDependencies(): { itemIds: string[]; urls: string[] } {
+    // v1 buffer holds no item references. The slot exists so future
+    // tools (intersect against a second layer, choices from a pick
+    // list, ...) plug into the dependency graph automatically.
+    return { itemIds: [], urls: [] };
+  },
+
+  toSql(inputAlias: string, params: BufferParams, paramOffset: number) {
+    // The geography cast interprets distance as meters; the cast
+    // back to geometry (SRID 4326) keeps the next step / output in
+    // the SRID every other layer in the system uses. ST_SetSRID is
+    // a no-op when the geography already carries 4326 but cheap
+    // insurance against PostGIS spatial-ref drift between Postgres
+    // versions.
+    const placeholder = `$${paramOffset + 1}`;
+    const sql = `
+      SELECT
+        global_id,
+        ST_SetSRID(
+          ST_Buffer(geom::geography, ${placeholder})::geometry,
+          4326
+        ) AS geom,
+        properties
+      FROM ${inputAlias}
+      WHERE geom IS NOT NULL
+    `;
+    return { sql, params: [params.distance] };
+  },
+};

--- a/apps/portal-api/src/derived-layers/tools/registry.ts
+++ b/apps/portal-api/src/derived-layers/tools/registry.ts
@@ -1,0 +1,55 @@
+import { BadRequestException } from '@nestjs/common';
+import type { ToolStep } from '@gratis-gis/shared-types';
+
+import { bufferGenerator } from './buffer.js';
+import type { ToolGenerator } from './types.js';
+
+/**
+ * Central tool registry. Adding a new tool is purely additive: write
+ * a generator file, import it here, and add an entry to the map. The
+ * derived-layers service iterates the registry through `getGenerator`
+ * so it never imports individual tool files directly.
+ *
+ * The runtime types use `ToolGenerator<unknown>` because the registry
+ * holds heterogeneous tools. Per-call narrowing happens through the
+ * `validate(...)` method on each generator: callers pass the raw
+ * params off the wire and get back a strongly-typed value.
+ */
+const REGISTRY: Map<string, ToolGenerator<unknown>> = new Map([
+  [bufferGenerator.kind, bufferGenerator as ToolGenerator<unknown>],
+]);
+
+/**
+ * Look up a generator by `kind`. Throws `BadRequestException` for
+ * unknown kinds so the wizard / API gets a clear 400 instead of a
+ * runtime crash if a client sends a tool name the server doesn't
+ * recognize.
+ */
+export function getGenerator(kind: string): ToolGenerator<unknown> {
+  const g = REGISTRY.get(kind);
+  if (!g) {
+    throw new BadRequestException(`Unknown derived-layer tool: ${kind}`);
+  }
+  return g;
+}
+
+/**
+ * Discriminator helper for typed `ToolStep` unions: returns the
+ * registered generator for a step's kind. Pulled out so call sites
+ * read as `getGeneratorForStep(step)` rather than poking the
+ * discriminator manually.
+ */
+export function getGeneratorForStep(
+  step: ToolStep,
+): ToolGenerator<unknown> {
+  return getGenerator(step.tool);
+}
+
+/**
+ * Snapshot of every registered tool kind. Used by tests + the
+ * `/admin/health` surface (future) so a deployment can list
+ * available analysis tools without crawling source.
+ */
+export function listRegisteredTools(): string[] {
+  return Array.from(REGISTRY.keys());
+}

--- a/apps/portal-api/src/derived-layers/tools/types.ts
+++ b/apps/portal-api/src/derived-layers/tools/types.ts
@@ -1,0 +1,112 @@
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+/**
+ * Common shape every tool generator produces from `toSql`. The
+ * backing string is a SQL fragment, parameterized through `$N`
+ * placeholders, that defines a single CTE-style subquery yielding the
+ * tool's output rows.
+ *
+ * Generators NEVER inline user-controlled values into `sql`.
+ * Everything goes through `params`, which the service appends to the
+ * outer query's parameter list before execution. Generators are also
+ * trusted to avoid quoting user-supplied identifiers (column names,
+ * table aliases) directly; the registry hands generators the alias to
+ * select from, so the tool only emits hand-authored SQL plus
+ * placeholders.
+ */
+export interface ToolSqlFragment {
+  /**
+   * SQL for one CTE body (the `(...)` after `WITH step_N AS`). Must
+   * select `geom`, `global_id`, and the attribute columns declared by
+   * `outputSchema`. Reads from the input via the `inputAlias` passed
+   * to `toSql`.
+   */
+  sql: string;
+  /**
+   * Parameter values referenced by `$N` placeholders inside `sql`.
+   * Numbering inside `sql` starts at `paramOffset + 1`; the service
+   * appends these to the outer query's parameter array as-is.
+   */
+  params: unknown[];
+}
+
+/**
+ * Item-id / url references a tool's params hold. Returned to the
+ * dependency extractor so the derived layer's forward edges include
+ * everything the recipe references, not just `source.itemId`.
+ *
+ * v1 buffer returns empty arrays; future tools (intersect's second
+ * input layer, choices that pull from a pick_list) populate this.
+ */
+export interface ToolDependencies {
+  itemIds: string[];
+  urls: string[];
+}
+
+/**
+ * Per-tool contract. One file in this folder per tool. Adding a new
+ * tool is purely additive: drop a generator here, register it in
+ * `registry.ts`, add the param shape to `ToolStep` in shared-types,
+ * and add a wizard step in portal-web. No schema migration, no
+ * touchpoint outside these files.
+ *
+ * Type parameters:
+ *   - `TParams` is the strongly-typed param shape. The discriminator
+ *     in the union (`tool: 'buffer'`) gates which generator runs.
+ */
+export interface ToolGenerator<TParams> {
+  /** Stable identifier; matches the discriminator in `ToolStep`. */
+  readonly kind: string;
+
+  /**
+   * Hand-authored validator. Throws `BadRequestException` (or returns
+   * a list of human-readable errors as a `ValidationError[]`) when
+   * params don't match the declared shape. The registry calls this
+   * before any other generator method, so other methods can assume
+   * params are well-formed.
+   */
+  validate(params: unknown): TParams;
+
+  /**
+   * Compute the output schema from the input schema + params. Pure.
+   * Called at save time to populate `data.outputSchema`. For tools
+   * that don't change the shape (e.g. buffer), returns the input
+   * schema unchanged.
+   */
+  outputSchema(input: FeatureField[], params: TParams): FeatureField[];
+
+  /**
+   * Maximum distance (meters) this tool can grow geometries outward.
+   * Used by the read path to expand the source bbox before the
+   * pipeline runs, so features near tile edges retain their halo.
+   * Most tools return 0; buffer returns `params.distance`. The
+   * pipeline's total reach is the sum of its steps.
+   */
+  outwardReachMeters(params: TParams): number;
+
+  /**
+   * Item references the tool's params hold (other layers, pick
+   * lists, ...). The dependency extractor merges these into the
+   * derived layer's forward edges, so the dependency graph stays
+   * complete as new tools arrive.
+   */
+  extractDependencies(params: TParams): ToolDependencies;
+
+  /**
+   * Emit the SQL CTE body for this tool. Must:
+   *   - read input rows from `inputAlias` (a CTE name picked by the
+   *     service: `source` for step 0's input, `step_N` for step N's
+   *     input).
+   *   - select `geom` (PostGIS geometry, SRID 4326), `global_id`,
+   *     and every attribute column declared by `outputSchema(...)`.
+   *   - reference user-supplied values only through `$N`
+   *     placeholders. `paramOffset` is the count of parameters
+   *     already in the outer query; the first placeholder a tool
+   *     emits is `$${paramOffset + 1}`.
+   */
+  toSql(
+    inputAlias: string,
+    params: TParams,
+    paramOffset: number,
+  ): ToolSqlFragment;
+}

--- a/apps/portal-api/src/items/dependency-extractor.spec.ts
+++ b/apps/portal-api/src/items/dependency-extractor.spec.ts
@@ -1,0 +1,46 @@
+import { extractDependencies } from './dependency-extractor.js';
+
+describe('extractDependencies for derived_layer', () => {
+  it('emits the source data layer as a hard forward edge', () => {
+    const result = extractDependencies({
+      type: 'derived_layer' as const,
+      data: {
+        version: 1,
+        source: {
+          kind: 'data_layer',
+          itemId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        },
+        pipeline: [
+          { tool: 'buffer', params: { distance: 100, unit: 'meters' } },
+        ],
+        featureLimit: 1000,
+        outputSchema: [],
+        bbox: [],
+      },
+    });
+    expect(result.itemIds).toEqual([
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    ]);
+    expect(result.urls).toEqual([]);
+  });
+
+  it('returns no edges when the source ref is missing', () => {
+    const result = extractDependencies({
+      type: 'derived_layer' as const,
+      data: { version: 1, pipeline: [] },
+    });
+    expect(result).toEqual({ itemIds: [], urls: [] });
+  });
+
+  it('returns no edges when source.itemId is the empty string', () => {
+    const result = extractDependencies({
+      type: 'derived_layer' as const,
+      data: {
+        version: 1,
+        source: { kind: 'data_layer', itemId: '' },
+        pipeline: [],
+      },
+    });
+    expect(result).toEqual({ itemIds: [], urls: [] });
+  });
+});

--- a/apps/portal-api/src/items/dependency-extractor.ts
+++ b/apps/portal-api/src/items/dependency-extractor.ts
@@ -185,6 +185,21 @@ export function extractDependencies(
     }
   }
 
+  if (item.type === 'derived_layer') {
+    // A derived layer always references its source data_layer through
+    // `data.source.itemId`. Each step in `data.pipeline` may also
+    // reference items (a future intersect tool's second-input layer,
+    // a pickList referenced in a where clause). v1 buffer holds none.
+    // When a tool with item-typed params is added, give it a `case`
+    // branch here AND a matching `extractDependencies` on its
+    // generator (the latter for callers that want a single-tool view).
+    const sourceRef = (data as { source?: { itemId?: unknown } }).source;
+    const sourceId = sourceRef?.itemId;
+    if (typeof sourceId === 'string' && sourceId.length > 0) {
+      itemIds.add(sourceId);
+    }
+  }
+
   // Hook points for other types: extend as those item types come online.
 
   return { itemIds: Array.from(itemIds), urls: Array.from(urls) };
@@ -284,6 +299,7 @@ function walkQuestionRefs(
 export const REFERENCER_TYPES: ItemType[] = [
   'map',
   'data_layer',
+  'derived_layer',
   'folder',
   'editor',
   'form',

--- a/apps/portal-api/src/items/item-bbox.ts
+++ b/apps/portal-api/src/items/item-bbox.ts
@@ -28,6 +28,11 @@ export function itemBbox(
   switch (type) {
     case 'data_layer':
       return readBboxField(data) ?? aggregateLayerBboxes(data);
+    case 'derived_layer':
+      // The DerivedLayersService writes a padded copy of the source's
+      // bbox into `data.bbox` whenever the recipe is enriched, so a
+      // cached read here matches what the source had at save time.
+      return readBboxField(data);
     case 'arcgis_service':
     case 'wms_service':
     case 'wfs_service':

--- a/apps/portal-api/src/items/items.module.ts
+++ b/apps/portal-api/src/items/items.module.ts
@@ -10,9 +10,10 @@ import { ServiceProbeController } from './service-probe.controller.js';
 import { EditorPolicyService } from './editor-policy.service.js';
 import { V3TablesModule } from '../features-v3/v3-tables.module.js';
 import { NotificationsModule } from '../notifications/notifications.module.js';
+import { DerivedLayersModule } from '../derived-layers/derived-layers.module.js';
 
 @Module({
-  imports: [V3TablesModule, NotificationsModule],
+  imports: [V3TablesModule, NotificationsModule, DerivedLayersModule],
   controllers: [
     ItemsController,
     ItemCredentialController,

--- a/apps/portal-api/src/items/items.service.ts
+++ b/apps/portal-api/src/items/items.service.ts
@@ -358,29 +358,64 @@ export class ItemsService {
         for (const c of counted) counts.set(c.id, c.sublayer_count);
       }
 
-      // Compute `_storageType` for data_layer rows in one targeted
-      // raw query. The lite findMany strips `data` to keep the wire
-      // payload small, but downstream UI surfaces (the derived-layer
-      // wizard, future analysis tools) need to know whether a layer
-      // is v1 inline-GeoJSON or v2 PostGIS-backed so they can filter
-      // out incompatible sources before the user picks one. Reads
-      // only the `data_json -> 'storageType'` path so the trip back
-      // is one short string per row, not the whole metadata blob.
+      // Compute lite-mode annotations for data_layer rows in one
+      // targeted raw query. The lite findMany strips `data` to keep
+      // the wire payload small, but downstream UI surfaces (the
+      // derived-layer wizard, future analysis tools) need three
+      // small derived facts:
+      //   - `_storageType`: tells v1 inline-GeoJSON apart from v2 /
+      //     v3 PostGIS-backed layers.
+      //   - `_layers`: for v3 multi-layer items, the per-sublayer
+      //     {id, label, geometryType} list so the picker can flatten
+      //     sublayers into selectable rows.
+      // Reads only the JSON paths we care about so the trip back is
+      // one string + a small array per row, not the whole metadata
+      // blob.
       const dataLayerIds = rows
         .filter((r) => r.type === 'data_layer')
         .map((r) => r.id);
       const storageTypes = new Map<string, string>();
+      const sublayerInfo = new Map<
+        string,
+        Array<{ id: string; label: string; geometryType: string | null }>
+      >();
       if (dataLayerIds.length > 0) {
         const storage = await this.prisma.$queryRaw<
-          Array<{ id: string; storage_type: string | null }>
+          Array<{
+            id: string;
+            storage_type: string | null;
+            layers: unknown;
+          }>
         >`
           SELECT id::text AS id,
-                 (data_json ->> 'storageType') AS storage_type
+                 (data_json ->> 'storageType') AS storage_type,
+                 (data_json -> 'layers')        AS layers
           FROM "item"
           WHERE id = ANY(${dataLayerIds}::uuid[])
         `;
         for (const s of storage) {
           if (s.storage_type) storageTypes.set(s.id, s.storage_type);
+          if (Array.isArray(s.layers)) {
+            const slim: Array<{
+              id: string;
+              label: string;
+              geometryType: string | null;
+            }> = [];
+            for (const raw of s.layers as unknown[]) {
+              if (!raw || typeof raw !== 'object') continue;
+              const o = raw as Record<string, unknown>;
+              if (typeof o.id !== 'string') continue;
+              slim.push({
+                id: o.id,
+                label: typeof o.label === 'string' ? o.label : o.id,
+                geometryType:
+                  typeof o.geometryType === 'string'
+                    ? (o.geometryType as string)
+                    : null,
+              });
+            }
+            sublayerInfo.set(s.id, slim);
+          }
         }
       }
 
@@ -394,6 +429,7 @@ export class ItemsService {
           return {
             ...r,
             _storageType: storageTypes.get(r.id) ?? 'inline',
+            _layers: sublayerInfo.get(r.id) ?? [],
           };
         }
         return r;

--- a/apps/portal-api/src/items/items.service.ts
+++ b/apps/portal-api/src/items/items.service.ts
@@ -32,6 +32,7 @@ import {
   type V3LayerShape,
 } from '../features-v3/v3-tables.service.js';
 import { NotificationsService } from '../notifications/notifications.service.js';
+import { DerivedLayersService } from '../derived-layers/derived-layers.service.js';
 
 // Optional fields use `| undefined` explicitly so class-validator DTOs
 // (which leave unset keys present-as-undefined) can satisfy these types
@@ -104,6 +105,7 @@ export class ItemsService {
     private readonly v3Tables: V3TablesService,
     private readonly snapshots: DataSnapshotService,
     private readonly notifications: NotificationsService,
+    private readonly derivedLayers: DerivedLayersService,
   ) {}
 
   async list(
@@ -562,13 +564,24 @@ export class ItemsService {
     // DEFAULT_MAP to the org's seeded positron (or any available)
     // basemap item UUID so every new map opens against a real
     // basemap without the client needing to know any UUIDs up front.
-    const resolvedData: Prisma.InputJsonValue =
+    let resolvedData: Prisma.InputJsonValue =
       input.type === 'map'
         ? ((await this.resolveDefaultBasemap(
             user.orgId,
             input.data,
           )) as Prisma.InputJsonValue)
         : input.data;
+
+    // For derived_layer items, validate the recipe + compute the
+    // cached outputSchema and bbox before persisting. The source
+    // ACL check is run here (not in DerivedLayersService) so the
+    // module dependency stays one-directional.
+    if (input.type === 'derived_layer') {
+      resolvedData = (await this.enrichDerivedLayerData(
+        user,
+        input.data,
+      )) as Prisma.InputJsonValue;
+    }
 
     const bbox = itemBbox(input.type, resolvedData);
     const row = await this.prisma.item.create({
@@ -614,6 +627,56 @@ export class ItemsService {
       }
     }
     return row;
+  }
+
+  /**
+   * Validate + enrich a derived_layer's `data` payload. Loads the
+   * source data layer, runs an explicit canRead check (so a user
+   * can't construct a derived layer over a layer they can't see),
+   * then delegates to DerivedLayersService for the per-tool
+   * validation, output-schema computation, and bbox padding.
+   *
+   * Returns the enriched data (with `outputSchema` and `bbox`
+   * populated) ready to write to `item.data`. Throws
+   * `BadRequestException` for any validation failure, including a
+   * non-readable / wrong-type / trashed source.
+   */
+  private async enrichDerivedLayerData(
+    user: AuthUser,
+    rawData: Prisma.InputJsonValue,
+  ): Promise<Prisma.JsonValue> {
+    if (!rawData || typeof rawData !== 'object') {
+      throw new BadRequestException('derived_layer data must be an object');
+    }
+    const sourceRef = (rawData as { source?: unknown }).source as
+      | { itemId?: unknown }
+      | undefined;
+    if (!sourceRef || typeof sourceRef.itemId !== 'string') {
+      throw new BadRequestException(
+        'derived_layer.source.itemId is required',
+      );
+    }
+    const source = await this.prisma.item.findUnique({
+      where: { id: sourceRef.itemId },
+      include: { shares: true },
+    });
+    if (
+      !source ||
+      source.deletedAt !== null ||
+      !this.sharing.canRead(user, source, source.shares)
+    ) {
+      // Match items.service.get's existence-vs-access idiom:
+      // surface the same generic error regardless of whether the
+      // source is missing, trashed, or unshared, so an attacker
+      // can't probe for hidden item ids.
+      throw new BadRequestException(
+        'derived_layer.source.itemId does not point at an accessible data layer',
+      );
+    }
+    return this.derivedLayers.validateAndEnrich(
+      rawData,
+      source,
+    ) as unknown as Prisma.JsonValue;
   }
 
   /**
@@ -702,22 +765,34 @@ export class ItemsService {
     if (input.data !== undefined && item.type === 'data_layer') {
       await this.snapshots.snapshot(id, user.id, 'pre-update');
     }
+    // For derived_layer updates that touch the recipe, validate +
+    // re-enrich (recomputes outputSchema and bbox) before persisting.
+    // Metadata-only updates (title / tags / sharing) bypass this so
+    // they stay cheap.
+    let nextData: Prisma.InputJsonValue | undefined = input.data;
+    if (input.data !== undefined && item.type === 'derived_layer') {
+      nextData = (await this.enrichDerivedLayerData(
+        user,
+        input.data,
+      )) as Prisma.InputJsonValue;
+    }
+
     // Recompute the cached extent when the data blob changes; leave
     // it untouched on metadata-only edits so we don't churn the
     // index for no reason.
     const nextBbox =
-      input.data !== undefined ? itemBbox(item.type, input.data) : null;
+      nextData !== undefined ? itemBbox(item.type, nextData) : null;
     const updated = await this.prisma.item.update({
       where: { id },
       data: {
         ...(input.title !== undefined && { title: input.title }),
         ...(input.description !== undefined && { description: input.description }),
         ...(input.tags !== undefined && { tags: input.tags }),
-        ...(input.data !== undefined && { data: input.data }),
+        ...(nextData !== undefined && { data: nextData }),
         ...(input.access !== undefined && { access: input.access }),
         ...(input.thumbnailUrl !== undefined && { thumbnailUrl: input.thumbnailUrl }),
         ...(input.license !== undefined && { license: input.license }),
-        ...(input.data !== undefined && { bbox: nextBbox ?? [] }),
+        ...(nextData !== undefined && { bbox: nextBbox ?? [] }),
       },
     });
     // v3: reconcile layer tables against the updated schema. prev lets
@@ -900,6 +975,33 @@ export class ItemsService {
     } = {},
   ): Promise<{ type: 'FeatureCollection'; features: unknown[] }> {
     const item = await this.get(user, id);
+
+    if (item.type === 'derived_layer') {
+      // Resolve and authorize the source data layer here so the
+      // derived-layers service stays one-directional (no SharingService
+      // dependency). A source that's missing, trashed, or out of
+      // reach for the caller produces an empty FeatureCollection
+      // rather than throwing, so a momentary inconsistency degrades
+      // gracefully on the map.
+      const data = item.data as { source?: { itemId?: string } } | null;
+      const sourceId = data?.source?.itemId;
+      if (typeof sourceId !== 'string' || sourceId.length === 0) {
+        return { type: 'FeatureCollection', features: [] };
+      }
+      const source = await this.prisma.item.findUnique({
+        where: { id: sourceId },
+        include: { shares: true },
+      });
+      if (
+        !source ||
+        source.deletedAt !== null ||
+        !this.sharing.canRead(user, source, source.shares)
+      ) {
+        return { type: 'FeatureCollection', features: [] };
+      }
+      return this.derivedLayers.getGeoJson(item, source, opts);
+    }
+
     if (item.type !== 'data_layer') {
       return { type: 'FeatureCollection', features: [] };
     }

--- a/apps/portal-api/src/items/items.service.ts
+++ b/apps/portal-api/src/items/items.service.ts
@@ -357,11 +357,47 @@ export class ItemsService {
         `;
         for (const c of counted) counts.set(c.id, c.sublayer_count);
       }
-      result = rows.map((r) =>
-        r.type === 'arcgis_service'
-          ? { ...r, _subLayerCount: counts.get(r.id) ?? 0 }
-          : r,
-      );
+
+      // Compute `_storageType` for data_layer rows in one targeted
+      // raw query. The lite findMany strips `data` to keep the wire
+      // payload small, but downstream UI surfaces (the derived-layer
+      // wizard, future analysis tools) need to know whether a layer
+      // is v1 inline-GeoJSON or v2 PostGIS-backed so they can filter
+      // out incompatible sources before the user picks one. Reads
+      // only the `data_json -> 'storageType'` path so the trip back
+      // is one short string per row, not the whole metadata blob.
+      const dataLayerIds = rows
+        .filter((r) => r.type === 'data_layer')
+        .map((r) => r.id);
+      const storageTypes = new Map<string, string>();
+      if (dataLayerIds.length > 0) {
+        const storage = await this.prisma.$queryRaw<
+          Array<{ id: string; storage_type: string | null }>
+        >`
+          SELECT id::text AS id,
+                 (data_json ->> 'storageType') AS storage_type
+          FROM "item"
+          WHERE id = ANY(${dataLayerIds}::uuid[])
+        `;
+        for (const s of storage) {
+          if (s.storage_type) storageTypes.set(s.id, s.storage_type);
+        }
+      }
+
+      result = rows.map((r) => {
+        if (r.type === 'arcgis_service') {
+          return { ...r, _subLayerCount: counts.get(r.id) ?? 0 };
+        }
+        if (r.type === 'data_layer') {
+          // Default to 'inline' (v1) when the field is absent so the
+          // client never has to special-case "missing means v1".
+          return {
+            ...r,
+            _storageType: storageTypes.get(r.id) ?? 'inline',
+          };
+        }
+        return r;
+      });
     }
 
     if (traceTiming) {

--- a/apps/portal-web/src/app/items/[id]/derived-layer/detail.tsx
+++ b/apps/portal-web/src/app/items/[id]/derived-layer/detail.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { ArrowRight, FlaskConical, Layers } from 'lucide-react';
+import type {
+  DerivedLayerData,
+  Item,
+  ToolStep,
+} from '@gratis-gis/shared-types';
+
+/**
+ * Read-only summary of a derived layer's recipe. Editing the recipe
+ * (changing the source, tweaking buffer distance, adding tools) lives
+ * on the standard /edit screen for now: this panel just shows what
+ * the layer is so a viewer or owner can understand it at a glance,
+ * and shows the cached output schema so people binding dashboards
+ * to it can see the columns without running a query.
+ *
+ * Source title resolution is best-effort: a missing / unshared /
+ * trashed source renders the bare UUID with a warning rather than
+ * blocking the panel.
+ */
+export function DerivedLayerDetail({
+  data,
+}: {
+  data: DerivedLayerData;
+}) {
+  const [sourceItem, setSourceItem] = useState<Item | null>(null);
+  const [sourceErr, setSourceErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!data.source.itemId) return;
+    fetch(`/api/portal/items/${data.source.itemId}`)
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        const body = (await r.json()) as Item;
+        if (!cancelled) setSourceItem(body);
+      })
+      .catch(() => {
+        if (!cancelled) setSourceErr('Source layer not accessible.');
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [data.source.itemId]);
+
+  return (
+    <section className="mb-6 space-y-6 rounded-lg border border-border bg-surface-1 p-4">
+      <header className="flex items-start gap-3">
+        <span className="mt-0.5 inline-flex h-8 w-8 items-center justify-center rounded-md bg-blue-700/90 text-white">
+          <FlaskConical className="h-4 w-4" />
+        </span>
+        <div>
+          <h2 className="text-sm font-medium text-ink-0">Recipe</h2>
+          <p className="mt-1 text-xs text-muted">
+            This layer is computed live: it stores the steps below and
+            re-runs them on every read so it stays in sync with its
+            source.
+          </p>
+        </div>
+      </header>
+
+      <div className="space-y-2">
+        <h3 className="text-xs font-medium uppercase tracking-wide text-muted">
+          Source layer
+        </h3>
+        {sourceItem ? (
+          <Link
+            href={`/items/${sourceItem.id}`}
+            className="inline-flex items-start gap-2 rounded-md border border-border bg-surface-0 px-3 py-2 text-sm hover:bg-surface-2"
+          >
+            <Layers className="mt-0.5 h-4 w-4 shrink-0 text-sky-600" />
+            <span className="min-w-0 flex-1">
+              <span className="block font-medium text-ink-0">
+                {sourceItem.title}
+              </span>
+              {sourceItem.description ? (
+                <span className="mt-0.5 block text-xs text-muted">
+                  {sourceItem.description}
+                </span>
+              ) : null}
+            </span>
+          </Link>
+        ) : sourceErr ? (
+          <p className="text-xs text-danger">
+            {sourceErr} The recipe still references{' '}
+            <code>{data.source.itemId}</code>.
+          </p>
+        ) : (
+          <p className="text-xs text-muted">Loading source layer…</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="text-xs font-medium uppercase tracking-wide text-muted">
+          Pipeline ({data.pipeline.length} step
+          {data.pipeline.length === 1 ? '' : 's'})
+        </h3>
+        {data.pipeline.length === 0 ? (
+          <p className="text-xs text-muted">
+            No tool steps configured. The layer needs at least one
+            step to return any features.
+          </p>
+        ) : (
+          <ol className="space-y-1">
+            {data.pipeline.map((step, idx) => (
+              <li
+                key={idx}
+                className="flex items-start gap-2 rounded-md border border-border bg-surface-0 px-3 py-2 text-sm"
+              >
+                <span className="mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-blue-700/90 text-[11px] font-semibold text-white">
+                  {idx + 1}
+                </span>
+                <span className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+                  <span className="font-medium text-ink-0">
+                    {labelForTool(step)}
+                  </span>
+                  <ArrowRight className="h-3 w-3 text-muted" />
+                  <span className="text-xs text-muted">
+                    {summarizeStep(step)}
+                  </span>
+                </span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="text-xs font-medium uppercase tracking-wide text-muted">
+          Output schema
+        </h3>
+        {data.outputSchema.length === 0 ? (
+          <p className="text-xs text-muted">
+            No fields recorded yet. Save the recipe (or wait for the
+            server to recompute) to populate this list.
+          </p>
+        ) : (
+          <ul className="grid grid-cols-1 gap-1 text-xs sm:grid-cols-2">
+            {data.outputSchema.map((f) => (
+              <li
+                key={f.name}
+                className="flex items-baseline justify-between rounded-md border border-border bg-surface-0 px-2 py-1"
+              >
+                <span className="truncate font-medium text-ink-0">
+                  {f.label || f.name}
+                </span>
+                <span className="ml-2 shrink-0 text-muted">{f.type}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="text-[11px] text-muted">
+        Feature limit: {data.featureLimit.toLocaleString()} features per
+        read.
+      </div>
+    </section>
+  );
+}
+
+function labelForTool(step: ToolStep): string {
+  switch (step.tool) {
+    case 'buffer':
+      return 'Buffer';
+    default:
+      // Future tools land in this default until they grow a label;
+      // shows the raw kind so the panel never goes silently blank
+      // when a deployment is on a newer schema than the client.
+      return (step as { tool: string }).tool;
+  }
+}
+
+function summarizeStep(step: ToolStep): string {
+  switch (step.tool) {
+    case 'buffer': {
+      const { distance, unit } = step.params;
+      return `${distance.toLocaleString()} ${unit}`;
+    }
+    default:
+      return '';
+  }
+}

--- a/apps/portal-web/src/app/items/[id]/map/add-layer-dialog.tsx
+++ b/apps/portal-web/src/app/items/[id]/map/add-layer-dialog.tsx
@@ -102,13 +102,19 @@ export function AddLayerDialog({ open, onClose, onAdd }: Props) {
   }, []);
 
   // Load portal items when the portal tab activates or the query
-  // changes. One fetch (?type=data_layer,arcgis_service&lite=1)
-  // covers both supported types; lite mode strips the heavy data
+  // changes. One fetch
+  // (?type=data_layer,derived_layer,arcgis_service&lite=1) covers
+  // every supported source type; lite mode strips the heavy data
   // JSONB from each row so the wire payload is small and the
   // backend skips serialising hundreds of KB of layer metadata
   // per arcgis_service. The badge count comes from the derived
   // `_subLayerCount` field the server attaches in lite mode. Full
   // `data` is fetched lazily when the user clicks an item below.
+  // Derived layers join the list because the map renderer treats
+  // them as `kind: 'data-layer'` sources -- /items/:id/geojson on
+  // a derived_layer routes to derivedLayers.getGeoJson on the
+  // backend, so MapLibre fetches the same shape it does for a
+  // regular data layer.
   //
   // The fetch wires through an AbortController so when the user
   // navigates away mid-load (or types another character) the
@@ -127,7 +133,7 @@ export function AddLayerDialog({ open, onClose, onAdd }: Props) {
       try {
         const q = portalQ.trim();
         const qs = new URLSearchParams({
-          type: 'data_layer,arcgis_service',
+          type: 'data_layer,derived_layer,arcgis_service',
           lite: '1',
         });
         if (q) qs.set('q', q);
@@ -811,12 +817,16 @@ export function AddLayerDialog({ open, onClose, onAdd }: Props) {
                             className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] uppercase tracking-wide ${
                               item.type === 'arcgis_service'
                                 ? 'bg-cyan-100 text-cyan-800'
-                                : 'bg-sky-100 text-sky-800'
+                                : item.type === 'derived_layer'
+                                  ? 'bg-blue-100 text-blue-800'
+                                  : 'bg-sky-100 text-sky-800'
                             }`}
                           >
                             {item.type === 'arcgis_service'
                               ? 'ArcGIS'
-                              : 'Feature'}
+                              : item.type === 'derived_layer'
+                                ? 'Derived'
+                                : 'Feature'}
                           </span>
                         </div>
                         {item.description ? (

--- a/apps/portal-web/src/app/items/[id]/page.tsx
+++ b/apps/portal-web/src/app/items/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import type {
   BasemapData,
+  DerivedLayerData,
   FolderData,
   Item,
   ItemShare,
@@ -102,6 +103,7 @@ import { DataLayerV3SchemaEditor } from './data-layer/v3-schema-editor';
 import { ArcgisServiceEditor } from './arcgis-service/editor';
 import { PickListEditor } from './pick-list/editor';
 import { GeoBoundaryEditor } from './geo-boundary/editor';
+import { DerivedLayerDetail } from './derived-layer/detail';
 import { FolderDetail } from './folder/folder-detail';
 import { EditorDetail } from './editor/editor-detail';
 import { FormDesigner } from './form/designer';
@@ -487,6 +489,10 @@ export default async function ItemDetailPage({ params }: Props) {
             canEdit={canManage}
           />
         </section>
+      ) : item.type === 'derived_layer' ? (
+        <DerivedLayerDetail
+          data={(item.data ?? {}) as DerivedLayerData}
+        />
       ) : item.type === 'pick_list' ? (
         <section className="mb-6">
           <PickListEditor

--- a/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
+++ b/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
@@ -1,7 +1,19 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { FlaskConical, Layers, Search } from 'lucide-react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  ChevronDown,
+  FlaskConical,
+  Layers,
+  Search,
+  X,
+} from 'lucide-react';
 import {
   DEFAULT_DERIVED_LAYER_FEATURE_LIMIT,
   MAX_BUFFER_DISTANCE_METERS,
@@ -33,47 +45,6 @@ export function DerivedLayerBuilder({
   value: DerivedLayerData;
   onChange: (next: DerivedLayerData) => void;
 }) {
-  // Source layer picker state. We resolve the items list once on
-  // mount and let the user filter inline; for orgs with hundreds of
-  // data_layer items this should still feel snappy because the
-  // existing list endpoint streams them in bulk.
-  const [sources, setSources] = useState<Item[] | null>(null);
-  const [sourceFilter, setSourceFilter] = useState('');
-  const [sourceErr, setSourceErr] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    fetch('/api/portal/items?type=data_layer')
-      .then(async (r) => {
-        if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        const body = (await r.json()) as { items?: Item[] } | Item[];
-        const list = Array.isArray(body) ? body : (body.items ?? []);
-        if (!cancelled) setSources(list);
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          setSourceErr(
-            err instanceof Error ? err.message : 'Could not load data layers',
-          );
-          setSources([]);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const visibleSources = useMemo(() => {
-    if (!sources) return [];
-    const q = sourceFilter.trim().toLowerCase();
-    if (q.length === 0) return sources;
-    return sources.filter(
-      (s) =>
-        s.title.toLowerCase().includes(q) ||
-        s.description.toLowerCase().includes(q),
-    );
-  }, [sources, sourceFilter]);
-
   // Buffer step is the only tool in v1, so we surface it directly
   // rather than via a "pick a tool" intermediate step. When more
   // tools land, this becomes a tool selector and per-tool form
@@ -144,64 +115,13 @@ export function DerivedLayerBuilder({
         <h4 className="text-xs font-medium uppercase tracking-wide text-muted">
           Source layer
         </h4>
-        <div className="relative">
-          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted" />
-          <input
-            type="search"
-            value={sourceFilter}
-            onChange={(e) => setSourceFilter(e.target.value)}
-            placeholder="Filter by title or description"
-            className="h-10 w-full rounded-md border border-border bg-surface-0 pl-9 pr-3 text-sm text-ink-0 placeholder:text-muted focus:border-accent focus:outline-none"
-          />
-        </div>
-        {sourceErr ? (
-          <p className="text-xs text-danger">Could not load data layers: {sourceErr}</p>
-        ) : null}
-        {sources === null ? (
-          <p className="text-xs text-muted">Loading data layers…</p>
-        ) : visibleSources.length === 0 ? (
-          <p className="text-xs text-muted">
-            No data layers match the filter. Create one first under
-            Data {'>'} Data layer, then come back here.
-          </p>
-        ) : (
-          <ul
-            role="radiogroup"
-            aria-label="Source data layer"
-            className="max-h-64 space-y-1 overflow-y-auto rounded-md border border-border bg-surface-0 p-1"
-          >
-            {visibleSources.map((s) => {
-              const selected = value.source.itemId === s.id;
-              return (
-                <li key={s.id}>
-                  <button
-                    type="button"
-                    role="radio"
-                    aria-checked={selected}
-                    onClick={() => setSourceItem(s.id)}
-                    className={`flex w-full items-start gap-3 rounded-md px-3 py-2 text-left text-sm hover:bg-surface-2 ${
-                      selected
-                        ? 'bg-accent/10 ring-1 ring-accent'
-                        : ''
-                    }`}
-                  >
-                    <Layers className="mt-0.5 h-4 w-4 shrink-0 text-sky-600" />
-                    <span className="min-w-0 flex-1">
-                      <span className="block truncate font-medium text-ink-0">
-                        {s.title}
-                      </span>
-                      {s.description ? (
-                        <span className="mt-0.5 block truncate text-xs text-muted">
-                          {s.description}
-                        </span>
-                      ) : null}
-                    </span>
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-        )}
+        <SourceLayerPicker
+          selectedId={value.source.itemId}
+          onSelect={setSourceItem}
+        />
+        <p className="text-[11px] text-muted">
+          The list shows data layers you own and ones shared with you.
+        </p>
       </section>
 
       <section className="space-y-2">
@@ -257,6 +177,283 @@ export function DerivedLayerBuilder({
           />
         </label>
       </section>
+    </div>
+  );
+}
+
+/**
+ * Combobox-style picker for a single data_layer Item.
+ *
+ * Closed state is a button showing the selected layer's title (or a
+ * placeholder). Click opens a popover with a search input and the
+ * filtered list of data layers visible to the caller. Search runs
+ * server-side via `?q=` on the items list endpoint, debounced 200ms
+ * so a rapid typist doesn't fire a request per keystroke. Click-
+ * outside or Escape closes the popover; clicking a row selects and
+ * closes.
+ *
+ * The fetch follows the same pattern as the map's add-layer dialog
+ * (`?type=data_layer&lite=1`), which already returns items the
+ * caller can see, so no extra "shared with me" filtering is needed
+ * here. The list is sorted server-side by updatedAt desc so the
+ * most-recently-touched layers float to the top.
+ */
+function SourceLayerPicker({
+  selectedId,
+  onSelect,
+}: {
+  selectedId: string;
+  onSelect: (id: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [items, setItems] = useState<Item[] | null>(null);
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // Cache the selected item separately so the trigger keeps showing
+  // the right title even after the popover's list refetches with a
+  // narrowed query that excludes it.
+  const [cachedSelection, setCachedSelection] = useState<Item | null>(null);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+
+  // Debounced server-side search. Aborts any in-flight request when
+  // the query changes again so we don't hold a stale Prisma
+  // connection on the API side.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const controller = new AbortController();
+    setLoading(true);
+    setErr(null);
+    const handle = setTimeout(async () => {
+      try {
+        const qs = new URLSearchParams({ type: 'data_layer', lite: '1' });
+        const q = query.trim();
+        if (q) qs.set('q', q);
+        const res = await fetch(`/api/portal/items?${qs}`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const body = (await res.json()) as Item[] | { items?: Item[] };
+        const list = Array.isArray(body) ? body : (body.items ?? []);
+        if (!cancelled) setItems(list);
+      } catch (e) {
+        if ((e as Error)?.name === 'AbortError') return;
+        if (!cancelled) {
+          setErr(
+            e instanceof Error ? e.message : 'Could not load data layers',
+          );
+          setItems([]);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }, 200);
+    return () => {
+      cancelled = true;
+      clearTimeout(handle);
+      controller.abort();
+    };
+  }, [open, query]);
+
+  // Resolve the selected id to a full Item once on mount (and again
+  // if the parent passes a new id we don't already have cached).
+  // Avoids a "selected but trigger shows blank" gap when the picker
+  // mounts with a value already set.
+  useEffect(() => {
+    if (!selectedId || cachedSelection?.id === selectedId) return;
+    let cancelled = false;
+    fetch(`/api/portal/items/${selectedId}?lite=1`)
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        const body = (await r.json()) as Item;
+        if (!cancelled) setCachedSelection(body);
+      })
+      .catch(() => {
+        // Best-effort: leave the trigger showing the bare id if the
+        // resolve fails. Probably means the item was deleted or
+        // un-shared between save and re-render.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId, cachedSelection?.id]);
+
+  // Close on click outside.
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [open]);
+
+  // Focus the search input when the popover opens, so the user can
+  // start typing immediately. Wrapped in rAF so the input has been
+  // mounted before we try to focus it.
+  useEffect(() => {
+    if (!open) return;
+    const id = requestAnimationFrame(() => searchInputRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, [open]);
+
+  const handleSelect = useCallback(
+    (item: Item) => {
+      setCachedSelection(item);
+      onSelect(item.id);
+      setOpen(false);
+      setQuery('');
+    },
+    [onSelect],
+  );
+
+  // Items currently visible in the popover. We let the server do the
+  // search but ALSO drop the selected item from the list when there's
+  // no query, so the popover doesn't waste a slot showing what's
+  // already chosen. Selected item still appears when the user is
+  // searching, so a typo recovery doesn't hide it.
+  const visibleItems = useMemo(() => {
+    if (!items) return null;
+    if (!selectedId || query.trim().length > 0) return items;
+    return items.filter((i) => i.id !== selectedId);
+  }, [items, selectedId, query]);
+
+  const triggerLabel =
+    cachedSelection && cachedSelection.id === selectedId
+      ? cachedSelection.title
+      : selectedId
+        ? '(Resolving selected layer…)'
+        : 'Pick a source data layer…';
+
+  const triggerSubtitle =
+    cachedSelection && cachedSelection.id === selectedId
+      ? cachedSelection.description
+      : '';
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-start gap-3 rounded-md border border-border bg-surface-0 px-3 py-2 text-left hover:bg-surface-2 focus:border-accent focus:outline-none"
+      >
+        <Layers className="mt-0.5 h-4 w-4 shrink-0 text-sky-600" />
+        <span className="min-w-0 flex-1">
+          <span
+            className={`block truncate text-sm font-medium ${
+              selectedId ? 'text-ink-0' : 'text-muted'
+            }`}
+          >
+            {triggerLabel}
+          </span>
+          {triggerSubtitle ? (
+            <span className="mt-0.5 block truncate text-xs text-muted">
+              {triggerSubtitle}
+            </span>
+          ) : null}
+        </span>
+        <ChevronDown
+          className={`mt-1 h-4 w-4 shrink-0 text-muted transition-transform ${
+            open ? 'rotate-180' : ''
+          }`}
+          aria-hidden="true"
+        />
+      </button>
+
+      {open ? (
+        <div
+          role="listbox"
+          aria-label="Data layers"
+          className="absolute left-0 right-0 z-20 mt-1 overflow-hidden rounded-md border border-border bg-surface-0 shadow-lg"
+        >
+          <div className="relative border-b border-border p-2">
+            <Search
+              className="pointer-events-none absolute left-5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted"
+              aria-hidden="true"
+            />
+            <input
+              ref={searchInputRef}
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                  e.preventDefault();
+                  setOpen(false);
+                }
+              }}
+              placeholder="Search data layers…"
+              className="h-9 w-full rounded-md border border-border bg-surface-1 pl-9 pr-8 text-sm text-ink-0 placeholder:text-muted focus:border-accent focus:outline-none"
+            />
+            {query ? (
+              <button
+                type="button"
+                onClick={() => setQuery('')}
+                aria-label="Clear search"
+                className="absolute right-4 top-1/2 -translate-y-1/2 rounded p-0.5 text-muted hover:bg-surface-2"
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            ) : null}
+          </div>
+
+          <div className="max-h-64 overflow-y-auto p-1">
+            {err ? (
+              <p className="px-3 py-2 text-xs text-danger">
+                Could not load data layers: {err}
+              </p>
+            ) : loading && !visibleItems ? (
+              <p className="px-3 py-2 text-xs text-muted">
+                Loading data layers…
+              </p>
+            ) : !visibleItems || visibleItems.length === 0 ? (
+              <p className="px-3 py-2 text-xs text-muted">
+                {query
+                  ? `No data layers match "${query}".`
+                  : 'No data layers visible to you yet. Create one under Data > Data layer first.'}
+              </p>
+            ) : (
+              <ul className="space-y-0.5">
+                {visibleItems.map((s) => {
+                  const selected = selectedId === s.id;
+                  return (
+                    <li key={s.id}>
+                      <button
+                        type="button"
+                        role="option"
+                        aria-selected={selected}
+                        onClick={() => handleSelect(s)}
+                        className={`flex w-full items-start gap-3 rounded-md px-3 py-2 text-left text-sm hover:bg-surface-2 ${
+                          selected ? 'bg-accent/10 ring-1 ring-accent' : ''
+                        }`}
+                      >
+                        <Layers className="mt-0.5 h-4 w-4 shrink-0 text-sky-600" />
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate font-medium text-ink-0">
+                            {s.title}
+                          </span>
+                          {s.description ? (
+                            <span className="mt-0.5 block truncate text-xs text-muted">
+                              {s.description}
+                            </span>
+                          ) : null}
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
+++ b/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
@@ -151,7 +151,10 @@ export function DerivedLayerBuilder({
           onSelect={setSourceItem}
         />
         <p className="text-[11px] text-muted">
-          The list shows data layers you own and ones shared with you.
+          Lists data layers you own or have been shared with. Only v2
+          PostGIS-backed layers are eligible: the buffer tool runs SQL
+          against the source's feature table, which v1 inline-GeoJSON
+          layers don't have.
         </p>
       </section>
 
@@ -241,6 +244,11 @@ function SourceLayerPicker({
   const [query, setQuery] = useState('');
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  // Count of data layers that exist for the user but are hidden
+  // because they aren't v2 PostGIS-backed. Drives the footnote in
+  // the empty / footer state so the user understands why a layer
+  // they remember creating doesn't appear in the list.
+  const [hiddenIncompatibleCount, setHiddenIncompatibleCount] = useState(0);
 
   // Cache the selected item separately so the trigger keeps showing
   // the right title even after the popover's list refetches with a
@@ -253,6 +261,14 @@ function SourceLayerPicker({
   // Debounced server-side search. Aborts any in-flight request when
   // the query changes again so we don't hold a stale Prisma
   // connection on the API side.
+  //
+  // The list is filtered to v2 PostGIS-backed data layers only.
+  // Buffer (and any future tool that issues SQL against the source's
+  // fs_<uuid> table) needs that table to exist; v1 inline-GeoJSON
+  // layers don't have one, and selecting one would silently produce
+  // an empty result. The server attaches `_storageType` to lite-mode
+  // data_layer rows so we can filter without paying the full data-
+  // blob cost.
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
@@ -268,9 +284,17 @@ function SourceLayerPicker({
           signal: controller.signal,
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const body = (await res.json()) as Item[] | { items?: Item[] };
+        const body = (await res.json()) as
+          | Array<Item & { _storageType?: string }>
+          | { items?: Array<Item & { _storageType?: string }> };
         const list = Array.isArray(body) ? body : (body.items ?? []);
-        if (!cancelled) setItems(list);
+        const compatible = list.filter(
+          (i) => i._storageType === 'postgis',
+        );
+        if (!cancelled) {
+          setItems(compatible);
+          setHiddenIncompatibleCount(list.length - compatible.length);
+        }
       } catch (e) {
         if ((e as Error)?.name === 'AbortError') return;
         if (!cancelled) {
@@ -445,11 +469,21 @@ function SourceLayerPicker({
                 Loading data layers…
               </p>
             ) : !visibleItems || visibleItems.length === 0 ? (
-              <p className="px-3 py-2 text-xs text-muted">
-                {query
-                  ? `No data layers match "${query}".`
-                  : 'No data layers visible to you yet. Create one under Data > Data layer first.'}
-              </p>
+              <div className="px-3 py-2 text-xs text-muted">
+                <p>
+                  {query
+                    ? `No compatible data layers match "${query}".`
+                    : 'No compatible data layers visible to you yet. Create one under Data > Data layer first.'}
+                </p>
+                {hiddenIncompatibleCount > 0 ? (
+                  <p className="mt-1 text-[11px]">
+                    {hiddenIncompatibleCount} v1 inline-GeoJSON
+                    layer{hiddenIncompatibleCount === 1 ? ' is' : 's are'}{' '}
+                    hidden because the buffer tool needs a v2 PostGIS-
+                    backed source.
+                  </p>
+                ) : null}
+              </div>
             ) : (
               <ul className="space-y-0.5">
                 {visibleItems.map((s) => {

--- a/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
+++ b/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
@@ -49,10 +49,41 @@ export function DerivedLayerBuilder({
   // rather than via a "pick a tool" intermediate step. When more
   // tools land, this becomes a tool selector and per-tool form
   // fragments.
+  //
+  // Default buffer distance shown in the input on first render.
+  // Pulled into a constant so the seed-on-mount effect below and
+  // the input value derivation agree on the same number.
+  const DEFAULT_BUFFER_DISTANCE = 100;
   const bufferStep = value.pipeline.find(
     (s): s is Extract<ToolStep, { tool: 'buffer' }> => s.tool === 'buffer',
   );
-  const bufferDistance = bufferStep?.params.distance ?? 100;
+  const bufferDistance = bufferStep?.params.distance ?? DEFAULT_BUFFER_DISTANCE;
+
+  // Seed the pipeline with a default buffer step the moment the
+  // builder mounts. Without this, the input shows "100" via the
+  // `?? DEFAULT_BUFFER_DISTANCE` fallback but `value.pipeline` stays
+  // empty until the user edits the field, which causes the wizard's
+  // "at least one step" guard to (correctly) reject the submit even
+  // though the form looks filled in.
+  useEffect(() => {
+    if (value.pipeline.length === 0) {
+      onChange({
+        ...value,
+        pipeline: [
+          {
+            tool: 'buffer',
+            params: { distance: DEFAULT_BUFFER_DISTANCE, unit: 'meters' },
+          },
+        ],
+      });
+    }
+    // We deliberately depend only on the pipeline length so this
+    // effect doesn't re-fire on every keystroke that mutates
+    // `value`. The intent is "ensure a step exists at startup or
+    // after a reset"; per-keystroke mutations go through
+    // `setBufferDistance` instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value.pipeline.length]);
 
   const setSourceItem = useCallback(
     (id: string) => {

--- a/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
+++ b/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
@@ -86,10 +86,14 @@ export function DerivedLayerBuilder({
   }, [value.pipeline.length]);
 
   const setSourceItem = useCallback(
-    (id: string) => {
+    (ref: { itemId: string; layerKey?: string }) => {
       onChange({
         ...value,
-        source: { kind: 'data_layer', itemId: id },
+        source: {
+          kind: 'data_layer',
+          itemId: ref.itemId,
+          ...(ref.layerKey ? { layerKey: ref.layerKey } : {}),
+        },
       });
     },
     [value, onChange],
@@ -147,14 +151,23 @@ export function DerivedLayerBuilder({
           Source layer
         </h4>
         <SourceLayerPicker
-          selectedId={value.source.itemId}
+          selectedRef={
+            value.source.itemId
+              ? {
+                  itemId: value.source.itemId,
+                  ...(value.source.layerKey
+                    ? { layerKey: value.source.layerKey }
+                    : {}),
+                }
+              : null
+          }
           onSelect={setSourceItem}
         />
         <p className="text-[11px] text-muted">
-          Lists data layers you own or have been shared with. Only v2
-          PostGIS-backed layers are eligible: the buffer tool runs SQL
-          against the source's feature table, which v1 inline-GeoJSON
-          layers don't have.
+          Lists data layers you own or have been shared with. v3
+          multi-layer items expand to one row per spatial sublayer;
+          v1 inline-GeoJSON layers are hidden because the buffer
+          tool runs SQL against the source's feature table.
         </p>
       </section>
 
@@ -232,28 +245,55 @@ export function DerivedLayerBuilder({
  * here. The list is sorted server-side by updatedAt desc so the
  * most-recently-touched layers float to the top.
  */
+/**
+ * Compact descriptor of a row in the popover's list. v3 items
+ * expand into one row per spatial sublayer; v2 items collapse to a
+ * single row. The composite `key` is used as React key + selection
+ * identity; downstream `onSelect` receives the full ref so the
+ * parent can write { itemId, layerKey? } into the recipe.
+ */
+interface PickerRow {
+  /** Unique within the rendered list. itemId for v2, itemId#layerKey for v3. */
+  key: string;
+  /** Backing item (carries title, description, etc.). */
+  item: Item;
+  /** Sublayer key when the row is a v3 sublayer; absent for v2. */
+  layerKey?: string;
+  /** Sublayer label when v3; for v2 the row uses item.title directly. */
+  sublayerLabel?: string;
+  /** Geometry type when v3; informational, not surfaced for v2. */
+  geometryType?: string;
+}
+
+interface ItemWithLite extends Item {
+  _storageType?: string;
+  _layers?: Array<{ id: string; label: string; geometryType: string | null }>;
+}
+
 function SourceLayerPicker({
-  selectedId,
+  selectedRef,
   onSelect,
 }: {
-  selectedId: string;
-  onSelect: (id: string) => void;
+  selectedRef: { itemId: string; layerKey?: string } | null;
+  onSelect: (ref: { itemId: string; layerKey?: string }) => void;
 }) {
   const [open, setOpen] = useState(false);
-  const [items, setItems] = useState<Item[] | null>(null);
+  const [rows, setRows] = useState<PickerRow[] | null>(null);
   const [query, setQuery] = useState('');
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   // Count of data layers that exist for the user but are hidden
-  // because they aren't v2 PostGIS-backed. Drives the footnote in
-  // the empty / footer state so the user understands why a layer
+  // because they aren't v2 / v3 PostGIS-backed. Drives the footnote
+  // in the empty / footer state so the user understands why a layer
   // they remember creating doesn't appear in the list.
   const [hiddenIncompatibleCount, setHiddenIncompatibleCount] = useState(0);
 
-  // Cache the selected item separately so the trigger keeps showing
+  // Cache the selected row separately so the trigger keeps showing
   // the right title even after the popover's list refetches with a
   // narrowed query that excludes it.
-  const [cachedSelection, setCachedSelection] = useState<Item | null>(null);
+  const [cachedSelection, setCachedSelection] = useState<PickerRow | null>(
+    null,
+  );
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
@@ -262,13 +302,17 @@ function SourceLayerPicker({
   // the query changes again so we don't hold a stale Prisma
   // connection on the API side.
   //
-  // The list is filtered to v2 PostGIS-backed data layers only.
-  // Buffer (and any future tool that issues SQL against the source's
-  // fs_<uuid> table) needs that table to exist; v1 inline-GeoJSON
-  // layers don't have one, and selecting one would silently produce
-  // an empty result. The server attaches `_storageType` to lite-mode
-  // data_layer rows so we can filter without paying the full data-
-  // blob cost.
+  // The list is filtered to PostGIS-backed data layers only. v1
+  // inline-GeoJSON has no PostGIS table for buffer to query against
+  // and selecting one would silently produce an empty result. The
+  // server attaches `_storageType` and (for v3) `_layers` to lite-
+  // mode data_layer rows so we can filter and flatten sublayers
+  // without paying the full data-blob cost.
+  //
+  // After filtering by storage type, each item is flattened into one
+  // PickerRow per spatial sublayer (for v3) or a single PickerRow
+  // (for v2). Attribute-only "tables" inside v3 items are dropped
+  // here because buffer needs geometry to operate on.
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
@@ -285,15 +329,55 @@ function SourceLayerPicker({
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const body = (await res.json()) as
-          | Array<Item & { _storageType?: string }>
-          | { items?: Array<Item & { _storageType?: string }> };
+          | ItemWithLite[]
+          | { items?: ItemWithLite[] };
         const list = Array.isArray(body) ? body : (body.items ?? []);
         const compatible = list.filter(
           (i) => i._storageType === 'postgis',
         );
+        const flattened: PickerRow[] = [];
+        for (const item of compatible) {
+          const layers = item._layers ?? [];
+          // v3 = at least one declared layer; flatten spatial layers.
+          // v2 = no _layers entry (or empty); single row for the
+          // whole item.
+          const spatial = layers.filter(
+            (l) => typeof l.geometryType === 'string',
+          );
+          if (spatial.length > 0) {
+            for (const l of spatial) {
+              flattened.push({
+                key: `${item.id}#${l.id}`,
+                item,
+                layerKey: l.id,
+                sublayerLabel: l.label,
+                ...(l.geometryType ? { geometryType: l.geometryType } : {}),
+              });
+            }
+          } else {
+            flattened.push({ key: item.id, item });
+          }
+        }
         if (!cancelled) {
-          setItems(compatible);
-          setHiddenIncompatibleCount(list.length - compatible.length);
+          setRows(flattened);
+          // Items with NO spatial sublayers (attribute-only v3 items
+          // or v3 items still empty in the builder) effectively count
+          // as incompatible from the user's POV. Track them in the
+          // hidden count so the empty-state message is honest.
+          const hiddenItems = list.length - compatible.length;
+          const itemsWithNoSpatial = compatible.filter(
+            (i) => !(i._layers ?? []).some(
+              (l) => typeof l.geometryType === 'string',
+            ),
+          ).length;
+          // Subtract v2 items (which don't have _layers but ARE
+          // valid sources) so we don't count them as hidden.
+          const v2Count = compatible.filter(
+            (i) => (i._layers ?? []).length === 0,
+          ).length;
+          setHiddenIncompatibleCount(
+            hiddenItems + Math.max(0, itemsWithNoSpatial - v2Count),
+          );
         }
       } catch (e) {
         if ((e as Error)?.name === 'AbortError') return;
@@ -301,7 +385,7 @@ function SourceLayerPicker({
           setErr(
             e instanceof Error ? e.message : 'Could not load data layers',
           );
-          setItems([]);
+          setRows([]);
         }
       } finally {
         if (!cancelled) setLoading(false);
@@ -314,18 +398,38 @@ function SourceLayerPicker({
     };
   }, [open, query]);
 
-  // Resolve the selected id to a full Item once on mount (and again
-  // if the parent passes a new id we don't already have cached).
-  // Avoids a "selected but trigger shows blank" gap when the picker
-  // mounts with a value already set.
+  // Resolve the selected ref to a full PickerRow once on mount (and
+  // again if the parent passes a new ref we don't already have
+  // cached). Avoids a "selected but trigger shows blank" gap when
+  // the picker mounts with a value already set.
+  const selectedRefKey = selectedRef
+    ? selectedRef.layerKey
+      ? `${selectedRef.itemId}#${selectedRef.layerKey}`
+      : selectedRef.itemId
+    : null;
   useEffect(() => {
-    if (!selectedId || cachedSelection?.id === selectedId) return;
+    if (!selectedRef || cachedSelection?.key === selectedRefKey) return;
     let cancelled = false;
-    fetch(`/api/portal/items/${selectedId}?lite=1`)
+    fetch(`/api/portal/items/${selectedRef.itemId}?lite=1`)
       .then(async (r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
-        const body = (await r.json()) as Item;
-        if (!cancelled) setCachedSelection(body);
+        const body = (await r.json()) as ItemWithLite;
+        if (cancelled) return;
+        // Locate the matching sublayer label when the ref points at
+        // one; for v2 sources the sublayerLabel stays absent.
+        const sub =
+          selectedRef.layerKey && Array.isArray(body._layers)
+            ? body._layers.find((l) => l.id === selectedRef.layerKey)
+            : undefined;
+        setCachedSelection({
+          key: selectedRefKey ?? body.id,
+          item: body,
+          ...(selectedRef.layerKey ? { layerKey: selectedRef.layerKey } : {}),
+          ...(sub?.label ? { sublayerLabel: sub.label } : {}),
+          ...(typeof sub?.geometryType === 'string'
+            ? { geometryType: sub.geometryType }
+            : {}),
+        });
       })
       .catch(() => {
         // Best-effort: leave the trigger showing the bare id if the
@@ -335,7 +439,7 @@ function SourceLayerPicker({
     return () => {
       cancelled = true;
     };
-  }, [selectedId, cachedSelection?.id]);
+  }, [selectedRef, selectedRefKey, cachedSelection?.key]);
 
   // Close on click outside.
   useEffect(() => {
@@ -358,37 +462,48 @@ function SourceLayerPicker({
   }, [open]);
 
   const handleSelect = useCallback(
-    (item: Item) => {
-      setCachedSelection(item);
-      onSelect(item.id);
+    (row: PickerRow) => {
+      setCachedSelection(row);
+      onSelect({
+        itemId: row.item.id,
+        ...(row.layerKey ? { layerKey: row.layerKey } : {}),
+      });
       setOpen(false);
       setQuery('');
     },
     [onSelect],
   );
 
-  // Items currently visible in the popover. We let the server do the
-  // search but ALSO drop the selected item from the list when there's
+  // Rows currently visible in the popover. We let the server do the
+  // search but ALSO drop the selected row from the list when there's
   // no query, so the popover doesn't waste a slot showing what's
-  // already chosen. Selected item still appears when the user is
+  // already chosen. The selected row still appears when the user is
   // searching, so a typo recovery doesn't hide it.
-  const visibleItems = useMemo(() => {
-    if (!items) return null;
-    if (!selectedId || query.trim().length > 0) return items;
-    return items.filter((i) => i.id !== selectedId);
-  }, [items, selectedId, query]);
+  const visibleRows = useMemo(() => {
+    if (!rows) return null;
+    if (!selectedRefKey || query.trim().length > 0) return rows;
+    return rows.filter((r) => r.key !== selectedRefKey);
+  }, [rows, selectedRefKey, query]);
 
-  const triggerLabel =
-    cachedSelection && cachedSelection.id === selectedId
-      ? cachedSelection.title
-      : selectedId
-        ? '(Resolving selected layer…)'
-        : 'Pick a source data layer…';
+  // Trigger text: prefer "Item title - Sublayer label" when a v3
+  // sublayer is selected, fall back to the bare item title for v2.
+  const triggerLabel = (() => {
+    if (cachedSelection && cachedSelection.key === selectedRefKey) {
+      const base = cachedSelection.item.title;
+      return cachedSelection.sublayerLabel
+        ? `${base} - ${cachedSelection.sublayerLabel}`
+        : base;
+    }
+    if (selectedRefKey) return '(Resolving selected layer…)';
+    return 'Pick a source data layer…';
+  })();
 
   const triggerSubtitle =
-    cachedSelection && cachedSelection.id === selectedId
-      ? cachedSelection.description
+    cachedSelection && cachedSelection.key === selectedRefKey
+      ? cachedSelection.item.description
       : '';
+
+  const triggerHasSelection = Boolean(selectedRefKey);
 
   return (
     <div ref={containerRef} className="relative">
@@ -403,7 +518,7 @@ function SourceLayerPicker({
         <span className="min-w-0 flex-1">
           <span
             className={`block truncate text-sm font-medium ${
-              selectedId ? 'text-ink-0' : 'text-muted'
+              triggerHasSelection ? 'text-ink-0' : 'text-muted'
             }`}
           >
             {triggerLabel}
@@ -464,11 +579,11 @@ function SourceLayerPicker({
               <p className="px-3 py-2 text-xs text-danger">
                 Could not load data layers: {err}
               </p>
-            ) : loading && !visibleItems ? (
+            ) : loading && !visibleRows ? (
               <p className="px-3 py-2 text-xs text-muted">
                 Loading data layers…
               </p>
-            ) : !visibleItems || visibleItems.length === 0 ? (
+            ) : !visibleRows || visibleRows.length === 0 ? (
               <div className="px-3 py-2 text-xs text-muted">
                 <p>
                   {query
@@ -477,24 +592,31 @@ function SourceLayerPicker({
                 </p>
                 {hiddenIncompatibleCount > 0 ? (
                   <p className="mt-1 text-[11px]">
-                    {hiddenIncompatibleCount} v1 inline-GeoJSON
-                    layer{hiddenIncompatibleCount === 1 ? ' is' : 's are'}{' '}
-                    hidden because the buffer tool needs a v2 PostGIS-
-                    backed source.
+                    {hiddenIncompatibleCount} layer
+                    {hiddenIncompatibleCount === 1 ? ' is' : 's are'}{' '}
+                    hidden because the buffer tool needs a PostGIS-backed
+                    source with at least one spatial sublayer.
                   </p>
                 ) : null}
               </div>
             ) : (
               <ul className="space-y-0.5">
-                {visibleItems.map((s) => {
-                  const selected = selectedId === s.id;
+                {visibleRows.map((row) => {
+                  const selected = selectedRefKey === row.key;
+                  // Headline shows the item title for v2 (one row per
+                  // item) or "title - sublayer" for v3 sublayers, so a
+                  // multi-layer item with several spatial sublayers
+                  // reads cleanly down the list.
+                  const headline = row.sublayerLabel
+                    ? `${row.item.title} - ${row.sublayerLabel}`
+                    : row.item.title;
                   return (
-                    <li key={s.id}>
+                    <li key={row.key}>
                       <button
                         type="button"
                         role="option"
                         aria-selected={selected}
-                        onClick={() => handleSelect(s)}
+                        onClick={() => handleSelect(row)}
                         className={`flex w-full items-start gap-3 rounded-md px-3 py-2 text-left text-sm hover:bg-surface-2 ${
                           selected ? 'bg-accent/10 ring-1 ring-accent' : ''
                         }`}
@@ -502,14 +624,19 @@ function SourceLayerPicker({
                         <Layers className="mt-0.5 h-4 w-4 shrink-0 text-sky-600" />
                         <span className="min-w-0 flex-1">
                           <span className="block truncate font-medium text-ink-0">
-                            {s.title}
+                            {headline}
                           </span>
-                          {s.description ? (
+                          {row.item.description ? (
                             <span className="mt-0.5 block truncate text-xs text-muted">
-                              {s.description}
+                              {row.item.description}
                             </span>
                           ) : null}
                         </span>
+                        {row.geometryType ? (
+                          <span className="ml-2 mt-0.5 shrink-0 rounded bg-sky-100 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-sky-800">
+                            {row.geometryType}
+                          </span>
+                        ) : null}
                       </button>
                     </li>
                   );

--- a/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
+++ b/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { FlaskConical, Layers, Search } from 'lucide-react';
+import {
+  DEFAULT_DERIVED_LAYER_FEATURE_LIMIT,
+  MAX_BUFFER_DISTANCE_METERS,
+  type DerivedLayerData,
+  type Item,
+  type ToolStep,
+} from '@gratis-gis/shared-types';
+
+/**
+ * Inline builder for derived layers.
+ *
+ * The recipe (source data layer + ordered tool pipeline) is structural
+ * to a derived layer's identity, so the wizard collects it up front
+ * rather than starting with an empty scaffold the user fills in on
+ * the detail page (the pattern data_layer / pick_list / geo_boundary
+ * use). v1 ships one tool, buffer; this component renders a single
+ * step UI and emits a one-element pipeline. When more tools land,
+ * step ordering moves into the same component without restructuring
+ * the wizard.
+ *
+ * The component emits a complete DerivedLayerData; the server
+ * recomputes `outputSchema` and `bbox` regardless, so the values we
+ * send for those are placeholders and can be empty arrays.
+ */
+export function DerivedLayerBuilder({
+  value,
+  onChange,
+}: {
+  value: DerivedLayerData;
+  onChange: (next: DerivedLayerData) => void;
+}) {
+  // Source layer picker state. We resolve the items list once on
+  // mount and let the user filter inline; for orgs with hundreds of
+  // data_layer items this should still feel snappy because the
+  // existing list endpoint streams them in bulk.
+  const [sources, setSources] = useState<Item[] | null>(null);
+  const [sourceFilter, setSourceFilter] = useState('');
+  const [sourceErr, setSourceErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/portal/items?type=data_layer')
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        const body = (await r.json()) as { items?: Item[] } | Item[];
+        const list = Array.isArray(body) ? body : (body.items ?? []);
+        if (!cancelled) setSources(list);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setSourceErr(
+            err instanceof Error ? err.message : 'Could not load data layers',
+          );
+          setSources([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const visibleSources = useMemo(() => {
+    if (!sources) return [];
+    const q = sourceFilter.trim().toLowerCase();
+    if (q.length === 0) return sources;
+    return sources.filter(
+      (s) =>
+        s.title.toLowerCase().includes(q) ||
+        s.description.toLowerCase().includes(q),
+    );
+  }, [sources, sourceFilter]);
+
+  // Buffer step is the only tool in v1, so we surface it directly
+  // rather than via a "pick a tool" intermediate step. When more
+  // tools land, this becomes a tool selector and per-tool form
+  // fragments.
+  const bufferStep = value.pipeline.find(
+    (s): s is Extract<ToolStep, { tool: 'buffer' }> => s.tool === 'buffer',
+  );
+  const bufferDistance = bufferStep?.params.distance ?? 100;
+
+  const setSourceItem = useCallback(
+    (id: string) => {
+      onChange({
+        ...value,
+        source: { kind: 'data_layer', itemId: id },
+      });
+    },
+    [value, onChange],
+  );
+
+  const setBufferDistance = useCallback(
+    (distance: number) => {
+      const safe =
+        Number.isFinite(distance) && distance > 0
+          ? Math.min(distance, MAX_BUFFER_DISTANCE_METERS)
+          : 0;
+      const next: ToolStep = {
+        tool: 'buffer',
+        params: { distance: safe, unit: 'meters' },
+      };
+      onChange({
+        ...value,
+        pipeline: [next],
+      });
+    },
+    [value, onChange],
+  );
+
+  const setFeatureLimit = useCallback(
+    (limit: number) => {
+      const safe =
+        Number.isFinite(limit) && limit > 0
+          ? Math.floor(limit)
+          : DEFAULT_DERIVED_LAYER_FEATURE_LIMIT;
+      onChange({ ...value, featureLimit: safe });
+    },
+    [value, onChange],
+  );
+
+  return (
+    <div className="space-y-6 rounded-lg border border-border bg-surface-1 p-4">
+      <header className="flex items-start gap-3">
+        <span className="mt-0.5 inline-flex h-8 w-8 items-center justify-center rounded-md bg-blue-700/90 text-white">
+          <FlaskConical className="h-4 w-4" />
+        </span>
+        <div>
+          <h3 className="text-sm font-medium text-ink-0">
+            Recipe
+          </h3>
+          <p className="mt-1 text-xs text-muted">
+            Pick a source data layer, then choose how to transform it.
+            Results are computed live: when the source's features
+            change, this layer reflects the change on the next read.
+          </p>
+        </div>
+      </header>
+
+      <section className="space-y-2">
+        <h4 className="text-xs font-medium uppercase tracking-wide text-muted">
+          Source layer
+        </h4>
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted" />
+          <input
+            type="search"
+            value={sourceFilter}
+            onChange={(e) => setSourceFilter(e.target.value)}
+            placeholder="Filter by title or description"
+            className="h-10 w-full rounded-md border border-border bg-surface-0 pl-9 pr-3 text-sm text-ink-0 placeholder:text-muted focus:border-accent focus:outline-none"
+          />
+        </div>
+        {sourceErr ? (
+          <p className="text-xs text-danger">Could not load data layers: {sourceErr}</p>
+        ) : null}
+        {sources === null ? (
+          <p className="text-xs text-muted">Loading data layers…</p>
+        ) : visibleSources.length === 0 ? (
+          <p className="text-xs text-muted">
+            No data layers match the filter. Create one first under
+            Data {'>'} Data layer, then come back here.
+          </p>
+        ) : (
+          <ul
+            role="radiogroup"
+            aria-label="Source data layer"
+            className="max-h-64 space-y-1 overflow-y-auto rounded-md border border-border bg-surface-0 p-1"
+          >
+            {visibleSources.map((s) => {
+              const selected = value.source.itemId === s.id;
+              return (
+                <li key={s.id}>
+                  <button
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    onClick={() => setSourceItem(s.id)}
+                    className={`flex w-full items-start gap-3 rounded-md px-3 py-2 text-left text-sm hover:bg-surface-2 ${
+                      selected
+                        ? 'bg-accent/10 ring-1 ring-accent'
+                        : ''
+                    }`}
+                  >
+                    <Layers className="mt-0.5 h-4 w-4 shrink-0 text-sky-600" />
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate font-medium text-ink-0">
+                        {s.title}
+                      </span>
+                      {s.description ? (
+                        <span className="mt-0.5 block truncate text-xs text-muted">
+                          {s.description}
+                        </span>
+                      ) : null}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <h4 className="text-xs font-medium uppercase tracking-wide text-muted">
+          Tool: Buffer
+        </h4>
+        <p className="text-xs text-muted">
+          Expand each feature outward by a fixed distance. The result
+          is a polygon layer that lines up with the source's halo on
+          every map read.
+        </p>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-ink-1">Distance</span>
+          <span className="flex items-center gap-2">
+            <input
+              type="number"
+              min={1}
+              max={MAX_BUFFER_DISTANCE_METERS}
+              step={1}
+              value={bufferDistance}
+              onChange={(e) => setBufferDistance(Number(e.target.value))}
+              className="h-10 w-32 rounded-md border border-border bg-surface-0 px-3 text-sm text-ink-0 focus:border-accent focus:outline-none"
+            />
+            <span className="text-sm text-muted">meters</span>
+          </span>
+        </label>
+        <p className="text-[11px] text-muted">
+          Up to {MAX_BUFFER_DISTANCE_METERS.toLocaleString()} m. Other
+          units arrive when the reproject tool ships.
+        </p>
+      </section>
+
+      <section className="space-y-2">
+        <h4 className="text-xs font-medium uppercase tracking-wide text-muted">
+          Feature limit (advanced)
+        </h4>
+        <p className="text-xs text-muted">
+          Hard ceiling on features returned by a single read. The map
+          UI passes its current view extent so this rarely bites
+          on map workflows; it's the safety net for opening the
+          layer with no map context.
+        </p>
+        <label className="flex flex-col gap-1 text-sm">
+          <span className="text-ink-1">Maximum features per read</span>
+          <input
+            type="number"
+            min={1}
+            max={50000}
+            step={1}
+            value={value.featureLimit}
+            onChange={(e) => setFeatureLimit(Number(e.target.value))}
+            className="h-10 w-32 rounded-md border border-border bg-surface-0 px-3 text-sm text-ink-0 focus:border-accent focus:outline-none"
+          />
+        </label>
+      </section>
+    </div>
+  );
+}

--- a/apps/portal-web/src/app/items/new/wizard.tsx
+++ b/apps/portal-web/src/app/items/new/wizard.tsx
@@ -28,6 +28,7 @@ import {
 import type {
   ArcgisServiceData,
   DataLayerDataV3,
+  DerivedLayerData,
   ISODateString,
   Item,
   ItemAccess,
@@ -37,6 +38,7 @@ import {
   DEFAULT_ARCGIS_SERVICE,
   DEFAULT_BASEMAP,
   DEFAULT_DATA_LAYER_V3,
+  DEFAULT_DERIVED_LAYER,
   DEFAULT_GEO_BOUNDARY,
   DEFAULT_PICK_LIST,
   DEFAULT_MAP,
@@ -53,6 +55,7 @@ import {
   type ArcgisServiceDescription,
 } from '@/lib/arcgis-rest';
 import { DataLayerBuilder } from './data-layer-builder';
+import { DerivedLayerBuilder } from './derived-layer-builder';
 import { MetadataXmlImporter } from './metadata-xml-importer';
 
 /**
@@ -189,6 +192,12 @@ const TYPE_GROUPS: TypeGroup[] = [
     label: 'Analysis',
     options: [
       {
+        value: 'derived_layer',
+        label: 'Derived layer',
+        desc: 'A layer computed live from another, with tools like buffer.',
+        Icon: FlaskConical,
+      },
+      {
         value: 'notebook',
         label: 'Notebook',
         desc: 'A Jupyter notebook hosted in the portal.',
@@ -321,6 +330,12 @@ export function NewItemWizard() {
   // the POST body can be sent as-is.
   const [featureServiceData, setDataLayerData] =
     useState<DataLayerDataV3>(DEFAULT_DATA_LAYER_V3);
+
+  // Derived-layer builder state. The recipe (source + pipeline) is
+  // structural so the wizard collects it up front rather than starting
+  // with an empty scaffold the user fills in on the detail page.
+  const [derivedLayerData, setDerivedLayerData] =
+    useState<DerivedLayerData>(DEFAULT_DERIVED_LAYER);
 
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -643,6 +658,28 @@ export function NewItemWizard() {
       // an empty-state prompt until the first target is added. See
       // docs/editing-and-collection.md.
       data = DEFAULT_EDITOR;
+    } else if (type === 'derived_layer') {
+      // The wizard's DerivedLayerBuilder gathers the source layer +
+      // pipeline up front (the recipe is structural, not optional).
+      // Bail out with a friendly error if the user clicked Create
+      // without picking a source / configuring a tool.
+      if (!derivedLayerData) {
+        setError('Pick a source data layer and configure at least one tool.');
+        return;
+      }
+      const src = derivedLayerData.source;
+      if (!src || !src.itemId) {
+        setError('Pick a source data layer for this derived layer.');
+        return;
+      }
+      if (
+        !Array.isArray(derivedLayerData.pipeline) ||
+        derivedLayerData.pipeline.length === 0
+      ) {
+        setError('Add at least one tool step to the pipeline.');
+        return;
+      }
+      data = derivedLayerData;
     } else {
       data = {};
     }
@@ -1067,6 +1104,13 @@ export function NewItemWizard() {
         <DataLayerBuilder
           value={featureServiceData}
           onChange={setDataLayerData}
+        />
+      ) : null}
+
+      {type === 'derived_layer' ? (
+        <DerivedLayerBuilder
+          value={derivedLayerData}
+          onChange={setDerivedLayerData}
         />
       ) : null}
 

--- a/apps/portal-web/src/lib/item-type-icon.tsx
+++ b/apps/portal-web/src/lib/item-type-icon.tsx
@@ -3,6 +3,7 @@ import {
   ClipboardList,
   FileText,
   File as FileIcon,
+  FlaskConical,
   Folder as FolderIcon,
   Globe,
   Inbox,
@@ -34,6 +35,7 @@ import type { ItemType } from '@gratis-gis/shared-types';
 const ITEM_TYPE_ICONS: Record<ItemType, LucideIcon> = {
   map: MapIcon,
   data_layer: Layers,
+  derived_layer: FlaskConical,
   arcgis_service: Plug,
   form: ClipboardList,
   form_submission_collection: Inbox,
@@ -65,6 +67,7 @@ const ITEM_TYPE_ICONS: Record<ItemType, LucideIcon> = {
 const ITEM_TYPE_LABELS: Record<ItemType, string> = {
   map: 'Map',
   data_layer: 'Data layer',
+  derived_layer: 'Derived layer',
   arcgis_service: 'ArcGIS service',
   form: 'Form',
   form_submission_collection: 'Form submissions',
@@ -96,6 +99,7 @@ export function getItemTypeLabel(t: ItemType): string {
 const ITEM_TYPE_ACCENT: Record<ItemType, string> = {
   map: 'text-emerald-600',
   data_layer: 'text-sky-600',
+  derived_layer: 'text-blue-700',
   arcgis_service: 'text-cyan-600',
   form: 'text-violet-600',
   form_submission_collection: 'text-violet-500',
@@ -122,6 +126,7 @@ const ITEM_TYPE_ACCENT: Record<ItemType, string> = {
 const ITEM_TYPE_TILE: Record<ItemType, string> = {
   map: 'bg-emerald-500/90 text-white',
   data_layer: 'bg-sky-500/90 text-white',
+  derived_layer: 'bg-blue-700/90 text-white',
   arcgis_service: 'bg-cyan-600/90 text-white',
   form: 'bg-violet-500/90 text-white',
   form_submission_collection: 'bg-violet-400/90 text-white',

--- a/docs/derived-layers.md
+++ b/docs/derived-layers.md
@@ -1,0 +1,439 @@
+# Derived layers
+
+A `derived_layer` is an Item whose contents are computed at read time from
+another layer plus an ordered pipeline of tool steps. The derived layer
+stores the recipe, not the result. When the source layer's features change,
+the derived layer reflects those changes on the next read.
+
+This document covers v1 scope. Out-of-scope ideas are flagged in
+[Out of scope (v1)](#out-of-scope-v1).
+
+## Status
+
+Phase: design (this doc). Implementation has not started.
+
+v1 ships:
+
+- One new item type: `derived_layer`.
+- One tool: `buffer`.
+- Source: a single `data_layer` item. No chaining of derived layers.
+- Read path: reuses `GET /api/items/:id/geojson?bbox=&at=&clip=`.
+- Storage: pure on-the-fly compute. No materialization, no caching beyond
+  what the existing read path already does.
+
+This makes the derived-layer item a precursor to the Phase 7 tool builder
+(see [ROADMAP.md](../ROADMAP.md)). The tool registry shape introduced here
+is designed so a tool-builder node can later wrap the same generators
+without forking code.
+
+## Why not store SQL?
+
+A derived layer's storage is **structured parameters**, never a raw SQL
+string. Three reasons:
+
+1. **Security.** A row that contains executable SQL is a SQL injection /
+   data exfiltration vector for anyone who can write to the row.
+2. **CONTRIBUTING rule 7** (guided before raw input). A SQL textarea is
+   the textbook "advanced fallback" surface, not the primary entry.
+3. **Editability.** A typed pipeline can be rendered as a wizard, diffed
+   in PRs, validated, and migrated forward as tool definitions evolve.
+   A SQL string can't.
+
+The API holds a small library of tool generators. Each generator takes
+`(source, params)` and emits a parameterized SQL fragment. Users never
+see SQL.
+
+## Data shape
+
+A `derived_layer` item reuses the existing polymorphic `Item` row. No
+new tables. The `data` JSON blob holds the recipe:
+
+```ts
+// packages/shared-types/src/derived-layer.ts
+export interface DerivedLayerData {
+  /** Schema version. Bump when the shape changes incompatibly. */
+  version: 1;
+
+  /** The single input layer. v1 = data_layer only. */
+  source: {
+    kind: 'data_layer';
+    itemId: string;
+  };
+
+  /**
+   * Ordered list of tool steps. The output of step N is the input of
+   * step N+1. v1 ships only `buffer`; the union grows as tools are
+   * added. Empty pipeline is invalid (use the source layer directly).
+   */
+  pipeline: ToolStep[];
+
+  /**
+   * Cap on features returned by the read path. Hard ceiling, applied
+   * after the pipeline runs. Default 1000. The map UI passes a bbox
+   * on every read (see "Extent and feature cap" below), so on real
+   * map workflows this cap rarely bites; it's the safety net for
+   * "open the layer with no map context" cases.
+   */
+  featureLimit: number; // default 1000
+
+  /**
+   * Cached output schema (column list with types). Computed at save
+   * time from the source schema + pipeline. Lets dashboards and apps
+   * bind to the layer without running the query.
+   */
+  outputSchema: FeatureField[];
+}
+
+export type ToolStep =
+  | BufferStep
+  // future: DissolveStep | IntersectStep | ...
+  ;
+
+export interface BufferStep {
+  tool: 'buffer';
+  params: {
+    /** Buffer distance in `unit`. Must be positive. */
+    distance: number;
+    /** v1: 'meters' only. Other units arrive when reprojection lands. */
+    unit: 'meters';
+  };
+}
+```
+
+`Item.bbox` is recomputed on save as the source bbox expanded by the
+pipeline's outward reach (for buffer: source bbox + buffer distance,
+converted to degrees at the source's latitude).
+
+## Tool registry and generator interface
+
+Each tool is a small module that knows its parameter shape, how to
+validate it, how its output schema relates to the input schema, and
+how to emit a SQL CTE that produces its output rows.
+
+```ts
+// apps/portal-api/src/derived-layers/tools/types.ts
+export interface ToolGenerator<TParams> {
+  /** Stable identifier; matches the discriminator in `ToolStep`. */
+  kind: string;
+
+  /** Runtime validation (zod). */
+  paramsSchema: ZodType<TParams>;
+
+  /**
+   * Compute the output schema from the input schema + params. Pure.
+   * Called at save time to populate `outputSchema`.
+   */
+  outputSchema(input: FeatureField[], params: TParams): FeatureField[];
+
+  /**
+   * Compute how far this tool can grow geometries outward, in meters.
+   * Used to expand the read bbox so features near the edge keep their
+   * halo. Most tools return 0; buffer returns its distance. A pipeline's
+   * total reach is the sum of its steps.
+   */
+  outwardReachMeters(params: TParams): number;
+
+  /**
+   * Emit a SQL fragment that produces the tool's output as a CTE-style
+   * subquery over `inputAlias`. Returns `{ sql, params }` where `params`
+   * are appended to the outer query's parameter list. The fragment must:
+   *   - select `geom` (PostGIS geometry, SRID 4326), `global_id`, and
+   *     all attribute columns from the schema it declared in
+   *     `outputSchema`.
+   *   - reference `inputAlias` for input rows.
+   *   - never inline user input as text; everything goes through
+   *     parameter placeholders.
+   */
+  toSql(inputAlias: string, params: TParams, paramOffset: number): {
+    sql: string;
+    params: unknown[];
+  };
+
+  /**
+   * Item references the tool's params hold (other layers, pick lists,
+   * etc.). Returned to the dependency extractor so the derived layer's
+   * forward edges are complete. v1 buffer returns empty arrays.
+   */
+  extractDependencies(params: TParams): {
+    itemIds: string[];
+    urls: string[];
+  };
+}
+```
+
+The registry is a `Map<string, ToolGenerator<unknown>>`. Adding a new
+tool is a new file plus a registry entry, no schema migration.
+
+## Read path
+
+`GET /api/items/:id/geojson` already routes by item type. We extend it:
+when `item.type === 'derived_layer'`, the service builds a chained CTE
+over the source's PostGIS table.
+
+Pseudocode for the v1 buffer case:
+
+```sql
+WITH source AS (
+  SELECT global_id, geom, /* ...attrs... */
+  FROM fs_<source_uuid>
+  WHERE valid_to IS NULL                              -- temporal
+    AND ST_Intersects(geom, ST_MakeEnvelope($1,$2,$3,$4, 4326))  -- expanded bbox
+  /* boundary clip applied here if ?clip= present */
+),
+step_1 AS (                                           -- buffer
+  SELECT global_id,
+         ST_Buffer(geom::geography, $5)::geometry AS geom,
+         /* ...attrs... */
+  FROM source
+)
+SELECT * FROM step_1
+LIMIT $6;                                             -- featureLimit
+```
+
+Notes:
+
+- Source filtering happens **before** the pipeline, on an **expanded**
+  bbox. The expansion is `pipeline.outwardReachMeters()` converted to
+  degrees at the bbox latitude. This preserves halo correctness at
+  tile edges.
+- The boundary clip (`?clip=`) is applied to the source, mirroring the
+  data-layer behavior, with the same expansion.
+- `featureLimit` is applied at the end. If the user passed `?bbox=`,
+  the result is "features inside the (post-pipeline) bbox view, capped
+  at featureLimit". If they didn't, it's the global cap.
+- Buffer uses `geography` so the distance is in meters regardless of
+  longitude. Distances stay correct globally.
+
+## Extent and feature cap
+
+Two cooperating defaults:
+
+- **Bbox + halo.** When the map viewer requests features for the
+  current frame, it sends `?bbox=`. The API expands that bbox by the
+  pipeline's outward reach before querying the source, then clips back
+  to the user's bbox after the pipeline runs (or relies on MapLibre to
+  draw outside the view, depending on tile boundary).
+- **Feature cap.** A hard ceiling. Default 1000. Settable per layer
+  in the wizard. Applied as `LIMIT N` after the pipeline.
+
+Per Chris's call: take whichever returns fewer rows. In practice the
+bbox prefilter usually wins for map workflows; the cap is the safety
+net for "no map context" reads (e.g., a dashboard panel that opens
+the layer without a view extent).
+
+## Sharing
+
+A derived layer has its own `ItemShare` rows like any other item. The
+read check is the **intersection** of the derived layer's ACL and the
+source layer's ACL: a user can read the derived layer iff they can
+read both.
+
+Implemented as a delegated check inside `sharing.service.ts` (the
+"bedrock", per CONTRIBUTING). When `getGeoJson` resolves a derived
+layer, it calls the existing sharing check on the source as the
+calling user before running the SQL. If the source check fails, the
+read fails closed regardless of who shared the derived layer.
+
+This propagates revocation for free: when the source is unshared, the
+derived layer stops returning rows on the next read with no background
+job.
+
+## v1 buffer tool
+
+Specification:
+
+- **kind**: `'buffer'`
+- **params**: `{ distance: number, unit: 'meters' }`. `distance > 0`.
+- **outputSchema**: identical to input schema. Buffer keeps every
+  attribute; only geometry changes.
+- **outwardReachMeters**: `params.distance`.
+- **toSql**: wraps `ST_Buffer(geom::geography, $distance)::geometry`.
+  The cast to `geography` makes the distance unambiguous in meters
+  worldwide.
+
+Validation rules:
+
+- `distance` must be finite and `> 0`. UI bounds it to a sensible max
+  (e.g., 100 km) to prevent accidental world-spanning buffers.
+- Source layer must have a non-null geometry column. Empty layers
+  produce empty results.
+
+UI surface (per rule 7, guided primary):
+
+- Wizard step 1: pick the source data layer (same picker the map
+  builder uses).
+- Wizard step 2: enter buffer distance with a unit dropdown. Live
+  preview on the map of one feature buffered at the chosen distance.
+- Wizard step 3: name + tags + sharing. Same as any item-create flow.
+
+No raw SQL surface, no JSON paste field. If a power-user surface ships
+later, it's a separate item type.
+
+## Output schema and bbox
+
+Computed once at save time and stored on `data.outputSchema`. For
+buffer it's a copy of the source's field list; for tools that change
+attributes (dissolve, count-in-polygon, etc.) the generator returns
+the new shape. Dashboards and apps bind to `outputSchema` so they
+never need to "open the layer to see what columns it has".
+
+`Item.bbox` is the source's bbox padded outward by
+`pipeline.outwardReachMeters()`. Recomputed when the source bbox
+changes (the existing data-layer save path already touches this; we
+hook a re-derive there).
+
+## Dependency graph
+
+Every item in GratisGIS publishes its forward edges (what it depends on)
+and exposes its reverse edges (what depends on it) through a single
+machinery: `extractDependencies()` in
+`apps/portal-api/src/items/dependency-extractor.ts` plus
+`GET /items/:id/dependencies` and
+`GET /items/:id/dependents?transitive=true|false`. A derived layer
+participates in that paradigm like any other item: its source and any
+item-typed tool parameters are first-class edges, never opaque blobs.
+
+### Forward edges (what a derived layer depends on)
+
+The extractor gains a `derived_layer` branch that walks `data` and
+emits:
+
+- `data.source.itemId` for every derived layer. Always present, always
+  a hard dependency: deleting the source breaks the derived layer's
+  ability to return rows.
+- For each step in `data.pipeline`, any item references the tool
+  declares. v1 buffer has none. To keep the extractor stable as tools
+  arrive, each `ToolGenerator` declares a small helper:
+
+```ts
+// On the ToolGenerator interface
+extractDependencies(params: TParams): { itemIds: string[]; urls: string[] };
+```
+
+The extractor calls it for each step and merges the results. A future
+`intersect` tool whose params include a second-layer item ID returns
+that ID here; a future tool that pulls choices from a `pick_list`
+returns the pick list ID here. New tools become discoverable to the
+dependency graph without any changes outside the tool's own file.
+
+### Reverse edges (what depends on a derived layer)
+
+No code change needed. The reverse index is built by the items
+service from each item's forward edges, so as soon as the extractor
+emits a `data_layer -> derived_layer` edge, the data layer's "Used
+by" panel and `GET /items/:dataLayerId/dependents` automatically list
+the derived layers built on top of it.
+
+A derived layer is itself a valid dependency target: a map that adds
+the derived layer as a layer source records the same `data-layer`
+shaped reference (since to the map renderer it's still a layer of
+features). The map's "Depends on" panel lists the derived layer; the
+derived layer's "Used by" panel lists the map. Transitive lookups
+walk the chain (`data_layer -> derived_layer -> map -> dashboard`)
+through the existing `?transitive=true` path.
+
+### Deletion and rename behavior
+
+The existing deletion semantics apply unchanged:
+
+- Soft-delete a source `data_layer`: any derived layer that depends
+  on it returns empty results until either the source is restored or
+  the derived layer is repointed / deleted. The "Used by" panel on
+  the source shows the affected derived layers before confirming the
+  delete, matching the current pattern for maps that reference a
+  layer.
+- Hard-delete (admin purge) a source: dependent derived layers are
+  left with a dangling `source.itemId`. The read path treats a
+  missing source as an empty FeatureCollection (same as a missing
+  `geo_boundary` clip today). The dependents panel surfaces the
+  dangle so an admin can clean it up.
+- Rename / re-share a source: no change to the derived layer's
+  recipe. The reference is by UUID, not title, and sharing is
+  re-evaluated on every read (see [Sharing](#sharing)).
+
+### What this gives users
+
+- The "Depends on" panel on a derived layer lists its source plus any
+  pick lists / second-input layers a future tool introduces.
+- The "Used by" panel on a data layer lists every derived layer over
+  it, alongside the maps and forms that use it directly.
+- An impact report before deletion. Admins can see "this data layer
+  is used by 3 maps, 2 dashboards, and 4 derived layers (which are
+  themselves used by 1 dashboard)" and decide accordingly.
+- A search query like "what depends on this data layer transitively"
+  works without any new endpoints.
+
+## CRS and units
+
+v1 stores all geometries in EPSG:4326 (matching the existing
+`data_layer` tables). Buffer distance is in meters via the
+`geography` cast. Other CRSes and other units land when we add a
+reprojection step to the pipeline (probably as its own tool,
+`reproject`).
+
+## Out of scope (v1)
+
+- Chaining: a derived layer's source must be a data layer. Stacking
+  derived layers is deferred until there's clear demand. When it
+  comes, the sharing rule already generalizes (intersection over the
+  full ancestor chain), and cycle detection plus a depth cap are
+  needed. Track in a follow-up issue.
+- Materialization: no matview, no on-disk cache. A pure view is
+  correct and simple. When perf becomes a problem, add a
+  `materialization: 'view' | 'cache' | 'matview'` knob and
+  NOTIFY/LISTEN-driven refresh.
+- More tools: dissolve, intersect, centroid, convex hull,
+  point-in-polygon counts, distance to nearest. Each is one new
+  generator file plus a wizard step. Land them one at a time as
+  demand surfaces.
+- A power-user "raw SQL" item type. Has security implications that
+  warrant its own design.
+- Bidirectional editing: a derived layer is read-only. Edits to its
+  features go through the source.
+
+## Open questions
+
+- Do derived layers participate in the temporal `?at=` query? v1 says
+  yes (the source CTE honors `valid_to IS NULL` or the `at` snapshot
+  the same way data layers do). Confirm during implementation.
+- Does the field map's "edit one feature at a time" UX need to know
+  the layer is derived? Probably yes (greyed-out edit affordance with
+  a tooltip explaining edits go through the source).
+- Do we need a debounce on the wizard's live preview when distance
+  changes rapidly? Unknown; benchmark on a 50k-feature layer.
+
+## Files affected
+
+- `packages/shared-types/src/derived-layer.ts` (new)
+- `packages/shared-types/src/item-types.ts` (add `'derived_layer'`)
+- `packages/shared-types/src/index.ts` (export new types)
+- `apps/portal-api/prisma/schema.prisma` (add `derived_layer` enum value, migration)
+- `apps/portal-api/src/derived-layers/` (new module: controller, service, tool registry, buffer generator)
+- `apps/portal-api/src/items/items.service.ts` (route `derived_layer` reads to the new service)
+- `apps/portal-api/src/items/sharing.service.ts` (intersection check)
+- `apps/portal-api/src/items/dependency-extractor.ts` (new `derived_layer` branch that emits `source.itemId` plus the merged output of each tool's `extractDependencies`)
+- `apps/portal-web/src/app/items/derived-layers/` (wizard UI, detail page)
+- `docs/data-model.md` (mention the new item type)
+
+## Test strategy
+
+- Unit tests on each tool generator's `outputSchema`, `paramsSchema`,
+  and `outwardReachMeters`. Pure functions, easy to cover.
+- Snapshot tests on emitted SQL against a fixed param set, parameter
+  offsets, and input alias.
+- Integration test: create a `data_layer` with N points, create a
+  `derived_layer` over it with `buffer { distance: 100m }`, read with
+  `?bbox=`, assert geometry is a polygon and edge features get a halo.
+- Sharing test: two users, A owns source, A shares derived with B but
+  not source. B's read returns 403 (or empty, depending on the
+  sharing service's idiom for "you can see the item but not the
+  data").
+- Dependency tests:
+  - `extractDependencies` on a `derived_layer` returns
+    `source.itemId` plus the merged tool refs.
+  - `GET /items/:dataLayerId/dependents` on a data layer that has a
+    derived layer over it lists that derived layer; with
+    `?transitive=true` it also lists maps that use the derived layer.
+  - Soft-deleting the source data layer leaves the derived layer's
+    forward edge intact (it still resolves through the trash) so the
+    "Used by" panel can show the link before the cascade.

--- a/packages/shared-types/src/derived-layer.ts
+++ b/packages/shared-types/src/derived-layer.ts
@@ -1,0 +1,159 @@
+/**
+ * Canonical shape stored in an Item's dataJson when `type =
+ * 'derived_layer'`.
+ *
+ * A derived layer holds a recipe, never a snapshot: a reference to a
+ * source data_layer plus an ordered pipeline of tool steps. The read
+ * path runs the pipeline against the source's PostGIS table on every
+ * request, so the derived layer stays in sync with its source for
+ * free.
+ *
+ * See docs/derived-layers.md for the full design (data shape, tool
+ * registry, read path, sharing, dependency tracking).
+ *
+ * Versioned for forward compatibility: bump `version` and write a
+ * migrator when a breaking change is needed. The runtime should
+ * tolerate missing fields and fall back to defaults so older derived
+ * layer items keep rendering after additive shape changes.
+ */
+
+import type { FeatureField } from './data-layer';
+
+/**
+ * v1 always points at a single data_layer item. Stored as a tagged
+ * shape so future kinds (a second derived_layer, a temporary
+ * in-pipeline source) can slot in without rewriting reads.
+ */
+export interface DerivedLayerSource {
+  kind: 'data_layer';
+  /** UUID of the source `data_layer` Item. */
+  itemId: string;
+  /**
+   * Optional sublayer key when the source is a v3 multi-layer data
+   * layer. Null / undefined means "the layer's only sublayer" or
+   * "treat the data_layer as a single feature collection".
+   */
+  layerKey?: string;
+}
+
+/**
+ * Buffer tool step. Expands every input geometry outward by `distance`
+ * meters using PostGIS `ST_Buffer(geom::geography, distance)`. The
+ * `geography` cast keeps distance correct globally regardless of
+ * longitude.
+ */
+export interface BufferStep {
+  tool: 'buffer';
+  params: {
+    /** Buffer distance in `unit`. Must be a finite number > 0. */
+    distance: number;
+    /**
+     * v1 ships meters only. Other units arrive when reprojection
+     * lands as a separate tool; the union widens then.
+     */
+    unit: 'meters';
+  };
+}
+
+/**
+ * Discriminated union of every available tool step. Adding a new tool
+ * means adding a member here, a generator file in
+ * apps/portal-api/src/derived-layers/tools/, and a wizard step in
+ * apps/portal-web. No schema migration required.
+ */
+export type ToolStep = BufferStep;
+
+/**
+ * The recipe persisted in `item.data` when `type = 'derived_layer'`.
+ */
+export interface DerivedLayerData {
+  /** Schema version. Bump when the shape changes incompatibly. */
+  version: 1;
+
+  /** The single input layer (v1: data_layer only). */
+  source: DerivedLayerSource;
+
+  /**
+   * Ordered list of tool steps. The output of step N is the input of
+   * step N+1. An empty pipeline is invalid: a derived layer with no
+   * steps adds no value over reading the source directly, so the
+   * server rejects it.
+   */
+  pipeline: ToolStep[];
+
+  /**
+   * Hard ceiling on features returned by the read path. Applied after
+   * the pipeline runs (i.e. on the output rows). Default 1000. The
+   * map UI passes a bbox on every read so on real map workflows this
+   * cap rarely bites; it's the safety net for "open the layer with no
+   * map context" cases.
+   */
+  featureLimit: number;
+
+  /**
+   * Cached output schema computed at save time from the source schema
+   * + pipeline. Lets dashboards and apps bind to the layer without
+   * running the query first. Recomputed on every recipe edit by the
+   * server (the client may send a hint, but the server is the
+   * authoritative writer).
+   */
+  outputSchema: FeatureField[];
+
+  /**
+   * Cached bounding box in EPSG:4326 as [west, south, east, north],
+   * derived from the source's bbox padded outward by the pipeline's
+   * total outward reach. Recomputed by the server whenever the
+   * recipe changes or the source's bbox is recomputed. Empty array
+   * when the source has no spatial footprint yet (matching the
+   * convention used by Item.bbox).
+   */
+  bbox: number[];
+}
+
+/**
+ * The default for the feature cap. Lifted into a constant so backend
+ * validation, the wizard's UI, and tests stay in sync.
+ */
+export const DEFAULT_DERIVED_LAYER_FEATURE_LIMIT = 1000;
+
+/**
+ * Per-tool maximum buffer distance the wizard exposes (meters). Soft
+ * UI bound to prevent accidental world-spanning buffers; the server
+ * enforces a matching ceiling (see backend `bufferGenerator`).
+ */
+export const MAX_BUFFER_DISTANCE_METERS = 100_000;
+
+/**
+ * Empty scaffold for a brand-new derived layer. The wizard fills
+ * `source` and `pipeline` before the first save, since a derived
+ * layer with no source / pipeline is invalid and the server rejects
+ * it. Provided here for symmetry with the other DEFAULT_* constants.
+ */
+export const DEFAULT_DERIVED_LAYER: DerivedLayerData = {
+  version: 1,
+  source: { kind: 'data_layer', itemId: '' },
+  pipeline: [],
+  featureLimit: DEFAULT_DERIVED_LAYER_FEATURE_LIMIT,
+  outputSchema: [],
+  bbox: [],
+};
+
+/**
+ * Type guard for a DerivedLayerData value coming off the wire / out of
+ * the database. Defensive: tolerates the shape going stale (older
+ * versions, fields the client doesn't recognize) by returning false
+ * rather than throwing.
+ */
+export function isDerivedLayerData(value: unknown): value is DerivedLayerData {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  if (v.version !== 1) return false;
+  const src = v.source as Record<string, unknown> | undefined;
+  if (!src || src.kind !== 'data_layer' || typeof src.itemId !== 'string') {
+    return false;
+  }
+  if (!Array.isArray(v.pipeline)) return false;
+  if (typeof v.featureLimit !== 'number') return false;
+  if (!Array.isArray(v.outputSchema)) return false;
+  return true;
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -15,6 +15,7 @@ export * from './user';
 export * from './item';
 export * from './map';
 export * from './data-layer';
+export * from './derived-layer';
 export * from './arcgis-service';
 export * from './pick-list';
 export * from './geo-boundary';

--- a/packages/shared-types/src/item-types.ts
+++ b/packages/shared-types/src/item-types.ts
@@ -11,6 +11,7 @@
 export const ITEM_TYPES = [
   'map',
   'data_layer',
+  'derived_layer',
   'arcgis_service',
   'form',
   'form_submission_collection',

--- a/packages/ui/src/item-card.tsx
+++ b/packages/ui/src/item-card.tsx
@@ -33,6 +33,7 @@ export interface ItemCardProps {
 const typeTileBg: Record<string, string> = {
   map: 'bg-emerald-500/90 text-white',
   data_layer: 'bg-sky-500/90 text-white',
+  derived_layer: 'bg-blue-700/90 text-white',
   arcgis_service: 'bg-cyan-600/90 text-white',
   form: 'bg-violet-500/90 text-white',
   form_submission_collection: 'bg-violet-400/90 text-white',
@@ -49,6 +50,7 @@ const typeTileBg: Record<string, string> = {
 const typeBadgeColor: Record<string, string> = {
   map: 'bg-emerald-100 text-emerald-800',
   data_layer: 'bg-sky-100 text-sky-800',
+  derived_layer: 'bg-blue-100 text-blue-800',
   arcgis_service: 'bg-cyan-100 text-cyan-800',
   form: 'bg-violet-100 text-violet-800',
   form_submission_collection: 'bg-violet-100 text-violet-800',
@@ -60,6 +62,40 @@ const typeBadgeColor: Record<string, string> = {
   notebook: 'bg-fuchsia-100 text-fuchsia-800',
   tool: 'bg-teal-100 text-teal-800',
   widget_package: 'bg-teal-100 text-teal-800',
+};
+
+/**
+ * Human-readable badge labels keyed by item type. The card was
+ * previously rendering the raw enum value (`derived_layer` etc.)
+ * which leaked the snake-case shape into the UI. Mirrors the
+ * portal-web `getItemTypeLabel` helper so the two surfaces agree;
+ * kept here so the ui package stays self-contained and doesn't
+ * import from portal-web. Falls back to the raw type string when
+ * an unknown value lands so a forgotten new type still renders
+ * something rather than blanking out.
+ */
+const typeLabel: Record<string, string> = {
+  map: 'Map',
+  data_layer: 'Data layer',
+  derived_layer: 'Derived layer',
+  arcgis_service: 'ArcGIS service',
+  form: 'Form',
+  form_submission_collection: 'Form submissions',
+  web_app: 'Web app',
+  report_template: 'Report template',
+  dashboard: 'Dashboard',
+  file: 'File',
+  layer_package: 'Layer package',
+  notebook: 'Notebook',
+  tool: 'Tool',
+  widget_package: 'Widget package',
+  pick_list: 'Pick list',
+  geo_boundary: 'Boundary',
+  basemap: 'Basemap',
+  wms_service: 'WMS service',
+  wfs_service: 'WFS service',
+  folder: 'Folder',
+  editor: 'Editor',
 };
 
 export function ItemCard({
@@ -123,7 +159,7 @@ export function ItemCard({
       {thumbnail}
       <div className="flex items-center justify-between gap-2">
         <span className={cn('rounded px-2 py-0.5 text-xs font-medium', badgeClass)}>
-          {item.type}
+          {typeLabel[item.type] ?? item.type}
         </span>
         {headerExtra ? <span className="shrink-0">{headerExtra}</span> : null}
       </div>


### PR DESCRIPTION
## Summary

Adds a new `derived_layer` item type: a layer whose features are computed at read time from another layer plus an ordered pipeline of tool steps. The first tool that ships is `buffer`. The recipe is structured (typed parameters, never raw SQL), so adding new tools is purely additive (new file in the registry, new wizard step) without schema migrations or security rework.

Full design in `docs/derived-layers.md` (added in this PR).

## What's in here

**Backend (`apps/portal-api`)**

- New `derived_layer` value on the `ItemType` Prisma enum, with the migration in `prisma/migrations/20260428220000_derived_layer_item_type/`.
- New module at `src/derived-layers/`:
  - `tools/types.ts` defines the `ToolGenerator` interface (validate, outputSchema, outwardReachMeters, extractDependencies, toSql).
  - `tools/buffer.ts` is the v1 generator. Wraps `ST_Buffer(geom::geography, ...)` so distance is meters globally regardless of CRS.
  - `tools/registry.ts` is the central tool map. Adding a generator is one import + one entry.
  - `derived-layers.service.ts` validates and enriches recipes (computes cached `outputSchema` + `bbox`), and composes a chained CTE over the source's PostGIS table for read.
- `items.service.ts` routes `derived_layer` reads to the new service after running the source ACL check itself, keeping the module dependency graph one-directional.
- `dependency-extractor.ts` learns the new kind so `GET /items/:id/dependencies` and `GET /items/:id/dependents?transitive=true` cover derived layers automatically. `REFERENCER_TYPES` gains `derived_layer`.
- Lite-mode item list grows two annotations on `data_layer` rows so client UIs can filter without pulling the full data blob:
  - `_storageType`: differentiates v1 inline-GeoJSON (incompatible with buffer) from v2/v3 PostGIS-backed (compatible).
  - `_layers`: slim `[{id, label, geometryType}]` for v3 multi-layer items.

**Shared types (`packages/shared-types`)**

- `derived-layer.ts` exports `DerivedLayerData`, `DerivedLayerSource`, `BufferStep`, `ToolStep`, plus `DEFAULT_DERIVED_LAYER`, `DEFAULT_DERIVED_LAYER_FEATURE_LIMIT`, `MAX_BUFFER_DISTANCE_METERS`.
- `item-types.ts` adds `'derived_layer'` to `ITEM_TYPES`.

**Frontend (`apps/portal-web` + `packages/ui`)**

- New "Analysis" tile in the New-item wizard for derived layers. Inline `DerivedLayerBuilder` collects source + pipeline up front (the recipe is structural, not optional). v1 surfaces a single buffer step.
- Source picker is a popover combobox with debounced server-side `?q=` search. v3 multi-layer items expand into one row per spatial sublayer with a `point / line / polygon` pill; attribute-only "tables" are dropped because buffer needs geometry. Incompatible v1 layers are hidden with a footnote when present.
- Read-only `DerivedLayerDetail` panel on the item detail page: source layer link, numbered pipeline summary, cached output schema, feature limit.
- `ItemCard` and `getItemTypeLabel` learn `derived_layer` plus the long-missing labels for `pick_list`, `geo_boundary`, `basemap`, `wms_service`, `wfs_service`, `folder`, `editor` (these had been falling back to slate-colored raw enum strings).
- The map's Add Layer dialog includes derived layers in its Portal tab. Selection flows through the existing `kind: 'data-layer'` source path, since `/items/:id/geojson` on a derived_layer is routed to the new service on the backend.

## Key design decisions

Spelled out in the design doc; calling out the load-bearing ones here.

**Structured params, never raw SQL.** Item rows store the analysis kind (enum) plus typed params (JSON), and the service has a small library of generators that emit parameterized SQL fragments. Three reasons: a SQL string in the row is a SQL injection / data exfil vector for anyone who can write to it; raw SQL conflicts with CONTRIBUTING rule 7 (guided before raw input); typed params can be rendered as a wizard, diffed in PRs, and validated.

**Sharing is an intersection.** A user can read a derived layer iff they can read the underlying source. Implemented by having `items.service.getGeoJson` resolve and authorize the source itself before delegating to `derived-layers.service`. Revocation propagates without a job: when the source is unshared, the derived layer stops returning rows on the next read.

**Tool-chain inside one item, not chain of items.** A derived layer is a single source plus an ordered pipeline. Cycles are impossible by construction. Sharing is one ACL, not N. v1 forbids derived-on-derived; if real demand arrives, the sharing rule already generalizes.

**Extent + feature cap cooperate.** The map UI passes a bbox on every read; the API expands that bbox by the pipeline's outward reach so features near tile edges keep their buffer halo. A hard `LIMIT 1000` (overridable per layer up to 50,000) caps the no-map-context case.

**Dependency graph integration is first-class.** `extractDependencies` emits the source as a hard forward edge, and the `ToolGenerator` interface has an `extractDependencies(params)` method so future tools that hold item refs (intersect's second-input layer, choices from a pick list) plug into the dependency graph automatically.

## Out of scope

Deliberately deferred:

- **v3 multi-layer rendering on maps directly.** A pre-existing bug: the legacy `/items/:id/geojson` queries `fs_<itemId>` but v3 stores features at `fs_<itemId>_<layerKey>`. The Editor reads through the v3 per-layer endpoint and works fine. The map's `kind: 'data-layer'` source needs an optional `layerKey` and the canvas needs to route to `/items/:id/layers/:layerKey/geojson`. Tracked for a separate `fix/v3-multilayer-map-rendering` branch. This PR works around the issue inside the derived-layer code path so the buffer pipeline can be exercised end-to-end on v3 sources today.
- **More tools.** Dissolve, intersect, centroid, convex hull, point-in-polygon counts, distance-to-nearest, simplify, reproject. Each is a new file in `tools/` plus a wizard step. Land them one at a time as demand surfaces; the registry interface is set up for that.
- **Materialization.** Pure on-the-fly compute for v1. When perf becomes a problem, add a `materialization: 'view' | 'cache' | 'matview'` knob and NOTIFY/LISTEN-driven refresh.
- **Power-user "raw SQL" item type.** Has its own security implications; warrants a separate design.
- **Bidirectional editing.** Derived layers are read-only. Edits to features go through the source.

## Migration

Reviewers pulling this branch:

```
pnpm install
cd apps/portal-api
pnpm db:migrate:deploy
pnpm db:generate
```

The migration just adds the `derived-layer` enum value to `ItemType`. No data migration, idempotent.

## Testing

36 unit tests, all passing. Coverage:

- Buffer generator: param validation (positive distance, ceiling, unit constraint), output-schema preservation, outward reach, item-ref extraction, SQL emission with parameter offsets.
- Service helpers: `readSourceVersion`, `resolveSublayer` (v2 / v3 / multi-sublayer / unknown layerKey / attribute-only), `padBboxByMeters`, `readSourceSchema`.
- `validateAndEnrich` end-to-end: empty pipeline rejection, non-object data rejection, mismatched `source.itemId`, `featureLimit` bounds, enriched output shape.
- `buildReadSql` snapshot: v2 single-table path, v3 per-sublayer path, bbox padding for buffer halos, parameter ordering.
- Dependency extractor: source emission, missing-source handling, empty-string handling.

## Commits

```
feat(derived-layers): read v3 multi-layer sources by sublayer
feat(derived-layers): filter source picker to v2 PostGIS layers
feat(ui,portal-web): humanized item-type labels and derived_layer in map add-layer dialog
fix(portal-web): seed default buffer step on builder mount
fix(portal-web): replace derived-layer source picker with combobox
feat(portal-web): derived_layer wizard step and detail panel
feat(portal-api): derived_layer item type backend
feat(shared-types): add derived_layer item type and DerivedLayerData
docs(derived-layers): design doc for the new analysis item type
```