### PR TITLE
feat(derived-layers): lazy-grow buffer-by-field caches on source writes

### DIFF
--- a/apps/portal-api/src/derived-layers/cache-refresh.service.spec.ts
+++ b/apps/portal-api/src/derived-layers/cache-refresh.service.spec.ts
@@ -1,0 +1,267 @@
+import type { Item } from '@prisma/client';
+import {
+  type BufferStep,
+  type DerivedLayerData,
+  type FeatureField,
+} from '@gratis-gis/shared-types';
+
+import {
+  DerivedLayerCacheRefreshService,
+  growCachedCaps,
+} from './cache-refresh.service.js';
+
+const NUMBER_FIELD: FeatureField = {
+  name: 'radius_m',
+  label: 'Radius (m)',
+  type: 'number',
+  nullable: true,
+};
+
+function fieldStep(
+  field: string,
+  unit: 'meters' | 'kilometers' | 'feet' | 'yards' | 'miles',
+  cachedMaxMeters: number,
+): BufferStep {
+  return {
+    tool: 'buffer',
+    params: { mode: 'field', field, unit, cachedMaxMeters },
+  };
+}
+
+function fixedStep(distance: number): BufferStep {
+  return {
+    tool: 'buffer',
+    params: { mode: 'fixed', distance, unit: 'meters' },
+  };
+}
+
+function recipe(pipeline: BufferStep[]): DerivedLayerData {
+  return {
+    version: 1,
+    source: { kind: 'data_layer', itemId: 'src-1' },
+    pipeline,
+    featureLimit: 1000,
+    outputSchema: [NUMBER_FIELD],
+    bbox: [-122.5, 37.5, -122.0, 38.0],
+  };
+}
+
+describe('growCachedCaps', () => {
+  it('returns null when no buffer step needs to grow', () => {
+    const r = recipe([fieldStep('radius_m', 'meters', 500)]);
+    expect(growCachedCaps(r, [{ radius_m: 100 }])).toBeNull();
+  });
+
+  it('returns null when the recipe has no field-mode buffer step', () => {
+    const r = recipe([fixedStep(100)]);
+    expect(growCachedCaps(r, [{ radius_m: 1_000_000 }])).toBeNull();
+  });
+
+  it('returns null when the changed key is not the buffer field', () => {
+    const r = recipe([fieldStep('radius_m', 'meters', 500)]);
+    expect(growCachedCaps(r, [{ unrelated: 9999 }])).toBeNull();
+  });
+
+  it('grows the cap when a payload value exceeds it', () => {
+    const r = recipe([fieldStep('radius_m', 'meters', 100)]);
+    const next = growCachedCaps(r, [{ radius_m: 250 }]);
+    expect(next).not.toBeNull();
+    const params = next!.pipeline[0]!.params;
+    expect(params.mode === 'field' ? params.cachedMaxMeters : null).toBe(250);
+  });
+
+  it('uses the largest value across the batch of payloads', () => {
+    const r = recipe([fieldStep('radius_m', 'meters', 100)]);
+    const next = growCachedCaps(r, [
+      { radius_m: 150 },
+      { radius_m: 999 },
+      { radius_m: 50 },
+    ]);
+    const params = next!.pipeline[0]!.params;
+    expect(params.mode === 'field' ? params.cachedMaxMeters : null).toBe(999);
+  });
+
+  it('converts the payload value through the recipe unit', () => {
+    // Recipe stores radius in feet; payload value is 1000 ft = 304.8 m.
+    const r = recipe([fieldStep('radius_m', 'feet', 100)]);
+    const next = growCachedCaps(r, [{ radius_m: 1000 }]);
+    const params = next!.pipeline[0]!.params;
+    if (params.mode !== 'field') throw new Error('expected field mode');
+    expect(params.cachedMaxMeters).toBeCloseTo(304.8, 4);
+  });
+
+  it('clamps the grown cap to MAX_BUFFER_DISTANCE_METERS', () => {
+    // 100 km recipe unit, payload 1000 km = 1_000_000 m, ceiling 100_000 m.
+    const r = recipe([fieldStep('radius_m', 'kilometers', 50_000)]);
+    const next = growCachedCaps(r, [{ radius_m: 1000 }]);
+    const params = next!.pipeline[0]!.params;
+    if (params.mode !== 'field') throw new Error('expected field mode');
+    expect(params.cachedMaxMeters).toBe(100_000);
+  });
+
+  it('ignores null, missing, and non-numeric values', () => {
+    const r = recipe([fieldStep('radius_m', 'meters', 100)]);
+    expect(
+      growCachedCaps(r, [
+        { radius_m: null },
+        { radius_m: 'unknown' },
+        {},
+      ]),
+    ).toBeNull();
+  });
+
+  it('coerces numeric strings ("250") to numbers', () => {
+    const r = recipe([fieldStep('radius_m', 'meters', 100)]);
+    const next = growCachedCaps(r, [{ radius_m: '250' }]);
+    const params = next!.pipeline[0]!.params;
+    expect(params.mode === 'field' ? params.cachedMaxMeters : null).toBe(250);
+  });
+
+  it('only grows the steps that are field-mode and matched on the changed key', () => {
+    // Two buffer steps in the pipeline: one fixed, one field. Only
+    // the field one should grow.
+    const r = recipe([fixedStep(50), fieldStep('radius_m', 'meters', 100)]);
+    const next = growCachedCaps(r, [{ radius_m: 250 }]);
+    expect(next).not.toBeNull();
+    expect(next!.pipeline[0]!.params).toEqual({
+      mode: 'fixed',
+      distance: 50,
+      unit: 'meters',
+    });
+    const second = next!.pipeline[1]!.params;
+    if (second.mode !== 'field') throw new Error('expected field mode');
+    expect(second.cachedMaxMeters).toBe(250);
+  });
+});
+
+describe('DerivedLayerCacheRefreshService.notifySourceWrite', () => {
+  function makeFakePrisma(opts: {
+    dependents: Array<Pick<Item, 'id' | 'data'>>;
+    sourceBbox?: number[];
+  }) {
+    const updates: Array<{ where: unknown; data: unknown }> = [];
+    const findMany = jest.fn(async () => opts.dependents);
+    const findUnique = jest.fn(async () => ({
+      bbox: opts.sourceBbox ?? [-122.5, 37.5, -122.0, 38.0],
+    }));
+    const update = jest.fn(async (args: unknown) => {
+      updates.push(args as { where: unknown; data: unknown });
+      return {};
+    });
+    const prisma = {
+      item: { findMany, findUnique, update },
+    };
+    // Cast through unknown to the constructor parameter type so
+    // PrismaService's massive type doesn't bleed into the test
+    // fixture. We only call `prisma.item.{findMany, findUnique,
+    // update}` from the service so the narrow stub above is
+    // sufficient at runtime.
+    return {
+      updates,
+      findMany,
+      findUnique,
+      update,
+      prisma: prisma as unknown as ConstructorParameters<
+        typeof DerivedLayerCacheRefreshService
+      >[0],
+    };
+  }
+
+  it('writes an update when a payload value exceeds the cached cap', async () => {
+    const dep = {
+      id: 'der-1',
+      data: recipe([fieldStep('radius_m', 'meters', 100)]) as unknown as Item['data'],
+    };
+    const { prisma, updates } = makeFakePrisma({ dependents: [dep] });
+    const svc = new DerivedLayerCacheRefreshService(prisma);
+    await svc.notifySourceWrite('src-1', null, [{ radius_m: 250 }]);
+    expect(updates).toHaveLength(1);
+    const u = updates[0]! as { where: { id: string }; data: { data: DerivedLayerData; bbox: number[] } };
+    expect(u.where.id).toBe('der-1');
+    const params = u.data.data.pipeline[0]!.params;
+    expect(params.mode === 'field' ? params.cachedMaxMeters : null).toBe(250);
+    // bbox repad happens too: the new total reach is 250 m, so the
+    // padded bbox is wider than the source bbox.
+    expect(u.data.bbox[0]).toBeLessThan(-122.5);
+  });
+
+  it('skips dependents whose source.itemId does not match', async () => {
+    const dep = {
+      id: 'der-1',
+      data: {
+        ...recipe([fieldStep('radius_m', 'meters', 100)]),
+        source: { kind: 'data_layer' as const, itemId: 'other-source' },
+      } as unknown as Item['data'],
+    };
+    const { prisma, updates } = makeFakePrisma({ dependents: [dep] });
+    const svc = new DerivedLayerCacheRefreshService(prisma);
+    await svc.notifySourceWrite('src-1', null, [{ radius_m: 9999 }]);
+    expect(updates).toHaveLength(0);
+  });
+
+  it('respects layerKey when matching a v3 source against a dependent', async () => {
+    const dep = {
+      id: 'der-1',
+      data: {
+        ...recipe([fieldStep('radius_m', 'meters', 100)]),
+        source: { kind: 'data_layer' as const, itemId: 'src-1', layerKey: 'sites' },
+      } as unknown as Item['data'],
+    };
+    const { prisma, updates } = makeFakePrisma({ dependents: [dep] });
+    const svc = new DerivedLayerCacheRefreshService(prisma);
+    // Write to a different sublayer: should not refresh.
+    await svc.notifySourceWrite('src-1', 'other-sublayer', [{ radius_m: 9999 }]);
+    expect(updates).toHaveLength(0);
+    // Write to the matching sublayer: should refresh.
+    await svc.notifySourceWrite('src-1', 'sites', [{ radius_m: 9999 }]);
+    expect(updates).toHaveLength(1);
+  });
+
+  it('does nothing when properties is empty', async () => {
+    const dep = {
+      id: 'der-1',
+      data: recipe([fieldStep('radius_m', 'meters', 100)]) as unknown as Item['data'],
+    };
+    const { prisma, updates, findMany } = makeFakePrisma({ dependents: [dep] });
+    const svc = new DerivedLayerCacheRefreshService(prisma);
+    await svc.notifySourceWrite('src-1', null, []);
+    expect(updates).toHaveLength(0);
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it('swallows errors from the database so a feature write is not rolled back', async () => {
+    const prisma = {
+      item: {
+        findMany: jest.fn(async () => {
+          throw new Error('oh no');
+        }),
+        findUnique: jest.fn(),
+        update: jest.fn(),
+      },
+    } as unknown as ConstructorParameters<
+      typeof DerivedLayerCacheRefreshService
+    >[0];
+    const svc = new DerivedLayerCacheRefreshService(prisma);
+    // Must NOT throw.
+    await expect(
+      svc.notifySourceWrite('src-1', null, [{ radius_m: 250 }]),
+    ).resolves.toBeUndefined();
+  });
+
+  it('updates several dependents in one call when each crosses its cap', async () => {
+    const a = {
+      id: 'der-a',
+      data: recipe([fieldStep('radius_m', 'meters', 100)]) as unknown as Item['data'],
+    };
+    const b = {
+      id: 'der-b',
+      data: recipe([fieldStep('radius_m', 'kilometers', 0.05)]) as unknown as Item['data'],
+    };
+    const { prisma, updates } = makeFakePrisma({ dependents: [a, b] });
+    const svc = new DerivedLayerCacheRefreshService(prisma);
+    await svc.notifySourceWrite('src-1', null, [{ radius_m: 250 }]);
+    expect(updates).toHaveLength(2);
+    const ids = updates.map((u) => (u.where as { id: string }).id).sort();
+    expect(ids).toEqual(['der-a', 'der-b']);
+  });
+});

--- a/apps/portal-api/src/derived-layers/cache-refresh.service.ts
+++ b/apps/portal-api/src/derived-layers/cache-refresh.service.ts
@@ -1,0 +1,244 @@
+import { Injectable, Logger } from '@nestjs/common';
+import type { Item, Prisma } from '@prisma/client';
+import {
+  MAX_BUFFER_DISTANCE_METERS,
+  METERS_PER_UNIT,
+  type BufferParams,
+  type DerivedLayerData,
+  type LengthUnit,
+  type ToolStep,
+} from '@gratis-gis/shared-types';
+
+import { PrismaService } from '../prisma/prisma.service.js';
+import { padBboxByMeters } from './derived-layers.service.js';
+import { getGeneratorForStep } from './tools/registry.js';
+
+/**
+ * Lazy-grow cache refresher for derived-layer recipes.
+ *
+ * The buffer tool's `field` mode caches the source's MAX(field) at
+ * recipe-save time and trusts that cap thereafter. Inserting or
+ * updating a row whose value exceeds the cap silently makes the
+ * cached cap stale: the read path keeps returning rows but the bbox
+ * pad is too small, so buffer halos near tile edges clip until the
+ * derived layer is re-saved.
+ *
+ * `notifySourceWrite` is the cure: feature write paths call it after
+ * a successful insert / update with the new properties payload, and
+ * it walks every derived_layer that depends on the source AND
+ * buffers on a key in the payload, comparing the row's value (in
+ * meters) to the cached cap. When the row's value exceeds the cap,
+ * the recipe's `cachedMaxMeters` and the derived layer's `bbox` are
+ * recomputed and persisted.
+ *
+ * Three deliberate properties:
+ * - **Grow only.** The hook never shrinks the cap. Over-padding is
+ *   correctness-safe; under-padding produces clipped halos. A row
+ *   write that lowers a value, or a delete that removes the global
+ *   max, is therefore a no-op here. The cap stays slightly inflated
+ *   until the derived layer is re-saved (full enrich runs MAX again).
+ * - **Best-effort.** Errors are logged but not thrown. A staleness
+ *   miss does not justify rolling back a successful feature write.
+ * - **Narrow query.** Only buffer steps in `field` mode whose `field`
+ *   key appears in the payload trigger a write. Recipes that use
+ *   fixed-mode buffer (or any unrelated tool, once more land) are
+ *   ignored without any further computation.
+ */
+@Injectable()
+export class DerivedLayerCacheRefreshService {
+  private readonly log = new Logger(DerivedLayerCacheRefreshService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Notify dependents that the source layer's rows have just been
+   * written. `properties` is the array of full property maps that
+   * were just persisted (not partial patches): for an UPDATE the
+   * caller is responsible for merging the patch into the prior row
+   * before passing it through, since field-mode buffer reads from
+   * the absolute key, not the delta. `layerKey` is the v3 sublayer
+   * the writes belong to, or `null` for v2 single-table sources.
+   *
+   * Returns when the refresh is complete. The caller should NOT
+   * await the result on the hot path of a feature write; fire it
+   * after the user-visible response is sent so a slow refresh
+   * cannot delay the write's HTTP response. Inside this service
+   * the work is one Postgres findMany + at most one update per
+   * dependent, so the latency is small in practice.
+   */
+  async notifySourceWrite(
+    sourceItemId: string,
+    layerKey: string | null,
+    properties: ReadonlyArray<Record<string, unknown> | undefined>,
+  ): Promise<void> {
+    if (properties.length === 0) return;
+    try {
+      const dependents = await this.findDependents(sourceItemId, layerKey);
+      if (dependents.length === 0) return;
+      // Source bbox is needed if we end up updating any dependent
+      // (so we can repad). Loaded once and shared across all
+      // matching dependents.
+      let sourceBbox: number[] | null = null;
+      for (const item of dependents) {
+        const data = item.data as unknown as DerivedLayerData | null;
+        if (!data || data.version !== 1) continue;
+        const next = growCachedCaps(data, properties);
+        if (!next) continue; // No buffer step in this recipe needed updating.
+        // Recompute the bbox lazily (only when at least one cap grew).
+        if (sourceBbox === null) {
+          sourceBbox = await this.readSourceBbox(sourceItemId);
+        }
+        const totalReach = totalOutwardReach(next.pipeline);
+        next.bbox = padBboxByMeters(sourceBbox ?? [], totalReach);
+        await this.prisma.item.update({
+          where: { id: item.id },
+          data: {
+            // Prisma's input shape rejects raw JsonValue (which
+            // includes JS `null`) and wants Prisma.InputJsonValue,
+            // so cast through unknown. The recipe is always a
+            // populated object in this code path; never null.
+            data: next as unknown as Prisma.InputJsonValue,
+            bbox: next.bbox,
+          },
+        });
+      }
+    } catch (err) {
+      // Log and swallow. A cache miss is correctness-safe; a thrown
+      // error here would roll back the feature write that called us.
+      this.log.warn(
+        `cache refresh failed for source ${sourceItemId}${layerKey ? `/${layerKey}` : ''}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+
+  /**
+   * Pull every derived_layer that points at the source. Filters in
+   * memory rather than via a JSON-path Prisma `where`, since the
+   * dependent set is small (one row per derived layer in any org)
+   * and the JSON-path predicate is awkward to write portably.
+   *
+   * For v3 sources the layerKey must match too: a write to a
+   * sublayer `A` shouldn't refresh derived layers that read from
+   * sublayer `B` of the same source item.
+   */
+  private async findDependents(
+    sourceItemId: string,
+    layerKey: string | null,
+  ): Promise<Array<{ id: string; data: Item['data'] }>> {
+    const rows = await this.prisma.item.findMany({
+      where: {
+        type: 'derived_layer',
+        deletedAt: null,
+      },
+      select: { id: true, data: true },
+    });
+    return rows.filter((r) => {
+      const d = r.data as unknown as DerivedLayerData | null;
+      if (!d || !d.source || d.source.itemId !== sourceItemId) return false;
+      const dependentLayerKey = d.source.layerKey ?? null;
+      return dependentLayerKey === layerKey;
+    });
+  }
+
+  /**
+   * Read just the source's bbox column. Pulled into a method so the
+   * notify path can avoid loading the full source row (the
+   * cache-refresh write doesn't need the source's data blob, only
+   * its spatial extent).
+   */
+  private async readSourceBbox(sourceItemId: string): Promise<number[]> {
+    const src = await this.prisma.item.findUnique({
+      where: { id: sourceItemId },
+      select: { bbox: true },
+    });
+    return Array.isArray(src?.bbox) ? (src!.bbox as number[]) : [];
+  }
+}
+
+/**
+ * Walk a recipe's pipeline and grow any field-mode buffer caps that
+ * are smaller than the largest relevant value found in `properties`.
+ * Returns a cloned recipe when at least one cap grew, or `null` when
+ * nothing needed updating (the most common case). Pure: no IO, no
+ * Prisma access, easy to test.
+ *
+ * Exported for unit tests; production callers should go through the
+ * service so write batching, dependent lookup, and bbox repadding
+ * stay in one place.
+ */
+export function growCachedCaps(
+  data: DerivedLayerData,
+  properties: ReadonlyArray<Record<string, unknown> | undefined>,
+): DerivedLayerData | null {
+  let mutated = false;
+  const nextPipeline: ToolStep[] = data.pipeline.map((step) => {
+    if (step.tool !== 'buffer') return step;
+    const params = step.params;
+    if (params.mode !== 'field') return step;
+    const candidate = largestRelevantValueMeters(
+      params.field,
+      params.unit,
+      properties,
+    );
+    if (candidate <= params.cachedMaxMeters) return step;
+    mutated = true;
+    const grown: BufferParams = {
+      mode: 'field',
+      field: params.field,
+      unit: params.unit,
+      cachedMaxMeters: Math.min(candidate, MAX_BUFFER_DISTANCE_METERS),
+    };
+    return { tool: 'buffer', params: grown };
+  });
+  if (!mutated) return null;
+  return { ...data, pipeline: nextPipeline };
+}
+
+/**
+ * Walk the new properties payloads and find the largest numeric
+ * value at `field`, converted to meters via `unit`. Skips entries
+ * where the field is missing, null, or not coercible to a positive
+ * number, so a row that doesn't carry the buffer field at all is a
+ * no-op for that recipe. Returns 0 when no payload had a usable
+ * value, which the caller compares against the cached cap (always
+ * >= 0) and ignores.
+ */
+function largestRelevantValueMeters(
+  field: string,
+  unit: LengthUnit,
+  properties: ReadonlyArray<Record<string, unknown> | undefined>,
+): number {
+  const factor = METERS_PER_UNIT[unit];
+  let best = 0;
+  for (const p of properties) {
+    if (!p || !Object.prototype.hasOwnProperty.call(p, field)) continue;
+    const raw = p[field];
+    const numeric =
+      typeof raw === 'number'
+        ? raw
+        : typeof raw === 'string' && raw.trim() !== ''
+          ? Number(raw)
+          : NaN;
+    if (!Number.isFinite(numeric) || numeric <= 0) continue;
+    const meters = numeric * factor;
+    if (meters > best) best = meters;
+  }
+  return best;
+}
+
+/**
+ * Sum each step's outward reach (meters) using the registered
+ * generators. Mirrors what `validateAndEnrich` does at recipe save
+ * time so the bbox repad here matches the bbox a fresh save would
+ * produce. Generators run in pure mode (no DB, no IO).
+ */
+function totalOutwardReach(pipeline: ToolStep[]): number {
+  let total = 0;
+  for (const step of pipeline) {
+    const generator = getGeneratorForStep(step);
+    total += generator.outwardReachMeters(generator.validate(step.params));
+  }
+  return total;
+}

--- a/apps/portal-api/src/derived-layers/derived-layers.module.ts
+++ b/apps/portal-api/src/derived-layers/derived-layers.module.ts
@@ -2,23 +2,29 @@ import { Module } from '@nestjs/common';
 
 import { PrismaModule } from '../prisma/prisma.module.js';
 import { DerivedLayersService } from './derived-layers.service.js';
+import { DerivedLayerCacheRefreshService } from './cache-refresh.service.js';
 
 /**
  * Derived layers live in their own module so the analysis surface
  * area (tools, generators, future tool-builder integration) gets a
- * clear home rather than crowding `items/`. The service is exported
- * so items.service can call it for validation on save and for read
- * routing on getGeoJson.
+ * clear home rather than crowding `items/`. The services are exported
+ * so:
+ *   - items.service can call DerivedLayersService for validation on
+ *     save and read routing on getGeoJson.
+ *   - features-v3 / features modules can call
+ *     DerivedLayerCacheRefreshService.notifySourceWrite from their
+ *     write paths so a feature edit that exceeds the cached
+ *     buffer-by-field cap grows the cap lazily.
  *
- * The module imports only PrismaModule, NOT ItemsModule. The flow
- * is one-directional: items.service depends on derived-layers.service,
- * never the other way. Per-user authorization (can the caller read
- * the source data layer?) lives in items.service, which already
- * holds the SharingService.
+ * The module imports only PrismaModule, NOT ItemsModule or any of
+ * the features modules. The flow is one-directional: items.service
+ * and the features modules depend on us, never the other way.
+ * Per-user authorization (can the caller read the source data
+ * layer?) lives in items.service, which already holds SharingService.
  */
 @Module({
   imports: [PrismaModule],
-  providers: [DerivedLayersService],
-  exports: [DerivedLayersService],
+  providers: [DerivedLayersService, DerivedLayerCacheRefreshService],
+  exports: [DerivedLayersService, DerivedLayerCacheRefreshService],
 })
 export class DerivedLayersModule {}

--- a/apps/portal-api/src/derived-layers/derived-layers.service.spec.ts
+++ b/apps/portal-api/src/derived-layers/derived-layers.service.spec.ts
@@ -208,14 +208,14 @@ describe('padBboxByMeters', () => {
 });
 
 describe('DerivedLayersService.validateAndEnrich', () => {
-  it('rejects non-object data', () => {
-    expect(() =>
+  it('rejects non-object data', async () => {
+    await expect(
       service.validateAndEnrich(null, makeSource()),
-    ).toThrow(/must be an object/);
+    ).rejects.toThrow(/must be an object/);
   });
 
-  it('rejects an empty pipeline', () => {
-    expect(() =>
+  it('rejects an empty pipeline', async () => {
+    await expect(
       service.validateAndEnrich(
         {
           version: 1,
@@ -227,12 +227,12 @@ describe('DerivedLayersService.validateAndEnrich', () => {
         },
         makeSource(),
       ),
-    ).toThrow(/non-empty array/);
+    ).rejects.toThrow(/non-empty array/);
   });
 
-  it('rejects a mismatched source.itemId vs the resolved source', () => {
+  it('rejects a mismatched source.itemId vs the resolved source', async () => {
     const source = makeSource();
-    expect(() =>
+    await expect(
       service.validateAndEnrich(
         {
           version: 1,
@@ -244,12 +244,12 @@ describe('DerivedLayersService.validateAndEnrich', () => {
         },
         source,
       ),
-    ).toThrow(/match the resolved source/);
+    ).rejects.toThrow(/match the resolved source/);
   });
 
-  it('produces an enriched DerivedLayerData with bbox padded by reach', () => {
+  it('produces an enriched DerivedLayerData with bbox padded by reach', async () => {
     const source = makeSource();
-    const enriched = service.validateAndEnrich(
+    const enriched = await service.validateAndEnrich(
       {
         version: 1,
         source: { kind: 'data_layer', itemId: source.id },
@@ -266,9 +266,9 @@ describe('DerivedLayersService.validateAndEnrich', () => {
     expect(enriched.bbox[3]).toBeCloseTo(38.1, 4);
   });
 
-  it('rejects featureLimit values outside the allowed range', () => {
+  it('rejects featureLimit values outside the allowed range', async () => {
     const source = makeSource();
-    expect(() =>
+    await expect(
       service.validateAndEnrich(
         {
           version: 1,
@@ -280,7 +280,103 @@ describe('DerivedLayersService.validateAndEnrich', () => {
         },
         source,
       ),
-    ).toThrow(/positive integer/);
+    ).rejects.toThrow(/positive integer/);
+  });
+
+  it('runs a tool generator enrich hook at save time and persists its output', async () => {
+    // Source that exposes a numeric field named `radius_m`. The
+    // buffer field-mode generator looks it up in the source schema,
+    // then calls `queryRaw` on the (fake) Prisma to find MAX(radius_m).
+    const NUMBER_FIELD: FeatureField = {
+      name: 'radius_m',
+      label: 'Radius (m)',
+      type: 'number',
+      nullable: true,
+    };
+    const source = makeSource({
+      data: {
+        version: 2,
+        storageType: 'postgis',
+        fields: [STRING_FIELD, NUMBER_FIELD],
+      } as unknown as Item['data'],
+    });
+    // Stand-in Prisma whose $queryRawUnsafe returns a single row
+    // with max_value: 250. The service is constructed with this
+    // fake; the generator's enrich hook calls through.
+    const queryCalls: string[] = [];
+    const fake = {
+      $queryRawUnsafe: jest.fn(async (sql: string) => {
+        queryCalls.push(sql);
+        return [{ max_value: 250 }] as unknown[];
+      }),
+    } as unknown as ConstructorParameters<typeof DerivedLayersService>[0];
+    const svc = new DerivedLayersService(fake);
+    const enriched = await svc.validateAndEnrich(
+      {
+        version: 1,
+        source: { kind: 'data_layer', itemId: source.id },
+        pipeline: [
+          {
+            tool: 'buffer',
+            params: { mode: 'field', field: 'radius_m', unit: 'meters' },
+          },
+        ],
+      },
+      source,
+    );
+    // Enrich populated cachedMaxMeters from the MAX query; the
+    // recipe persists with that cap baked in for future reads.
+    const step = enriched.pipeline[0]!;
+    expect(step.tool).toBe('buffer');
+    if (step.tool === 'buffer' && step.params.mode === 'field') {
+      expect(step.params.cachedMaxMeters).toBe(250);
+    } else {
+      throw new Error('expected a field-mode buffer step');
+    }
+    // bbox is padded by the cached cap, not zero, so map reads in
+    // tile-edge regions still see the buffer halo.
+    expect(enriched.bbox[0]).toBeLessThan(-122.5);
+    expect(queryCalls[0]).toMatch(/SELECT COALESCE\(\s*MAX\(/);
+  });
+
+  it('rejects field-mode buffer when the named field is not on the source schema', async () => {
+    const source = makeSource();
+    await expect(
+      service.validateAndEnrich(
+        {
+          version: 1,
+          source: { kind: 'data_layer', itemId: source.id },
+          pipeline: [
+            {
+              tool: 'buffer',
+              params: { mode: 'field', field: 'nope', unit: 'meters' },
+            },
+          ],
+        },
+        source,
+      ),
+    ).rejects.toThrow(/does not exist on the source schema/);
+  });
+
+  it('rejects field-mode buffer pointing at a non-numeric field', async () => {
+    // STRING_FIELD is name: 'name', type: 'string', so picking it for
+    // a buffer distance should be rejected up front.
+    const source = makeSource();
+    await expect(
+      service.validateAndEnrich(
+        {
+          version: 1,
+          source: { kind: 'data_layer', itemId: source.id },
+          pipeline: [
+            {
+              tool: 'buffer',
+              params: { mode: 'field', field: 'name', unit: 'meters' },
+            },
+          ],
+        },
+        source,
+      ),
+    ).rejects.toThrow(/must be a number field/);
   });
 });
 
@@ -291,7 +387,10 @@ describe('DerivedLayersService.buildReadSql', () => {
       version: 1,
       source: { kind: 'data_layer', itemId: source.id },
       pipeline: [
-        { tool: 'buffer', params: { distance: 250, unit: 'meters' } },
+        {
+          tool: 'buffer',
+          params: { mode: 'fixed', distance: 250, unit: 'meters' },
+        },
       ],
       featureLimit: 1000,
       outputSchema: [STRING_FIELD],
@@ -323,7 +422,10 @@ describe('DerivedLayersService.buildReadSql', () => {
         layerKey: 'sites',
       },
       pipeline: [
-        { tool: 'buffer', params: { distance: 25, unit: 'meters' } },
+        {
+          tool: 'buffer',
+          params: { mode: 'fixed', distance: 25, unit: 'meters' },
+        },
       ],
       featureLimit: 100,
       outputSchema: [STRING_FIELD],
@@ -342,7 +444,10 @@ describe('DerivedLayersService.buildReadSql', () => {
       version: 1,
       source: { kind: 'data_layer', itemId: source.id },
       pipeline: [
-        { tool: 'buffer', params: { distance: 11132, unit: 'meters' } },
+        {
+          tool: 'buffer',
+          params: { mode: 'fixed', distance: 11132, unit: 'meters' },
+        },
       ],
       featureLimit: 500,
       outputSchema: [STRING_FIELD],

--- a/apps/portal-api/src/derived-layers/derived-layers.service.ts
+++ b/apps/portal-api/src/derived-layers/derived-layers.service.ts
@@ -60,17 +60,19 @@ export class DerivedLayersService {
   /**
    * Validate a derived_layer's `data` payload, run each tool's
    * validator, and compute the cached `outputSchema` and `bbox` from
-   * the source. Returns the enriched, persistable data. Throws
-   * `BadRequestException` for any validation failure.
+   * the source. Tools that declare an `enrich` hook (currently
+   * `buffer` field-mode for the per-feature distance cap) get a
+   * source-aware async pass. Returns the enriched, persistable data.
+   * Throws `BadRequestException` for any validation failure.
    *
    * The caller is expected to have already authorized the user
    * against `sourceItem`. This method only verifies the source's
    * type and shape.
    */
-  validateAndEnrich(
+  async validateAndEnrich(
     rawData: unknown,
     sourceItem: Pick<Item, 'id' | 'type' | 'data' | 'bbox'>,
-  ): DerivedLayerData {
+  ): Promise<DerivedLayerData> {
     if (!rawData || typeof rawData !== 'object') {
       throw new BadRequestException('derived_layer data must be an object');
     }
@@ -156,6 +158,13 @@ export class DerivedLayersService {
     const sourceSchema = sublayer
       ? sublayer.fields
       : readSourceSchema(sourceItem.data);
+    // Source feature table, pre-quoted, for any tool's `enrich` hook
+    // that needs to query against it (buffer's field-mode max
+    // computation is the only consumer in v1). v3 uses the per-
+    // sublayer table; v2 uses the single fs_<itemId> table.
+    const sourceTable = sublayer
+      ? `"${toV3TableName(sourceItem.id, sublayer.id)}"`
+      : `"fs_${sourceItem.id.replace(/-/g, '')}"`;
     let schema: FeatureField[] = sourceSchema;
     let totalReachMeters = 0;
     const validatedPipeline: ToolStep[] = [];
@@ -176,12 +185,24 @@ export class DerivedLayersService {
         tool,
         params: (stepRaw as { params?: unknown }).params,
       } as ToolStep);
-      const params = generator.validate(
+      const validated = generator.validate(
         (stepRaw as { params?: unknown }).params,
+        { sourceSchema: schema },
       );
-      schema = generator.outputSchema(schema, params);
-      totalReachMeters += generator.outwardReachMeters(params);
-      validatedPipeline.push({ tool, params } as ToolStep);
+      // Async enrichment hook: tools fill in any caches the recipe
+      // needs (buffer's field-mode `cachedMaxMeters`). Only fired at
+      // save time; reads trust the persisted shape.
+      const enrichedParams = generator.enrich
+        ? await generator.enrich(validated, {
+            sourceSchema: schema,
+            sourceTable,
+            queryRaw: <T = unknown>(sql: string, ...p: unknown[]) =>
+              this.prisma.$queryRawUnsafe<T[]>(sql, ...p),
+          })
+        : validated;
+      schema = generator.outputSchema(schema, enrichedParams);
+      totalReachMeters += generator.outwardReachMeters(enrichedParams);
+      validatedPipeline.push({ tool, params: enrichedParams } as ToolStep);
     }
 
     const bbox = padBboxByMeters(

--- a/apps/portal-api/src/derived-layers/tools/buffer.spec.ts
+++ b/apps/portal-api/src/derived-layers/tools/buffer.spec.ts
@@ -3,10 +3,36 @@ import type { FeatureField } from '@gratis-gis/shared-types';
 
 import { bufferGenerator } from './buffer.js';
 
-describe('bufferGenerator.validate', () => {
-  it('accepts a positive distance in meters', () => {
+const STRING_FIELD: FeatureField = {
+  name: 'name',
+  label: 'Name',
+  type: 'string',
+  nullable: false,
+};
+const NUMBER_FIELD: FeatureField = {
+  name: 'radius_m',
+  label: 'Radius (m)',
+  type: 'number',
+  nullable: true,
+};
+
+describe('bufferGenerator.validate (fixed mode)', () => {
+  it('accepts the v1 shape ({ distance, unit: meters }) for back-compat', () => {
     const result = bufferGenerator.validate({ distance: 100, unit: 'meters' });
-    expect(result).toEqual({ distance: 100, unit: 'meters' });
+    expect(result).toEqual({ mode: 'fixed', distance: 100, unit: 'meters' });
+  });
+
+  it('accepts an explicit fixed-mode shape with a non-meter unit', () => {
+    const result = bufferGenerator.validate({
+      mode: 'fixed',
+      distance: 1,
+      unit: 'kilometers',
+    });
+    expect(result).toEqual({
+      mode: 'fixed',
+      distance: 1,
+      unit: 'kilometers',
+    });
   });
 
   it('rejects a non-object', () => {
@@ -29,52 +55,274 @@ describe('bufferGenerator.validate', () => {
     ).toThrow(/greater than 0/);
   });
 
-  it('rejects distances above the world-spanning ceiling', () => {
+  it('rejects distances above the world-spanning ceiling, in meters', () => {
     expect(() =>
       bufferGenerator.validate({ distance: 1_000_000, unit: 'meters' }),
     ).toThrow(/must not exceed/);
   });
 
-  it('rejects unknown units', () => {
+  it('rejects unit-converted distances above the meters ceiling', () => {
+    // 1000 km = 1_000_000 m, well past the ceiling.
     expect(() =>
-      bufferGenerator.validate({ distance: 100, unit: 'feet' }),
-    ).toThrow(/unit must be "meters"/);
+      bufferGenerator.validate({
+        mode: 'fixed',
+        distance: 1000,
+        unit: 'kilometers',
+      }),
+    ).toThrow(/must not exceed/);
+  });
+
+  it('rejects unknown unit names', () => {
+    expect(() =>
+      bufferGenerator.validate({ distance: 100, unit: 'parsecs' }),
+    ).toThrow(/must be one of/);
+  });
+});
+
+describe('bufferGenerator.validate (field mode)', () => {
+  it('accepts a field-mode shape with a known numeric field', () => {
+    const result = bufferGenerator.validate(
+      { mode: 'field', field: 'radius_m', unit: 'meters' },
+      { sourceSchema: [STRING_FIELD, NUMBER_FIELD] },
+    );
+    expect(result).toEqual({
+      mode: 'field',
+      field: 'radius_m',
+      unit: 'meters',
+      cachedMaxMeters: 0,
+    });
+  });
+
+  it('rejects a missing field name', () => {
+    expect(() =>
+      bufferGenerator.validate({ mode: 'field', unit: 'meters' }),
+    ).toThrow(/field is required/);
+  });
+
+  it('rejects a field that does not exist on the source schema', () => {
+    expect(() =>
+      bufferGenerator.validate(
+        { mode: 'field', field: 'nope', unit: 'meters' },
+        { sourceSchema: [STRING_FIELD, NUMBER_FIELD] },
+      ),
+    ).toThrow(/does not exist on the source schema/);
+  });
+
+  it('rejects a field that is not numeric', () => {
+    expect(() =>
+      bufferGenerator.validate(
+        { mode: 'field', field: 'name', unit: 'meters' },
+        { sourceSchema: [STRING_FIELD, NUMBER_FIELD] },
+      ),
+    ).toThrow(/must be a number field/);
+  });
+
+  it('skips schema checks when no context is provided (read-time path)', () => {
+    // With no schema context, validate trusts the persisted shape.
+    const result = bufferGenerator.validate({
+      mode: 'field',
+      field: 'whatever_was_persisted',
+      unit: 'feet',
+      cachedMaxMeters: 1500,
+    });
+    expect(result).toEqual({
+      mode: 'field',
+      field: 'whatever_was_persisted',
+      unit: 'feet',
+      cachedMaxMeters: 1500,
+    });
+  });
+
+  it('clamps a client-supplied cachedMaxMeters to the global ceiling', () => {
+    const result = bufferGenerator.validate({
+      mode: 'field',
+      field: 'radius_m',
+      unit: 'meters',
+      cachedMaxMeters: 999_999_999,
+    });
+    expect((result as { cachedMaxMeters: number }).cachedMaxMeters).toBe(
+      100_000,
+    );
+  });
+});
+
+describe('bufferGenerator.enrich', () => {
+  it('queries MAX(field) and bakes the result as cachedMaxMeters', async () => {
+    const queryRaw = jest
+      .fn()
+      .mockResolvedValue([{ max_value: 250 }] as unknown[]);
+    const enriched = await bufferGenerator.enrich!(
+      {
+        mode: 'field',
+        field: 'radius_m',
+        unit: 'meters',
+        cachedMaxMeters: 0,
+      },
+      {
+        sourceSchema: [NUMBER_FIELD],
+        sourceTable: '"fs_xyz"',
+        queryRaw,
+      },
+    );
+    expect(enriched).toEqual({
+      mode: 'field',
+      field: 'radius_m',
+      unit: 'meters',
+      cachedMaxMeters: 250,
+    });
+    expect(queryRaw).toHaveBeenCalledTimes(1);
+    const [sql, ...args] = queryRaw.mock.calls[0]!;
+    expect(sql).toMatch(/MAX\(/);
+    expect(sql).toMatch(/properties->>\$1/);
+    expect(args).toEqual(['radius_m']);
+  });
+
+  it('converts the raw max into meters using the recipe unit', async () => {
+    // Source values stored in feet; max(field) = 100 feet = 30.48 m.
+    const queryRaw = jest
+      .fn()
+      .mockResolvedValue([{ max_value: 100 }] as unknown[]);
+    const enriched = await bufferGenerator.enrich!(
+      {
+        mode: 'field',
+        field: 'radius_m',
+        unit: 'feet',
+        cachedMaxMeters: 0,
+      },
+      {
+        sourceSchema: [NUMBER_FIELD],
+        sourceTable: '"fs_xyz"',
+        queryRaw,
+      },
+    );
+    expect((enriched as { cachedMaxMeters: number }).cachedMaxMeters).toBeCloseTo(
+      30.48,
+      4,
+    );
+  });
+
+  it('clamps the cached cap to the global meters ceiling', async () => {
+    const queryRaw = jest
+      .fn()
+      .mockResolvedValue([{ max_value: 1000 }] as unknown[]); // 1000 km = 1_000_000 m
+    const enriched = await bufferGenerator.enrich!(
+      {
+        mode: 'field',
+        field: 'radius_m',
+        unit: 'kilometers',
+        cachedMaxMeters: 0,
+      },
+      {
+        sourceSchema: [NUMBER_FIELD],
+        sourceTable: '"fs_xyz"',
+        queryRaw,
+      },
+    );
+    expect((enriched as { cachedMaxMeters: number }).cachedMaxMeters).toBe(
+      100_000,
+    );
+  });
+
+  it('returns zero when the source is empty or has no positive values', async () => {
+    const queryRaw = jest
+      .fn()
+      .mockResolvedValue([{ max_value: 0 }] as unknown[]);
+    const enriched = await bufferGenerator.enrich!(
+      {
+        mode: 'field',
+        field: 'radius_m',
+        unit: 'meters',
+        cachedMaxMeters: 0,
+      },
+      {
+        sourceSchema: [NUMBER_FIELD],
+        sourceTable: '"fs_xyz"',
+        queryRaw,
+      },
+    );
+    expect((enriched as { cachedMaxMeters: number }).cachedMaxMeters).toBe(0);
+  });
+
+  it('passes through fixed-mode params unchanged', async () => {
+    const queryRaw = jest.fn();
+    const fixed = {
+      mode: 'fixed' as const,
+      distance: 100,
+      unit: 'meters' as const,
+    };
+    const enriched = await bufferGenerator.enrich!(fixed, {
+      sourceSchema: [],
+      sourceTable: '"fs_xyz"',
+      queryRaw,
+    });
+    expect(enriched).toBe(fixed);
+    expect(queryRaw).not.toHaveBeenCalled();
   });
 });
 
 describe('bufferGenerator.outputSchema', () => {
   it('passes through the source schema unchanged', () => {
-    const fields: FeatureField[] = [
-      { name: 'name', label: 'Name', type: 'string', nullable: false },
-      { name: 'population', label: 'Pop.', type: 'number', nullable: true },
-    ];
+    const fields: FeatureField[] = [STRING_FIELD, NUMBER_FIELD];
     expect(
-      bufferGenerator.outputSchema(fields, { distance: 100, unit: 'meters' }),
+      bufferGenerator.outputSchema(fields, {
+        mode: 'fixed',
+        distance: 100,
+        unit: 'meters',
+      }),
     ).toBe(fields);
   });
 });
 
 describe('bufferGenerator.outwardReachMeters', () => {
-  it('returns the buffer distance', () => {
+  it('returns the buffer distance in meters for fixed mode', () => {
     expect(
-      bufferGenerator.outwardReachMeters({ distance: 250, unit: 'meters' }),
+      bufferGenerator.outwardReachMeters({
+        mode: 'fixed',
+        distance: 250,
+        unit: 'meters',
+      }),
     ).toBe(250);
+  });
+
+  it('converts unit to meters for fixed mode', () => {
+    expect(
+      bufferGenerator.outwardReachMeters({
+        mode: 'fixed',
+        distance: 1,
+        unit: 'kilometers',
+      }),
+    ).toBe(1000);
+  });
+
+  it('returns the cached cap for field mode', () => {
+    expect(
+      bufferGenerator.outwardReachMeters({
+        mode: 'field',
+        field: 'r',
+        unit: 'meters',
+        cachedMaxMeters: 750,
+      }),
+    ).toBe(750);
   });
 });
 
 describe('bufferGenerator.extractDependencies', () => {
   it('returns no item or url references in v1', () => {
     expect(
-      bufferGenerator.extractDependencies({ distance: 100, unit: 'meters' }),
+      bufferGenerator.extractDependencies({
+        mode: 'fixed',
+        distance: 100,
+        unit: 'meters',
+      }),
     ).toEqual({ itemIds: [], urls: [] });
   });
 });
 
-describe('bufferGenerator.toSql', () => {
+describe('bufferGenerator.toSql (fixed mode)', () => {
   it('emits a CTE body that buffers via geography casting', () => {
     const fragment = bufferGenerator.toSql(
       'source',
-      { distance: 250, unit: 'meters' },
+      { mode: 'fixed', distance: 250, unit: 'meters' },
       0,
     );
     expect(fragment.params).toEqual([250]);
@@ -88,12 +336,76 @@ describe('bufferGenerator.toSql', () => {
   it('honors paramOffset so multi-step pipelines stay parameter-safe', () => {
     const fragment = bufferGenerator.toSql(
       'step_1',
-      { distance: 50, unit: 'meters' },
+      { mode: 'fixed', distance: 50, unit: 'meters' },
+      4,
+    );
+    expect(fragment.sql).toMatch(/\$5/);
+    expect(fragment.sql).not.toMatch(/\$1\b/);
+    expect(fragment.params).toEqual([50]);
+  });
+
+  it('converts non-meter units to meters in the emitted parameter', () => {
+    const fragment = bufferGenerator.toSql(
+      'source',
+      { mode: 'fixed', distance: 1, unit: 'kilometers' },
+      0,
+    );
+    expect(fragment.params).toEqual([1000]);
+  });
+});
+
+describe('bufferGenerator.toSql (field mode)', () => {
+  it('reads per-feature distance from properties JSON, converts to meters, and clamps to the cached cap', () => {
+    const fragment = bufferGenerator.toSql(
+      'source',
+      {
+        mode: 'field',
+        field: 'radius_m',
+        unit: 'meters',
+        cachedMaxMeters: 500,
+      },
+      0,
+    );
+    // Three placeholders: $1 = field name, $2 = unit factor, $3 = cap.
+    expect(fragment.params).toEqual(['radius_m', 1, 500]);
+    expect(fragment.sql).toMatch(/properties->>\$1/);
+    expect(fragment.sql).toMatch(/\* \$2/);
+    expect(fragment.sql).toMatch(/LEAST\(/);
+    expect(fragment.sql).toMatch(/\$3/);
+    // Skips rows with non-numeric field values rather than erroring.
+    expect(fragment.sql).toMatch(/properties \? \$1/);
+    expect(fragment.sql).toMatch(/~ '\^-\?\[0-9\]/);
+  });
+
+  it('emits the kilometers unit factor (1000) for kilometer-unit recipes', () => {
+    const fragment = bufferGenerator.toSql(
+      'source',
+      {
+        mode: 'field',
+        field: 'radius_km',
+        unit: 'kilometers',
+        cachedMaxMeters: 50_000,
+      },
+      0,
+    );
+    expect(fragment.params).toEqual(['radius_km', 1000, 50_000]);
+  });
+
+  it('honors paramOffset so multi-step pipelines stay parameter-safe', () => {
+    const fragment = bufferGenerator.toSql(
+      'step_1',
+      {
+        mode: 'field',
+        field: 'r',
+        unit: 'meters',
+        cachedMaxMeters: 100,
+      },
       4,
     );
     // First placeholder a step at offset 4 should emit is $5.
     expect(fragment.sql).toMatch(/\$5/);
+    expect(fragment.sql).toMatch(/\$6/);
+    expect(fragment.sql).toMatch(/\$7/);
     expect(fragment.sql).not.toMatch(/\$1\b/);
-    expect(fragment.params).toEqual([50]);
   });
 });

--- a/apps/portal-api/src/derived-layers/tools/buffer.ts
+++ b/apps/portal-api/src/derived-layers/tools/buffer.ts
@@ -1,68 +1,174 @@
 import { BadRequestException } from '@nestjs/common';
 import {
   MAX_BUFFER_DISTANCE_METERS,
+  METERS_PER_UNIT,
+  isLengthUnit,
+  metersFor,
+  type BufferParams,
   type FeatureField,
+  type LengthUnit,
 } from '@gratis-gis/shared-types';
 
-import type { ToolGenerator } from './types.js';
+import type {
+  ToolEnrichContext,
+  ToolGenerator,
+  ToolValidateContext,
+} from './types.js';
 
 /**
- * Validated buffer params after `validate(...)` returns. Mirrors
- * `BufferStep['params']` from shared-types but lives here too so the
- * generator's signature doesn't bleed shared-types' wider unions
- * (additional tools, sublayer hints) into the buffer code path.
- */
-export interface BufferParams {
-  distance: number;
-  unit: 'meters';
-}
-
-/**
- * Buffer generator. Wraps `ST_Buffer(geom::geography, distance)` so
- * the distance is interpreted in meters globally regardless of
- * longitude. Output is cast back to `geometry` (SRID 4326) so it
- * round-trips through the same pipeline machinery as every other
- * step.
+ * Buffer generator. Wraps `ST_Buffer(geom::geography, distance)` so the
+ * distance is interpreted in meters globally regardless of longitude.
+ * Output is cast back to `geometry` (SRID 4326) so it round-trips
+ * through the same pipeline machinery as every other step.
+ *
+ * Two distance modes:
+ *   - `fixed` applies the same distance to every input row. Distance
+ *     comes from `params.distance` interpreted in `params.unit`,
+ *     converted to meters at SQL emission time.
+ *   - `field` reads the per-feature distance from a numeric column on
+ *     the source schema. The wizard never asks the user for an upper
+ *     bound; the server queries `MAX(<field>)` once at recipe-save
+ *     time (`enrich`) and caches the result in meters as
+ *     `cachedMaxMeters`. That cap drives bbox padding on the read path
+ *     and clamps the per-row buffer in SQL via `LEAST(...)` so a stray
+ *     oversized value cannot generate a planet-spanning geometry.
  *
  * The `geography` cast is the v1 simplification: it's accurate within
  * a few meters at typical urban / regional scales and avoids the
  * "what CRS is the input in?" question that blocks raw projected
- * buffers. Future tools that need precise geodesic results can pick
- * a different strategy (project to UTM, buffer, project back) under
- * a separate `tool` kind.
+ * buffers. Future tools that need precise geodesic results can pick a
+ * different strategy (project to UTM, buffer, project back) under a
+ * separate `tool` kind.
+ *
+ * Backwards compatibility: existing rows persisted with the v1 shape
+ * `{ distance, unit: 'meters' }` (no `mode`) are accepted by `validate`
+ * and normalized to `{ mode: 'fixed', ... }`. No data migration
+ * required; the next save through the new builder writes the fully
+ * tagged shape forward.
  */
 export const bufferGenerator: ToolGenerator<BufferParams> = {
   kind: 'buffer',
 
-  validate(raw: unknown): BufferParams {
+  validate(raw: unknown, ctx?: ToolValidateContext): BufferParams {
     if (!raw || typeof raw !== 'object') {
       throw new BadRequestException('buffer.params must be an object');
     }
     const r = raw as Record<string, unknown>;
-    const distance = r.distance;
-    if (typeof distance !== 'number' || !Number.isFinite(distance)) {
+    // Resolve unit first; both modes use it. Default to 'meters' when
+    // absent so the v1 persisted shape (which never had a `unit` field
+    // worth widening) parses cleanly.
+    const unit = resolveUnit(r.unit);
+
+    // Mode resolution: an explicit `mode` wins; otherwise we infer
+    // 'fixed' from the presence of `distance`, matching the v1 shape.
+    const rawMode = r.mode;
+    const mode =
+      rawMode === 'field'
+        ? 'field'
+        : rawMode === 'fixed' || rawMode === undefined
+          ? 'fixed'
+          : (() => {
+              throw new BadRequestException(
+                `buffer.params.mode must be 'fixed' or 'field' (got ${JSON.stringify(rawMode)})`,
+              );
+            })();
+
+    if (mode === 'fixed') {
+      const distance = r.distance;
+      if (typeof distance !== 'number' || !Number.isFinite(distance)) {
+        throw new BadRequestException(
+          'buffer.params.distance must be a finite number',
+        );
+      }
+      if (distance <= 0) {
+        throw new BadRequestException(
+          'buffer.params.distance must be greater than 0',
+        );
+      }
+      const distanceMeters = metersFor(distance, unit);
+      if (distanceMeters > MAX_BUFFER_DISTANCE_METERS) {
+        throw new BadRequestException(
+          `buffer.params.distance must not exceed ${MAX_BUFFER_DISTANCE_METERS} meters (got ${distanceMeters}m)`,
+        );
+      }
+      return { mode: 'fixed', distance, unit };
+    }
+
+    // mode === 'field'
+    const field = r.field;
+    if (typeof field !== 'string' || field.length === 0) {
       throw new BadRequestException(
-        'buffer.params.distance must be a finite number',
+        "buffer.params.field is required when mode is 'field'",
       );
     }
-    if (distance <= 0) {
-      throw new BadRequestException(
-        'buffer.params.distance must be greater than 0',
-      );
+    // When the caller passed in a schema, check that `field` exists
+    // and is numeric. Without a schema (read-time validate) we trust
+    // the persisted shape and let the SQL surface a clear failure if
+    // the field has been removed from the source since save.
+    if (ctx?.sourceSchema) {
+      const match = ctx.sourceSchema.find((f) => f.name === field);
+      if (!match) {
+        throw new BadRequestException(
+          `buffer.params.field "${field}" does not exist on the source schema`,
+        );
+      }
+      if (match.type !== 'number') {
+        throw new BadRequestException(
+          `buffer.params.field "${field}" must be a number field (got ${match.type})`,
+        );
+      }
     }
-    if (distance > MAX_BUFFER_DISTANCE_METERS) {
-      throw new BadRequestException(
-        `buffer.params.distance must not exceed ${MAX_BUFFER_DISTANCE_METERS} meters`,
-      );
+    // cachedMaxMeters is filled in by `enrich`. Accept whatever's on
+    // the wire (the wizard sends 0; the server replaces it). Cap to
+    // the global ceiling so a malicious client can't bypass safety
+    // by sending a huge cached value directly.
+    const rawCap = (r as { cachedMaxMeters?: unknown }).cachedMaxMeters;
+    let cachedMaxMeters = 0;
+    if (typeof rawCap === 'number' && Number.isFinite(rawCap) && rawCap > 0) {
+      cachedMaxMeters = Math.min(rawCap, MAX_BUFFER_DISTANCE_METERS);
     }
-    if (r.unit !== 'meters') {
-      // v1 ships meters only; reject anything else loudly so callers
-      // notice rather than silently treating their value as meters.
-      throw new BadRequestException(
-        'buffer.params.unit must be "meters" in v1',
-      );
-    }
-    return { distance, unit: 'meters' };
+    return { mode: 'field', field, unit, cachedMaxMeters };
+  },
+
+  async enrich(
+    params: BufferParams,
+    ctx: ToolEnrichContext,
+  ): Promise<BufferParams> {
+    if (params.mode !== 'field') return params;
+    // Compute the global MAX of the named field across the source's
+    // feature table, cast to double precision so the `(properties->>...)`
+    // text gets interpreted as a number. Rows with NULL or
+    // non-numeric values are skipped via NULLIF + a regex guard, so
+    // a row whose value is "" or "abc" doesn't blow up the query.
+    // The result is converted to meters via the recipe's chosen unit
+    // and clamped to the global ceiling so the cached cap is always
+    // a meter value within bounds the read path can pad with safely.
+    const sql = `
+      SELECT COALESCE(
+        MAX(
+          (NULLIF(properties->>$1, ''))::double precision
+        ),
+        0
+      ) AS max_value
+      FROM ${ctx.sourceTable}
+      WHERE properties ? $1
+        AND (properties->>$1) ~ '^-?[0-9]+(\\.[0-9]+)?$'
+    `;
+    type Row = { max_value: number | string | null };
+    const rows = await ctx.queryRaw<Row>(sql, params.field);
+    const raw = rows[0]?.max_value;
+    const numeric =
+      typeof raw === 'number'
+        ? raw
+        : typeof raw === 'string'
+          ? Number.parseFloat(raw)
+          : 0;
+    const safeNumeric = Number.isFinite(numeric) && numeric > 0 ? numeric : 0;
+    const cachedMaxMeters = Math.min(
+      metersFor(safeNumeric, params.unit),
+      MAX_BUFFER_DISTANCE_METERS,
+    );
+    return { ...params, cachedMaxMeters };
   },
 
   outputSchema(input: FeatureField[]): FeatureField[] {
@@ -74,13 +180,21 @@ export const bufferGenerator: ToolGenerator<BufferParams> = {
   },
 
   outwardReachMeters(params: BufferParams): number {
-    return params.distance;
+    if (params.mode === 'fixed') {
+      return metersFor(params.distance, params.unit);
+    }
+    // Field mode: trust the cached cap. Zero (no rows or no positive
+    // values) yields no expansion, which is correct: a layer whose
+    // distances are all zero produces no buffered halo and needs no
+    // bbox padding.
+    return params.cachedMaxMeters;
   },
 
   extractDependencies(): { itemIds: string[]; urls: string[] } {
-    // v1 buffer holds no item references. The slot exists so future
-    // tools (intersect against a second layer, choices from a pick
-    // list, ...) plug into the dependency graph automatically.
+    // v1 buffer holds no item references regardless of mode. The
+    // slot exists so future tools (intersect against a second layer,
+    // choices from a pick list, ...) plug into the dependency graph
+    // automatically.
     return { itemIds: [], urls: [] };
   },
 
@@ -91,18 +205,73 @@ export const bufferGenerator: ToolGenerator<BufferParams> = {
     // a no-op when the geography already carries 4326 but cheap
     // insurance against PostGIS spatial-ref drift between Postgres
     // versions.
-    const placeholder = `$${paramOffset + 1}`;
+    if (params.mode === 'fixed') {
+      const distancePh = `$${paramOffset + 1}`;
+      const sql = `
+        SELECT
+          global_id,
+          ST_SetSRID(
+            ST_Buffer(geom::geography, ${distancePh})::geometry,
+            4326
+          ) AS geom,
+          properties
+        FROM ${inputAlias}
+        WHERE geom IS NOT NULL
+      `;
+      return { sql, params: [metersFor(params.distance, params.unit)] };
+    }
+    // Field mode. The per-row distance comes from
+    // (properties->>'<field>')::double precision; we convert to meters
+    // by multiplying by the unit factor, then clamp with LEAST() to
+    // the cached cap so a stray data outlier can't generate a
+    // gigantic buffer. NULLIF handles empty strings; the regex guard
+    // in the WHERE strips non-numeric junk before the cast so a row
+    // with `properties->>'field' = 'unknown'` doesn't error the
+    // query.
+    const fieldPh = `$${paramOffset + 1}`;
+    const factorPh = `$${paramOffset + 2}`;
+    const capPh = `$${paramOffset + 3}`;
     const sql = `
       SELECT
         global_id,
         ST_SetSRID(
-          ST_Buffer(geom::geography, ${placeholder})::geometry,
+          ST_Buffer(
+            geom::geography,
+            LEAST(
+              GREATEST(
+                (NULLIF(properties->>${fieldPh}, ''))::double precision * ${factorPh},
+                0
+              ),
+              ${capPh}
+            )
+          )::geometry,
           4326
         ) AS geom,
         properties
       FROM ${inputAlias}
       WHERE geom IS NOT NULL
+        AND properties ? ${fieldPh}
+        AND (properties->>${fieldPh}) ~ '^-?[0-9]+(\\.[0-9]+)?$'
     `;
-    return { sql, params: [params.distance] };
+    const factor = METERS_PER_UNIT[params.unit];
+    return {
+      sql,
+      params: [params.field, factor, params.cachedMaxMeters],
+    };
   },
 };
+
+/**
+ * Resolve a unit value off the wire. v1 persisted recipes used
+ * `unit: 'meters'` so an absent unit defaults to that, keeping
+ * existing rows valid without a data migration. Anything else has
+ * to be one of the known LengthUnit literals or we 400 with a clear
+ * message.
+ */
+function resolveUnit(raw: unknown): LengthUnit {
+  if (raw === undefined) return 'meters';
+  if (isLengthUnit(raw)) return raw;
+  throw new BadRequestException(
+    `buffer.params.unit must be one of meters / kilometers / feet / yards / miles (got ${JSON.stringify(raw)})`,
+  );
+}

--- a/apps/portal-api/src/derived-layers/tools/types.ts
+++ b/apps/portal-api/src/derived-layers/tools/types.ts
@@ -1,6 +1,44 @@
 import type { FeatureField } from '@gratis-gis/shared-types';
 
 /**
+ * Optional context handed to `validate(...)` when the call site has
+ * the source schema in hand (i.e. `validateAndEnrich` at save time).
+ * When omitted (e.g. read-time `validate` calls inside `getGeoJson`),
+ * generators must accept the persisted shape without touching the
+ * source schema. Keeps generators usable in two distinct call paths
+ * without forcing them into either one.
+ */
+export interface ToolValidateContext {
+  /** Schema of the rows the tool will receive as input. */
+  sourceSchema: FeatureField[];
+}
+
+/**
+ * Context handed to `enrich(...)` at recipe-save time. Lets a
+ * generator run a parameterized SQL query against the source's
+ * PostGIS table to compute caches the recipe needs (e.g. buffer's
+ * `cachedMaxMeters`). Generators receive a callback rather than a
+ * Prisma client so the dependency stays narrow and easy to mock in
+ * tests.
+ */
+export interface ToolEnrichContext {
+  sourceSchema: FeatureField[];
+  /**
+   * Quoted PostGIS table name backing the source rows the tool will
+   * read. v3 sources resolve to `fs_<itemId>_<layerKey>`; v2 sources
+   * to `fs_<itemId>`. Pre-quoted by the caller so the generator can
+   * splice it into hand-authored SQL without escaping concerns.
+   */
+  sourceTable: string;
+  /**
+   * Run a parameterized SQL query against the workspace database.
+   * Generators MUST go through this rather than touching Prisma
+   * directly so the surface stays narrow.
+   */
+  queryRaw: <T = unknown>(sql: string, ...params: unknown[]) => Promise<T[]>;
+}
+
+/**
  * Common shape every tool generator produces from `toSql`. The
  * backing string is a SQL fragment, parameterized through `$N`
  * placeholders, that defines a single CTE-style subquery yielding the
@@ -64,8 +102,30 @@ export interface ToolGenerator<TParams> {
    * params don't match the declared shape. The registry calls this
    * before any other generator method, so other methods can assume
    * params are well-formed.
+   *
+   * `ctx` is optional. When the caller has the source schema (i.e.
+   * recipe-save time), passing it lets the generator do schema-level
+   * checks ("does this field exist? is it numeric?") that would be
+   * impossible at read time. When omitted (read time), validation is
+   * limited to "the persisted shape parses cleanly" and the generator
+   * trusts that the shape was checked against the schema once at
+   * save.
    */
-  validate(params: unknown): TParams;
+  validate(params: unknown, ctx?: ToolValidateContext): TParams;
+
+  /**
+   * Optional async hook: compute and bake any cached values the
+   * recipe needs (e.g. buffer's `cachedMaxMeters` from MAX(field)).
+   * Called by `validateAndEnrich` after `validate` returns. The
+   * returned params are persisted and used by `outwardReachMeters`
+   * and `toSql` thereafter, so any cache placed here is durable
+   * across reads. Generators that don't need an async pass omit
+   * this method and the service skips the call.
+   */
+  enrich?: (
+    params: TParams,
+    ctx: ToolEnrichContext,
+  ) => Promise<TParams>;
 
   /**
    * Compute the output schema from the input schema + params. Pure.

--- a/apps/portal-api/src/features-v3/v3-features.module.ts
+++ b/apps/portal-api/src/features-v3/v3-features.module.ts
@@ -7,16 +7,24 @@ import { V3AttachmentsController } from './v3-attachments.controller.js';
 import { ItemsModule } from '../items/items.module.js';
 import { StorageModule } from '../storage/storage.module.js';
 import { NotificationsModule } from '../notifications/notifications.module.js';
+import { DerivedLayersModule } from '../derived-layers/derived-layers.module.js';
 
 /**
  * v3 feature CRUD + attachments. Depends on ItemsModule (auth / gate
- * checks) and StorageModule (attachment cleanup on delete). Does NOT
- * depend on V3TablesModule: tables are provisioned upstream by
- * ItemsService; this module just reads / writes rows and attachment
- * metadata against whatever's already there.
+ * checks), StorageModule (attachment cleanup on delete), and
+ * DerivedLayersModule (lazy-grow staleness hook for buffer-by-field
+ * caches; see DerivedLayerCacheRefreshService). Does NOT depend on
+ * V3TablesModule: tables are provisioned upstream by ItemsService;
+ * this module just reads / writes rows and attachment metadata
+ * against whatever's already there.
  */
 @Module({
-  imports: [ItemsModule, StorageModule, NotificationsModule],
+  imports: [
+    ItemsModule,
+    StorageModule,
+    NotificationsModule,
+    DerivedLayersModule,
+  ],
   providers: [V3FeaturesService, V3AttachmentsService],
   controllers: [V3FeaturesController, V3AttachmentsController],
   exports: [V3FeaturesService, V3AttachmentsService],

--- a/apps/portal-api/src/features-v3/v3-features.service.ts
+++ b/apps/portal-api/src/features-v3/v3-features.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 
 import { PrismaService } from '../prisma/prisma.service.js';
 import type { AuthUser } from '../auth/auth-sync.service.js';
+import { DerivedLayerCacheRefreshService } from '../derived-layers/cache-refresh.service.js';
 import { toV3TableName } from './v3-tables.service.js';
 
 /**
@@ -43,7 +44,10 @@ interface V3Row {
 export class V3FeaturesService {
   private readonly log = new Logger(V3FeaturesService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly cacheRefresh: DerivedLayerCacheRefreshService,
+  ) {}
 
   /** Current-state feature collection for a layer. Supports bbox
    *  filter + point-in-time (?at=) in the usual temporal-table form,
@@ -175,6 +179,15 @@ export class V3FeaturesService {
       inserted += 1;
     }
     this.log.log(`Inserted ${inserted} features into ${tbl}`);
+    // Lazy-grow buffer-by-field caches on any derived layer that
+    // reads from this source. Best-effort: notifySourceWrite swallows
+    // its own errors so an insert that goes through here is never
+    // rolled back by a downstream cache problem.
+    void this.cacheRefresh.notifySourceWrite(
+      itemId,
+      layerId,
+      inputs.map((f) => f.properties),
+    );
     return { inserted };
   }
 
@@ -241,7 +254,16 @@ export class V3FeaturesService {
         user.id,
         cur[0]!.created_at,
       );
-      return rowToFeature(inserted[0]!);
+      // Lazy-grow buffer-by-field caches on dependents. The merged
+      // properties object is what downstream reads will see, so it's
+      // also the right input to the staleness check. Fire after the
+      // transaction commits so a cache write can't bring down a
+      // user's edit.
+      const out = rowToFeature(inserted[0]!);
+      void this.cacheRefresh.notifySourceWrite(itemId, layerId, [
+        nextProps as Record<string, unknown>,
+      ]);
+      return out;
     });
   }
 

--- a/apps/portal-api/src/features/features.module.ts
+++ b/apps/portal-api/src/features/features.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 
 import { ItemsModule } from '../items/items.module.js';
+import { DerivedLayersModule } from '../derived-layers/derived-layers.module.js';
 import { FeaturesController } from './features.controller.js';
 import { FeaturesService } from './features.service.js';
 import { RelationshipsController } from './relationships.controller.js';
 
 @Module({
-  imports: [ItemsModule],
+  imports: [ItemsModule, DerivedLayersModule],
   providers: [FeaturesService],
   controllers: [FeaturesController, RelationshipsController],
   exports: [FeaturesService],

--- a/apps/portal-api/src/features/features.service.ts
+++ b/apps/portal-api/src/features/features.service.ts
@@ -7,6 +7,7 @@ import {
 
 import { PrismaService } from '../prisma/prisma.service.js';
 import type { AuthUser } from '../auth/auth-sync.service.js';
+import { DerivedLayerCacheRefreshService } from '../derived-layers/cache-refresh.service.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -153,7 +154,10 @@ function rowToFeature(row: FeatureRow, includeMeta: boolean): GeoJsonFeature {
 export class FeaturesService {
   private readonly log = new Logger(FeaturesService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly cacheRefresh: DerivedLayerCacheRefreshService,
+  ) {}
 
   // -------------------------------------------------------------------------
   // Table lifecycle
@@ -250,6 +254,15 @@ export class FeaturesService {
     if (features.length === 0) return { inserted: 0 };
     const tbl = toTableName(itemId);
     const inserted = await this.bulkInsertCore(this.prisma, tbl, features, user);
+    // Lazy-grow buffer-by-field caches on derived layers that read
+    // from this v2 source. v2 has no sublayer concept, so layerKey
+    // is null. Fire-and-forget: notifySourceWrite swallows its own
+    // errors so a cache problem can't roll back this insert.
+    void this.cacheRefresh.notifySourceWrite(
+      itemId,
+      null,
+      features.map((f) => f.properties),
+    );
     return { inserted };
   }
 
@@ -344,6 +357,15 @@ export class FeaturesService {
       const expired = typeof expireResult === 'number' ? expireResult : 0;
 
       const inserted = await this.bulkInsertCore(tx, tbl, features, user);
+      // Same staleness hook as bulkInsert. replaceAll is the bulk
+      // upload path the wizard / API caller uses to populate a v2
+      // layer; without this hook a freshly-uploaded source whose
+      // values exceed a stored cap would not propagate.
+      void this.cacheRefresh.notifySourceWrite(
+        itemId,
+        null,
+        features.map((f) => f.properties),
+      );
       return { inserted, expired };
     });
   }
@@ -427,6 +449,12 @@ export class FeaturesService {
         old.created_at.toISOString(),
       );
 
+      // Lazy-grow buffer-by-field caches on dependents. The merged
+      // newProps object is the absolute post-update state of the
+      // row, so it's the right input to the staleness check.
+      void this.cacheRefresh.notifySourceWrite(itemId, null, [
+        newProps as Record<string, unknown>,
+      ]);
       return rowToFeature(inserted[0]!, true);
     });
   }

--- a/apps/portal-api/src/items/items.service.ts
+++ b/apps/portal-api/src/items/items.service.ts
@@ -768,10 +768,11 @@ export class ItemsService {
         'derived_layer.source.itemId does not point at an accessible data layer',
       );
     }
-    return this.derivedLayers.validateAndEnrich(
+    const enriched = await this.derivedLayers.validateAndEnrich(
       rawData,
       source,
-    ) as unknown as Prisma.JsonValue;
+    );
+    return enriched as unknown as Prisma.JsonValue;
   }
 
   /**

--- a/apps/portal-web/src/app/items/[id]/derived-layer/detail.tsx
+++ b/apps/portal-web/src/app/items/[id]/derived-layer/detail.tsx
@@ -3,16 +3,18 @@
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { ArrowRight, FlaskConical, Layers } from 'lucide-react';
-import type {
-  DerivedLayerData,
-  Item,
-  ToolStep,
+import {
+  UNIT_LABELS,
+  type DerivedLayerData,
+  type Item,
+  type ToolStep,
 } from '@gratis-gis/shared-types';
 
 /**
  * Read-only summary of a derived layer's recipe. Editing the recipe
- * (changing the source, tweaking buffer distance, adding tools) lives
- * on the standard /edit screen for now: this panel just shows what
+ * (changing the source, tweaking buffer distance, adding tools) is
+ * surfaced on the standard /edit screen, which renders the same
+ * builder used by the new-item wizard. This panel just shows what
  * the layer is so a viewer or owner can understand it at a glance,
  * and shows the cached output schema so people binding dashboards
  * to it can see the columns without running a query.
@@ -177,10 +179,35 @@ function labelForTool(step: ToolStep): string {
 function summarizeStep(step: ToolStep): string {
   switch (step.tool) {
     case 'buffer': {
-      const { distance, unit } = step.params;
-      return `${distance.toLocaleString()} ${unit}`;
+      const params = step.params;
+      const unitLabel = UNIT_LABELS[params.unit] ?? params.unit;
+      if (params.mode === 'field') {
+        // Field-driven buffer: show which column the per-feature
+        // distance reads from, the unit it's interpreted in, and the
+        // server-computed cap so a viewer understands the upper
+        // bound at a glance.
+        const cap = formatCap(params.cachedMaxMeters);
+        return `${params.field} (${unitLabel}, max ~${cap})`;
+      }
+      // Fixed: simple distance + unit.
+      return `${params.distance.toLocaleString()} ${unitLabel}`;
     }
     default:
       return '';
   }
+}
+
+/**
+ * Format a meters cap for display. Compact: bare meters under 1 km,
+ * km above. Used by the field-mode buffer summary so the cap reads
+ * naturally regardless of magnitude.
+ */
+function formatCap(meters: number): string {
+  if (!Number.isFinite(meters) || meters <= 0) return '0 m';
+  if (meters >= 1000) {
+    return `${(meters / 1000).toLocaleString(undefined, {
+      maximumFractionDigits: 2,
+    })} km`;
+  }
+  return `${Math.round(meters).toLocaleString()} m`;
 }

--- a/apps/portal-web/src/app/items/[id]/edit/page.tsx
+++ b/apps/portal-web/src/app/items/[id]/edit/page.tsx
@@ -55,6 +55,7 @@ export default async function EditItemPage({ params }: Props) {
           thumbnailUrl: item.thumbnailUrl,
           license: item.license,
         }}
+        initialData={item.data}
       />
     </div>
   );

--- a/apps/portal-web/src/app/items/item-form.tsx
+++ b/apps/portal-web/src/app/items/item-form.tsx
@@ -11,13 +11,21 @@ import {
   Save,
   Sparkles,
 } from 'lucide-react';
-import type { Item, ItemAccess, ItemType } from '@gratis-gis/shared-types';
+import type {
+  DerivedLayerData,
+  Item,
+  ItemAccess,
+  ItemType,
+} from '@gratis-gis/shared-types';
 import {
   DEFAULT_ARCGIS_SERVICE,
   DEFAULT_DATA_LAYER,
+  DEFAULT_DERIVED_LAYER,
   DEFAULT_MAP,
+  isDerivedLayerData,
 } from '@gratis-gis/shared-types';
 import { ImageUploader } from '@/components/image-uploader';
+import { DerivedLayerBuilder } from './new/derived-layer-builder';
 
 type Mode =
   | { kind: 'create' }
@@ -37,6 +45,13 @@ interface Props {
       | 'license'
     >
   >;
+  /**
+   * Optional pre-loaded `data` blob, surfaced in edit mode for item
+   * types that have an inline recipe editor here (currently
+   * `derived_layer`). Untyped on the way in so this prop can carry any
+   * item type's data; consumers narrow against the type before reading.
+   */
+  initialData?: unknown;
   /** Item id in edit mode, used as a stable seed for the fallback badge. */
   itemId?: string;
 }
@@ -148,11 +163,17 @@ const accessOptions: Array<{
 ];
 
 /**
- * Create/edit form for item metadata. Data payload is not edited here
- * type-specific editors (map authoring, form designer, etc.) ship with
- * their respective pillars. On create, the payload defaults to {}.
+ * Create/edit form for item metadata. Most type-specific editors ship
+ * with their respective pillars (map authoring, form designer, etc.).
+ * Derived layers are an exception: the recipe (source + pipeline) is
+ * structural to the item's identity, so the same builder used in the
+ * new-item wizard is rendered inline here on the edit page so a saved
+ * derived layer can have its source or pipeline changed without a
+ * separate UI surface. The backend's PATCH handler re-runs
+ * `validateAndEnrich` whenever `data` is included in the body, so the
+ * cached `outputSchema` and `bbox` stay in sync.
  */
-export function ItemForm({ mode, initialValues, itemId }: Props) {
+export function ItemForm({ mode, initialValues, initialData, itemId }: Props) {
   const router = useRouter();
   const [pending, startTransition] = useTransition();
   const [submitting, setSubmitting] = useState(false);
@@ -192,6 +213,20 @@ export function ItemForm({ mode, initialValues, itemId }: Props) {
   const [licenseCustom, setLicenseCustom] = useState<string>(
     initialPreset ? '' : initialLicense,
   );
+
+  // Derived-layer recipe state. Only consulted when type is
+  // `derived_layer` and the form is in edit mode; for create flows the
+  // wizard owns the builder. We seed from `initialData` when it looks
+  // like a valid recipe and fall back to the default scaffold so the
+  // builder always has a coherent value to render. The original recipe
+  // (stringified) is captured once so submit can decide whether `data`
+  // is actually dirty and should be sent in the PATCH body.
+  const initialDerivedLayer: DerivedLayerData = isDerivedLayerData(initialData)
+    ? initialData
+    : DEFAULT_DERIVED_LAYER;
+  const [derivedLayerData, setDerivedLayerData] =
+    useState<DerivedLayerData>(initialDerivedLayer);
+  const initialDerivedLayerJson = JSON.stringify(initialDerivedLayer);
 
   function parseTags(raw: string): string[] {
     return raw
@@ -239,6 +274,34 @@ export function ItemForm({ mode, initialValues, itemId }: Props) {
             : type === 'arcgis_service'
               ? DEFAULT_ARCGIS_SERVICE
               : {};
+    } else if (type === 'derived_layer') {
+      // Only attach `data` to the PATCH when the recipe actually
+      // changed. The backend re-runs validateAndEnrich whenever `data`
+      // is present, which loads the source layer and recomputes the
+      // schema, so omitting it on metadata-only edits keeps those
+      // edits cheap and side-steps the case where the source is
+      // currently inaccessible (a metadata-only save would otherwise
+      // 400 on enrichment for no good reason).
+      const nextJson = JSON.stringify(derivedLayerData);
+      if (nextJson !== initialDerivedLayerJson) {
+        // Mirror the wizard's create-time guards. Catching this on
+        // the client gives a friendlier error than the backend's
+        // "derived_layer.source.itemId is required" 400.
+        if (!derivedLayerData.source?.itemId) {
+          setError('Pick a source data layer for this derived layer.');
+          setSubmitting(false);
+          return;
+        }
+        if (
+          !Array.isArray(derivedLayerData.pipeline) ||
+          derivedLayerData.pipeline.length === 0
+        ) {
+          setError('Add at least one tool step to the pipeline.');
+          setSubmitting(false);
+          return;
+        }
+        payload.data = derivedLayerData;
+      }
     }
 
     const url =
@@ -472,6 +535,23 @@ export function ItemForm({ mode, initialValues, itemId }: Props) {
           </p>
         ) : null}
       </section>
+
+      {/* Derived-layer recipe editor. Mirrors the wizard's inline
+          builder so editing parity matches creation parity: source
+          and pipeline can be changed from the same UI a user already
+          knows. The backend re-enriches outputSchema and bbox on
+          save, so this surface stays purely structural. */}
+      {mode.kind === 'edit' && type === 'derived_layer' ? (
+        <section>
+          <label className="mb-2 block text-xs font-medium uppercase tracking-wide text-muted">
+            Recipe
+          </label>
+          <DerivedLayerBuilder
+            value={derivedLayerData}
+            onChange={setDerivedLayerData}
+          />
+        </section>
+      ) : null}
 
       {error ? (
         <div

--- a/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
+++ b/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
@@ -15,10 +15,17 @@ import {
   X,
 } from 'lucide-react';
 import {
+  DEFAULT_BUFFER_STEP,
   DEFAULT_DERIVED_LAYER_FEATURE_LIMIT,
+  LENGTH_UNITS,
   MAX_BUFFER_DISTANCE_METERS,
+  METERS_PER_UNIT,
+  UNIT_LABELS,
+  type BufferParams,
   type DerivedLayerData,
+  type FeatureField,
   type Item,
+  type LengthUnit,
   type ToolStep,
 } from '@gratis-gis/shared-types';
 
@@ -49,40 +56,30 @@ export function DerivedLayerBuilder({
   // rather than via a "pick a tool" intermediate step. When more
   // tools land, this becomes a tool selector and per-tool form
   // fragments.
-  //
-  // Default buffer distance shown in the input on first render.
-  // Pulled into a constant so the seed-on-mount effect below and
-  // the input value derivation agree on the same number.
-  const DEFAULT_BUFFER_DISTANCE = 100;
   const bufferStep = value.pipeline.find(
     (s): s is Extract<ToolStep, { tool: 'buffer' }> => s.tool === 'buffer',
   );
-  const bufferDistance = bufferStep?.params.distance ?? DEFAULT_BUFFER_DISTANCE;
+  const bufferParams: BufferParams =
+    bufferStep?.params ?? DEFAULT_BUFFER_STEP.params;
 
   // Seed the pipeline with a default buffer step the moment the
   // builder mounts. Without this, the input shows "100" via the
-  // `?? DEFAULT_BUFFER_DISTANCE` fallback but `value.pipeline` stays
-  // empty until the user edits the field, which causes the wizard's
-  // "at least one step" guard to (correctly) reject the submit even
-  // though the form looks filled in.
+  // default fallback but `value.pipeline` stays empty until the user
+  // edits the field, which causes the wizard's "at least one step"
+  // guard to (correctly) reject the submit even though the form
+  // looks filled in.
   useEffect(() => {
     if (value.pipeline.length === 0) {
       onChange({
         ...value,
-        pipeline: [
-          {
-            tool: 'buffer',
-            params: { distance: DEFAULT_BUFFER_DISTANCE, unit: 'meters' },
-          },
-        ],
+        pipeline: [DEFAULT_BUFFER_STEP],
       });
     }
     // We deliberately depend only on the pipeline length so this
     // effect doesn't re-fire on every keystroke that mutates
     // `value`. The intent is "ensure a step exists at startup or
-    // after a reset"; per-keystroke mutations go through
-    // `setBufferDistance` instead.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // after a reset"; per-keystroke mutations go through the
+    // setBuffer* helpers instead.
   }, [value.pipeline.length]);
 
   const setSourceItem = useCallback(
@@ -99,22 +96,130 @@ export function DerivedLayerBuilder({
     [value, onChange],
   );
 
-  const setBufferDistance = useCallback(
-    (distance: number) => {
-      const safe =
-        Number.isFinite(distance) && distance > 0
-          ? Math.min(distance, MAX_BUFFER_DISTANCE_METERS)
-          : 0;
-      const next: ToolStep = {
-        tool: 'buffer',
-        params: { distance: safe, unit: 'meters' },
-      };
+  // Lookup the source's schema once a source is selected, so the
+  // field-mode picker can list numeric fields. Best-effort: if the
+  // fetch fails, the field selector falls back to a "no fields
+  // available" empty state and the user can switch to fixed mode.
+  const [sourceFields, setSourceFields] = useState<FeatureField[]>([]);
+  useEffect(() => {
+    if (!value.source.itemId) {
+      setSourceFields([]);
+      return;
+    }
+    let cancelled = false;
+    fetch(`/api/portal/items/${value.source.itemId}`)
+      .then(async (r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json() as Promise<Item>;
+      })
+      .then((it) => {
+        if (cancelled) return;
+        setSourceFields(extractFields(it.data, value.source.layerKey));
+      })
+      .catch(() => {
+        if (!cancelled) setSourceFields([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [value.source.itemId, value.source.layerKey]);
+
+  // Helper: write a new buffer params object back into the recipe.
+  // The pipeline is a one-element list in v1, so this is a single-
+  // step replace; the call sites below pass the params they want
+  // committed (post-clamping) and we wrap in the ToolStep envelope.
+  const setBufferParams = useCallback(
+    (params: BufferParams) => {
       onChange({
         ...value,
-        pipeline: [next],
+        pipeline: [{ tool: 'buffer', params }],
       });
     },
     [value, onChange],
+  );
+
+  const setBufferMode = useCallback(
+    (mode: 'fixed' | 'field') => {
+      if (mode === bufferParams.mode) return;
+      // Preserve the unit across mode switches so a user who chose
+      // "kilometers" doesn't have to re-pick when toggling to field
+      // mode and back. Other fields reset to sensible defaults.
+      if (mode === 'fixed') {
+        setBufferParams({
+          mode: 'fixed',
+          distance: 100,
+          unit: bufferParams.unit,
+        });
+      } else {
+        // Pre-pick the first numeric field if one is available; the
+        // user can change it. Without a default the picker shows a
+        // placeholder until they make a choice.
+        const firstNumeric = sourceFields.find((f) => f.type === 'number');
+        setBufferParams({
+          mode: 'field',
+          field: firstNumeric?.name ?? '',
+          unit: bufferParams.unit,
+          // cachedMaxMeters is server-computed at save time; the
+          // wizard always sends 0 and the API replaces it.
+          cachedMaxMeters: 0,
+        });
+      }
+    },
+    [bufferParams, sourceFields, setBufferParams],
+  );
+
+  const setBufferDistance = useCallback(
+    (distance: number) => {
+      if (bufferParams.mode !== 'fixed') return;
+      // Clamp the user-typed value to the meters ceiling, expressed
+      // in the chosen unit. A user typing "999" with unit=miles
+      // shouldn't sail past 100 km; converting to meters first keeps
+      // the cap absolute.
+      const meters = Number.isFinite(distance)
+        ? distance * METERS_PER_UNIT[bufferParams.unit]
+        : 0;
+      const cappedMeters = Math.max(0, Math.min(meters, MAX_BUFFER_DISTANCE_METERS));
+      const safe = cappedMeters / METERS_PER_UNIT[bufferParams.unit];
+      setBufferParams({
+        mode: 'fixed',
+        distance: safe,
+        unit: bufferParams.unit,
+      });
+    },
+    [bufferParams, setBufferParams],
+  );
+
+  const setBufferUnit = useCallback(
+    (unit: LengthUnit) => {
+      if (bufferParams.mode === 'fixed') {
+        setBufferParams({
+          mode: 'fixed',
+          distance: bufferParams.distance,
+          unit,
+        });
+      } else {
+        setBufferParams({
+          mode: 'field',
+          field: bufferParams.field,
+          unit,
+          cachedMaxMeters: 0,
+        });
+      }
+    },
+    [bufferParams, setBufferParams],
+  );
+
+  const setBufferField = useCallback(
+    (field: string) => {
+      if (bufferParams.mode !== 'field') return;
+      setBufferParams({
+        mode: 'field',
+        field,
+        unit: bufferParams.unit,
+        cachedMaxMeters: 0,
+      });
+    },
+    [bufferParams, setBufferParams],
   );
 
   const setFeatureLimit = useCallback(
@@ -176,29 +281,92 @@ export function DerivedLayerBuilder({
           Tool: Buffer
         </h4>
         <p className="text-xs text-muted">
-          Expand each feature outward by a fixed distance. The result
-          is a polygon layer that lines up with the source's halo on
-          every map read.
+          Expand each feature outward into a polygon halo. Distance
+          can be a fixed value applied to every feature, or read from
+          a numeric field on each row so different features get
+          different buffers.
         </p>
-        <label className="flex flex-col gap-1 text-sm">
-          <span className="text-ink-1">Distance</span>
-          <span className="flex items-center gap-2">
-            <input
-              type="number"
-              min={1}
-              max={MAX_BUFFER_DISTANCE_METERS}
-              step={1}
-              value={bufferDistance}
-              onChange={(e) => setBufferDistance(Number(e.target.value))}
-              className="h-10 w-32 rounded-md border border-border bg-surface-0 px-3 text-sm text-ink-0 focus:border-accent focus:outline-none"
-            />
-            <span className="text-sm text-muted">meters</span>
-          </span>
-        </label>
-        <p className="text-[11px] text-muted">
-          Up to {MAX_BUFFER_DISTANCE_METERS.toLocaleString()} m. Other
-          units arrive when the reproject tool ships.
-        </p>
+        <div
+          className="grid grid-cols-2 gap-2"
+          role="radiogroup"
+          aria-label="Buffer distance source"
+        >
+          <button
+            type="button"
+            role="radio"
+            aria-checked={bufferParams.mode === 'fixed'}
+            onClick={() => setBufferMode('fixed')}
+            className={`flex flex-col items-start gap-0.5 rounded-md border p-2.5 text-left transition-colors ${
+              bufferParams.mode === 'fixed'
+                ? 'border-accent bg-accent/5 ring-2 ring-accent/30'
+                : 'border-border bg-surface-0 hover:bg-surface-2'
+            }`}
+          >
+            <span className="text-sm font-medium text-ink-1">Fixed</span>
+            <span className="text-[11px] text-muted">
+              The same distance for every feature.
+            </span>
+          </button>
+          <button
+            type="button"
+            role="radio"
+            aria-checked={bufferParams.mode === 'field'}
+            onClick={() => setBufferMode('field')}
+            disabled={!value.source.itemId}
+            title={
+              !value.source.itemId
+                ? 'Pick a source layer first to see its numeric fields'
+                : undefined
+            }
+            className={`flex flex-col items-start gap-0.5 rounded-md border p-2.5 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${
+              bufferParams.mode === 'field'
+                ? 'border-accent bg-accent/5 ring-2 ring-accent/30'
+                : 'border-border bg-surface-0 hover:bg-surface-2'
+            }`}
+          >
+            <span className="text-sm font-medium text-ink-1">From a field</span>
+            <span className="text-[11px] text-muted">
+              Read the distance from a numeric column on each row.
+            </span>
+          </button>
+        </div>
+
+        {bufferParams.mode === 'fixed' ? (
+          <label className="flex flex-col gap-1 pt-1 text-sm">
+            <span className="text-ink-1">Distance</span>
+            <span className="flex items-center gap-2">
+              <input
+                type="number"
+                min={0}
+                step={1}
+                value={
+                  Number.isFinite(bufferParams.distance)
+                    ? bufferParams.distance
+                    : 0
+                }
+                onChange={(e) => setBufferDistance(Number(e.target.value))}
+                className="h-10 w-32 rounded-md border border-border bg-surface-0 px-3 text-sm text-ink-0 focus:border-accent focus:outline-none"
+              />
+              <UnitSelect
+                value={bufferParams.unit}
+                onChange={setBufferUnit}
+              />
+            </span>
+            <span className="text-[11px] text-muted">
+              Up to {MAX_BUFFER_DISTANCE_METERS.toLocaleString()} m. Try
+              kilometers, feet, yards, or miles.
+            </span>
+          </label>
+        ) : (
+          <FieldModeControls
+            sourceFields={sourceFields}
+            field={bufferParams.field}
+            unit={bufferParams.unit}
+            onFieldChange={setBufferField}
+            onUnitChange={setBufferUnit}
+            sourcePicked={Boolean(value.source.itemId)}
+          />
+        )}
       </section>
 
       <section className="space-y-2">
@@ -648,4 +816,140 @@ function SourceLayerPicker({
       ) : null}
     </div>
   );
+}
+
+/**
+ * Lightweight `<select>` for picking a length unit. Pulls the option
+ * list from `LENGTH_UNITS` (shared-types) so a new unit added there
+ * shows up here automatically. Sized small enough to live inline next
+ * to a numeric input without dominating the row.
+ */
+function UnitSelect({
+  value,
+  onChange,
+}: {
+  value: LengthUnit;
+  onChange: (u: LengthUnit) => void;
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value as LengthUnit)}
+      className="h-10 rounded-md border border-border bg-surface-0 px-2 text-sm text-ink-0 focus:border-accent focus:outline-none"
+    >
+      {LENGTH_UNITS.map((u) => (
+        <option key={u} value={u}>
+          {u} ({UNIT_LABELS[u]})
+        </option>
+      ))}
+    </select>
+  );
+}
+
+/**
+ * Field-mode controls for the buffer step: a numeric-field picker
+ * plus a unit dropdown. The picker is filtered to `type: 'number'`
+ * fields off the source's schema; non-numeric fields are not eligible
+ * because the SQL pipeline can't divide a string by a unit factor.
+ *
+ * The user is NOT asked for a maximum distance. The server queries
+ * MAX(field) at recipe-save time and stamps `cachedMaxMeters` on the
+ * recipe (see docs/derived-layers.md). That cap drives bbox padding
+ * and per-row clamping in SQL.
+ */
+function FieldModeControls({
+  sourceFields,
+  field,
+  unit,
+  onFieldChange,
+  onUnitChange,
+  sourcePicked,
+}: {
+  sourceFields: FeatureField[];
+  field: string;
+  unit: LengthUnit;
+  onFieldChange: (name: string) => void;
+  onUnitChange: (u: LengthUnit) => void;
+  sourcePicked: boolean;
+}) {
+  const numericFields = sourceFields.filter((f) => f.type === 'number');
+  return (
+    <div className="space-y-2 pt-1">
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-ink-1">Numeric field</span>
+        <select
+          value={field}
+          onChange={(e) => onFieldChange(e.target.value)}
+          disabled={!sourcePicked || numericFields.length === 0}
+          className="h-10 rounded-md border border-border bg-surface-0 px-3 text-sm text-ink-0 focus:border-accent focus:outline-none disabled:opacity-60"
+        >
+          {field === '' ? (
+            <option value="">
+              {!sourcePicked
+                ? 'Pick a source layer first'
+                : numericFields.length === 0
+                  ? 'No numeric fields on the source'
+                  : 'Pick a numeric field…'}
+            </option>
+          ) : null}
+          {numericFields.map((f) => (
+            <option key={f.name} value={f.name}>
+              {f.label || f.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-ink-1">Unit</span>
+        <UnitSelect value={unit} onChange={onUnitChange} />
+        <span className="text-[11px] text-muted">
+          The field's stored value is interpreted in this unit. The
+          server figures out the upper bound by reading the largest
+          value when the recipe saves.
+        </span>
+      </label>
+
+      {sourcePicked && numericFields.length === 0 ? (
+        <p className="text-[11px] text-amber-700">
+          The selected source has no numeric fields. Add a numeric
+          column to the source layer or switch to fixed mode.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * Pull the FeatureField list from a data_layer item's `data` blob,
+ * narrowing to the requested sublayer when one is given. Tolerant
+ * of malformed shapes: returns `[]` for anything we don't recognize
+ * so the field-mode picker degrades to "no fields available" rather
+ * than crashing the wizard.
+ */
+function extractFields(data: unknown, layerKey: string | undefined): FeatureField[] {
+  if (!data || typeof data !== 'object') return [];
+  const d = data as { version?: unknown; layers?: unknown; fields?: unknown };
+  if (Array.isArray(d.layers)) {
+    const layers = d.layers as Array<{
+      id?: string;
+      fields?: FeatureField[];
+    }>;
+    if (layerKey) {
+      const match = layers.find((l) => l.id === layerKey);
+      return Array.isArray(match?.fields) ? match!.fields : [];
+    }
+    // No layerKey: a v3 source with exactly one spatial layer is the
+    // common single-layer case; surface its fields. Otherwise we
+    // can't pick on the user's behalf without ambiguity, so return
+    // nothing.
+    if (layers.length === 1 && Array.isArray(layers[0]?.fields)) {
+      return layers[0]!.fields ?? [];
+    }
+    return [];
+  }
+  if (Array.isArray(d.fields)) {
+    return d.fields as FeatureField[];
+  }
+  return [];
 }

--- a/packages/shared-types/src/derived-layer.ts
+++ b/packages/shared-types/src/derived-layer.ts
@@ -18,6 +18,7 @@
  */
 
 import type { FeatureField } from './data-layer';
+import type { LengthUnit } from './length';
 
 /**
  * v1 always points at a single data_layer item. Stored as a tagged
@@ -37,22 +38,52 @@ export interface DerivedLayerSource {
 }
 
 /**
- * Buffer tool step. Expands every input geometry outward by `distance`
- * meters using PostGIS `ST_Buffer(geom::geography, distance)`. The
- * `geography` cast keeps distance correct globally regardless of
- * longitude.
+ * Buffer tool step. Expands every input geometry outward using PostGIS
+ * `ST_Buffer(geom::geography, distanceMeters)`. The `geography` cast
+ * keeps distance correct globally regardless of longitude.
+ *
+ * Distance can come from one of two places:
+ *   - `mode: 'fixed'` applies the same `distance` (interpreted in
+ *     `unit`) to every input feature.
+ *   - `mode: 'field'` reads a per-feature distance from the named
+ *     numeric field on the source schema, interpreted in `unit`. The
+ *     server stamps `cachedMaxMeters` at recipe-save time by querying
+ *     the source's MAX of that field, so the read path can pad the
+ *     bbox correctly without inspecting source rows on every call.
  */
+export type BufferParams =
+  | {
+      mode: 'fixed';
+      /** Buffer distance in `unit`. Must be a finite number > 0. */
+      distance: number;
+      unit: LengthUnit;
+    }
+  | {
+      mode: 'field';
+      /**
+       * Name of a field on the source schema whose value supplies the
+       * per-feature buffer distance. Must reference a `type: 'number'`
+       * FeatureField. NULL or non-numeric row values produce NULL
+       * geometry (skipped by the read path's `WHERE geom IS NOT NULL`).
+       */
+      field: string;
+      /** Unit the field's stored value is interpreted in. */
+      unit: LengthUnit;
+      /**
+       * Server-computed cap on the per-feature buffer in meters,
+       * derived from the source's MAX of `field` at recipe-save time.
+       * Drives bbox padding on the read path and clamps each feature's
+       * buffer in SQL so a stray oversized value can't generate a
+       * planet-spanning geometry. Persisted on the recipe; the wizard
+       * never asks the user for it. Stale-when-source-grows is
+       * acknowledged in v1; see docs/derived-layers.md.
+       */
+      cachedMaxMeters: number;
+    };
+
 export interface BufferStep {
   tool: 'buffer';
-  params: {
-    /** Buffer distance in `unit`. Must be a finite number > 0. */
-    distance: number;
-    /**
-     * v1 ships meters only. Other units arrive when reprojection
-     * lands as a separate tool; the union widens then.
-     */
-    unit: 'meters';
-  };
+  params: BufferParams;
 }
 
 /**
@@ -122,6 +153,17 @@ export const DEFAULT_DERIVED_LAYER_FEATURE_LIMIT = 1000;
  * enforces a matching ceiling (see backend `bufferGenerator`).
  */
 export const MAX_BUFFER_DISTANCE_METERS = 100_000;
+
+/**
+ * Default buffer step the wizard emits on first mount: 100 meters,
+ * fixed mode. Lifted into shared-types so the new-item wizard, the
+ * edit page builder, and any test that wants to seed a sane recipe
+ * agree on the same starting point.
+ */
+export const DEFAULT_BUFFER_STEP: BufferStep = {
+  tool: 'buffer',
+  params: { mode: 'fixed', distance: 100, unit: 'meters' },
+};
 
 /**
  * Empty scaffold for a brand-new derived layer. The wizard fills

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -15,6 +15,7 @@ export * from './user';
 export * from './item';
 export * from './map';
 export * from './data-layer';
+export * from './length';
 export * from './derived-layer';
 export * from './arcgis-service';
 export * from './pick-list';

--- a/packages/shared-types/src/length.ts
+++ b/packages/shared-types/src/length.ts
@@ -1,0 +1,84 @@
+/**
+ * Length units shared across UI surfaces and SQL emission. Used by
+ * tools that take a distance parameter (currently `buffer`; future
+ * `simplify`, `distance-to-nearest`).
+ *
+ * The canonical internal unit is meters: PostGIS `geography` distance
+ * is in meters, the bbox-padding helper expects meters, and the cap
+ * constant `MAX_BUFFER_DISTANCE_METERS` is meters. UI surfaces preserve
+ * the user's chosen unit so a recipe authored in "5 km" round-trips
+ * through save / reload as "5 km" rather than "5000 m". Converting to
+ * meters happens at SQL emission time using `metersFor(value, unit)`.
+ *
+ * The factors are international definitions (1 ft = 0.3048 m exactly,
+ * 1 mi = 1609.344 m). Survey-foot variants are 6 ppm different, which
+ * is irrelevant for buffer-distance use cases.
+ */
+
+export type LengthUnit =
+  | 'meters'
+  | 'kilometers'
+  | 'feet'
+  | 'yards'
+  | 'miles';
+
+/**
+ * Meters in one unit of `LengthUnit`. Multiply by a value in that unit
+ * to get meters; divide a meters value to get the unit value.
+ */
+export const METERS_PER_UNIT: Record<LengthUnit, number> = {
+  meters: 1,
+  kilometers: 1000,
+  feet: 0.3048,
+  yards: 0.9144,
+  miles: 1609.344,
+};
+
+/**
+ * Short, human-friendly labels for each unit. Used by the recipe
+ * detail panel and any other UI that summarizes a stored distance
+ * without re-reading the unit name verbatim.
+ */
+export const UNIT_LABELS: Record<LengthUnit, string> = {
+  meters: 'm',
+  kilometers: 'km',
+  feet: 'ft',
+  yards: 'yd',
+  miles: 'mi',
+};
+
+/**
+ * Convert a value in `unit` to meters. Pure; no rounding. Returns the
+ * input when `unit === 'meters'` so the common case is a no-op rather
+ * than a multiplication by 1.
+ */
+export function metersFor(value: number, unit: LengthUnit): number {
+  if (unit === 'meters') return value;
+  return value * METERS_PER_UNIT[unit];
+}
+
+/**
+ * Type guard for incoming JSON: narrows an unknown string to a
+ * `LengthUnit`. Used by validators to reject unknown unit names with
+ * a useful message.
+ */
+export function isLengthUnit(value: unknown): value is LengthUnit {
+  return (
+    typeof value === 'string' &&
+    Object.prototype.hasOwnProperty.call(METERS_PER_UNIT, value)
+  );
+}
+
+/**
+ * Ordered list of all units, useful for building a `<select>` so the
+ * UI doesn't drift away from the type definition. Order is
+ * meters -> kilometers -> feet -> yards -> miles, biggest-metric to
+ * biggest-imperial, which matches what GIS users expect.
+ */
+export const LENGTH_UNITS: ReadonlyArray<LengthUnit> = [
+  'meters',
+  'kilometers',
+  'feet',
+  'yards',
+  'miles',
+];


### PR DESCRIPTION
The buffer tool's field mode caches the source's MAX(field) at recipe-save time and trusts that cap thereafter. Inserting or updating a row whose value exceeds the cap silently makes the cap stale: reads keep returning rows but the bbox padding is too small, so buffer halos near tile edges clip until the derived layer is re-saved.
A new DerivedLayerCacheRefreshService closes that gap. Feature write paths call notifySourceWrite after a successful insert or update with the new properties payload. The service walks every derived layer that points at the source and buffers on a key in the payload, compares each row's value (in meters via the recipe unit) to the cached cap, and grows the cap when a row exceeds it. The recipe's cachedMaxMeters and the derived layer's bbox are recomputed and persisted in a single Prisma update.
Three deliberate properties: grow-only (the cap never shrinks; over-padding is correctness-safe), best-effort (errors are logged, never thrown back so a feature write can't be rolled back by a cache problem), and narrow filter (only field-mode buffer steps whose field key is in the payload trigger any work).
Wired into both write surfaces. v3 features: insertFeatures and updateFeature call notifySourceWrite after the SQL completes. v2 features: bulkInsert, replaceAll, and updateFeature follow the same pattern. v2 has no sublayer concept so the hook's layerKey is null. Both features modules now import DerivedLayersModule.
16 new tests covering the pure helper (growCachedCaps) and the service path (happy-path update with bbox repad, source-mismatch filtering, v3 layerKey discrimination, empty-payload short-circuit, error swallowing, multi-dependent fan-out).
Note for reviewers: the staleness hook fires void notifySourceWrite(...) from each write path, so cache work runs without blocking the user response. Trade-off is that if the process exits during shutdown before the promise settles, that one cache update is lost. Easy to flip to await if you want strict determinism.
Stacked on top of #PR1 (feat/derived-layer-edit-and-buffer-modes).