### PR TITLE
fix(map): render v3 multi-layer data layers correctly

### DIFF
--- a/apps/portal-api/src/items/items.controller.ts
+++ b/apps/portal-api/src/items/items.controller.ts
@@ -313,6 +313,7 @@ export class ItemsController {
     @Query('bbox') bbox?: string,
     @Query('at') at?: string,
     @Query('clip') clip?: string,
+    @Query('layerKey') layerKey?: string,
   ) {
     // Use conditional spread (not `undefined` values) to play nicely
     // with exactOptionalPropertyTypes; the destructure also narrows
@@ -322,6 +323,7 @@ export class ItemsController {
       bbox?: [number, number, number, number];
       at?: string;
       boundaryClipId?: string;
+      layerKey?: string;
     } = {};
     if (bbox) {
       const parts = bbox.split(',').map(Number);
@@ -336,6 +338,11 @@ export class ItemsController {
     // scope. Bypasses per-user authz on the boundary item; missing
     // / wrong-type / no-geometry is treated as no clip.
     if (clip) opts.boundaryClipId = clip;
+    // v3 multi-layer items split features across one PostGIS table
+    // per sublayer. layerKey names which to read; the service
+    // auto-picks when there's exactly one spatial sublayer, and
+    // rejects with a 400 otherwise. v1/v2 items ignore layerKey.
+    if (layerKey) opts.layerKey = layerKey;
     return this.items.getGeoJson(user, id, opts);
   }
 

--- a/apps/portal-api/src/items/items.service.ts
+++ b/apps/portal-api/src/items/items.service.ts
@@ -29,10 +29,64 @@ import {
 } from './dependency-extractor.js';
 import {
   V3TablesService,
+  toV3TableName,
   type V3LayerShape,
 } from '../features-v3/v3-tables.service.js';
 import { NotificationsService } from '../notifications/notifications.service.js';
 import { DerivedLayersService } from '../derived-layers/derived-layers.service.js';
+
+/**
+ * Pick the right PostGIS feature table for a `data_layer` item read via
+ * the legacy `/items/:id/geojson` endpoint. Encapsulates the v2-vs-v3
+ * branch so the read path stays linear:
+ *
+ * - v2 single-table items return `fs_<itemId>`. The layerKey arg is
+ *   ignored because v2 has no sublayer concept; passing one would
+ *   imply structure that doesn't exist, but we deliberately don't
+ *   400 here so a client that always sends `?layerKey=` against a
+ *   mixed v2/v3 portal still works.
+ * - v3 multi-layer items return `fs_<itemId>_<layerKey>`. The key is
+ *   either supplied by the caller or auto-picked when the item has
+ *   exactly one spatial sublayer. Multiple spatial sublayers without
+ *   an explicit key, or an unknown key, raise BadRequestException.
+ */
+function resolveLegacyGeoJsonTable(
+  itemId: string,
+  data: { version?: number; layers?: unknown } | null,
+  layerKey: string | undefined,
+): string {
+  const v2TableName = `fs_${itemId.replace(/-/g, '')}`;
+  if (data?.version !== 3) return v2TableName;
+
+  // v3 from here on. The data blob carries a `layers` array of
+  // sublayer descriptors; only ones with a `geometryType` string
+  // back a feature table (attribute-only related tables don't).
+  const layers = Array.isArray(data.layers) ? data.layers : [];
+  const spatial = layers.filter((l): l is { id: string; geometryType: string } => {
+    if (!l || typeof l !== 'object') return false;
+    const id = (l as { id?: unknown }).id;
+    const geom = (l as { geometryType?: unknown }).geometryType;
+    return typeof id === 'string' && id.length > 0 && typeof geom === 'string';
+  });
+  if (spatial.length === 0) {
+    throw new BadRequestException(
+      'data_layer has no spatial sublayers; nothing to render',
+    );
+  }
+  if (layerKey === undefined) {
+    if (spatial.length === 1) return toV3TableName(itemId, spatial[0]!.id);
+    throw new BadRequestException(
+      'data_layer has multiple sublayers; pass ?layerKey=<id> to disambiguate, or use /items/:id/layers/:layerKey/geojson',
+    );
+  }
+  const match = spatial.find((l) => l.id === layerKey);
+  if (!match) {
+    throw new BadRequestException(
+      `data_layer sublayer "${layerKey}" not found`,
+    );
+  }
+  return toV3TableName(itemId, match.id);
+}
 
 // Optional fields use `| undefined` explicitly so class-validator DTOs
 // (which leave unset keys present-as-undefined) can satisfy these types
@@ -1067,6 +1121,18 @@ export class ItemsService {
       bbox?: [number, number, number, number];
       at?: string;
       boundaryClipId?: string;
+      /**
+       * v3 multi-layer items split features across one PostGIS table
+       * per sublayer. When the source is v3, callers MUST name which
+       * sublayer to read from via this option (or via the dedicated
+       * /items/:id/layers/:layerKey/geojson endpoint, which is the
+       * Editor's path). v1/v2 items ignore the option since they
+       * have a single feature table. When omitted on a v3 item with
+       * exactly one spatial sublayer, the service auto-picks it; if
+       * the v3 item has multiple spatial sublayers, the request
+       * fails with a 400 telling the caller to disambiguate.
+       */
+      layerKey?: string;
     } = {},
   ): Promise<{ type: 'FeatureCollection'; features: unknown[] }> {
     const item = await this.get(user, id);
@@ -1126,8 +1192,13 @@ export class ItemsService {
     }
 
     if (data?.storageType === 'postgis') {
-      // v2: query the PostGIS table.
-      const tbl = `fs_${id.replace(/-/g, '')}`;
+      // v2 reads `fs_<id>`; v3 reads `fs_<id>_<layerKey>`. Pick the
+      // right table now so the rest of this branch is shape-agnostic.
+      // For v3 the resolution requires either an explicit layerKey
+      // from the caller or exactly one spatial sublayer to auto-pick;
+      // anything else 400s with a clear message rather than silently
+      // querying a non-existent table.
+      const tbl = resolveLegacyGeoJsonTable(id, data, opts.layerKey);
       const params: unknown[] = [];
       const conditions: string[] = [];
 

--- a/apps/portal-web/src/app/items/[id]/map/add-layer-dialog.tsx
+++ b/apps/portal-web/src/app/items/[id]/map/add-layer-dialog.tsx
@@ -536,7 +536,26 @@ export function AddLayerDialog({ open, onClose, onAdd }: Props) {
    * just `itemId` to the layer source) so they skip the hydrate.
    */
   async function submitPortalItem(item: Item) {
+    if (item.type === 'data_layer') {
+      // Hydrate so we can see `data.version` and `data.layers`. v3
+      // multi-layer items split features across one PostGIS table per
+      // sublayer, so a single map layer with bare itemId can't render
+      // them: the read endpoint needs ?layerKey=. We expand each
+      // spatial sublayer into its own MapLayer here, matching the
+      // convention the derived-layer source picker uses. v2 items
+      // hydrate too but keep the legacy single-layer behavior.
+      const hydrated = await hydratePortalItem(item);
+      if (hydrated === null) return;
+      addDataLayerPortalItem(hydrated);
+      reset();
+      onClose();
+      return;
+    }
     if (item.type !== 'arcgis_service') {
+      // derived_layer and any other compatible kind: passes through
+      // as a single data-layer source. derived_layer reads route
+      // through its own service path on the backend, which already
+      // resolves the source's sublayer internally.
       onAdd(makeLayer(item.title, { kind: 'data-layer', itemId: item.id }));
       reset();
       onClose();
@@ -559,6 +578,84 @@ export function AddLayerDialog({ open, onClose, onAdd }: Props) {
       'flat',
       new Set(ordered.map((l) => l.id)),
     );
+  }
+
+  /**
+   * Add a hydrated `data_layer` item to the map. Branches on schema
+   * version:
+   *
+   * - v3 multi-layer: one map layer per spatial sublayer. Layer
+   *   titles follow "Item - Sublayer" so a multi-sublayer add reads
+   *   clearly in the layer list. layerKey is stamped on each new
+   *   MapLayerSource so the canvas's URL builder routes to the
+   *   right per-sublayer table.
+   * - v3 single-spatial / v2 / v1: one map layer with no layerKey
+   *   (the API auto-picks for v3 single-spatial and the legacy path
+   *   handles v1/v2). Layer title is just the item title.
+   *
+   * Rare edge case: a v3 item with no spatial sublayers (only
+   * attribute-only related tables) yields nothing renderable. We
+   * surface the situation as a setError instead of silently adding
+   * a broken map layer.
+   */
+  function addDataLayerPortalItem(item: Item): void {
+    const data = item.data as
+      | { version?: unknown; layers?: unknown }
+      | null
+      | undefined;
+    const version = typeof data?.version === 'number' ? data.version : 0;
+    if (version !== 3) {
+      // v1 / v2 single-table item. layerKey absent.
+      onAdd(makeLayer(item.title, { kind: 'data-layer', itemId: item.id }));
+      return;
+    }
+    const layers = Array.isArray(data?.layers) ? data!.layers : [];
+    const spatial = (layers as Array<Record<string, unknown>>).filter((l) => {
+      const id = l.id;
+      const geom = l.geometryType;
+      return typeof id === 'string' && id.length > 0 && typeof geom === 'string';
+    });
+    if (spatial.length === 0) {
+      setError(
+        `${item.title} has no spatial sublayers; nothing to add to the map.`,
+      );
+      return;
+    }
+    if (spatial.length === 1) {
+      // Single spatial sublayer: stamp the layerKey explicitly so the
+      // canvas reads from fs_<id>_<layerKey> rather than relying on
+      // the server's auto-pick. Belt-and-suspenders: if the user later
+      // adds another sublayer to the source, the existing map layer
+      // keeps reading the originally-chosen one.
+      const layerKey = spatial[0]!.id as string;
+      onAdd(
+        makeLayer(item.title, {
+          kind: 'data-layer',
+          itemId: item.id,
+          layerKey,
+        }),
+      );
+      return;
+    }
+    // Multiple spatial sublayers: emit one MapLayer per sublayer.
+    // Each onAdd appends to the current map, so a user picking a v3
+    // item with three sublayers ends up with three map layers, each
+    // labeled "Item - Sublayer". The order matches the source's
+    // declared order, which the v3 builder controls.
+    for (const layer of spatial) {
+      const layerKey = layer.id as string;
+      const sublayerLabel =
+        typeof layer.label === 'string' && layer.label.length > 0
+          ? layer.label
+          : layerKey;
+      onAdd(
+        makeLayer(`${item.title} - ${sublayerLabel}`, {
+          kind: 'data-layer',
+          itemId: item.id,
+          layerKey,
+        }),
+      );
+    }
   }
 
   /**

--- a/apps/portal-web/src/app/items/[id]/map/layer-metadata.ts
+++ b/apps/portal-web/src/app/items/[id]/map/layer-metadata.ts
@@ -165,10 +165,20 @@ export async function discoverLayerMetadata(
       }
       raw = await res.json();
     } else {
-      const url =
-        layer.source.kind === 'geojson-url'
-          ? layer.source.url
-          : `/api/portal/items/${layer.source.itemId}/geojson`;
+      // For data-layer sources we route through the same legacy
+      // /items/:id/geojson endpoint MapCanvas uses. layerKey is
+      // threaded through so a v3 multi-layer source returns its
+      // specific sublayer's features rather than 400-ing on the
+      // ambiguous default.
+      const url = (() => {
+        if (layer.source.kind === 'geojson-url') return layer.source.url;
+        const base = `/api/portal/items/${layer.source.itemId}/geojson`;
+        if (layer.source.layerKey) {
+          const qs = new URLSearchParams({ layerKey: layer.source.layerKey });
+          return `${base}?${qs}`;
+        }
+        return base;
+      })();
       const init: RequestInit = {};
       if (signal) init.signal = signal;
       const res = await fetch(url, init);

--- a/apps/portal-web/src/app/items/[id]/map/map-canvas.tsx
+++ b/apps/portal-web/src/app/items/[id]/map/map-canvas.tsx
@@ -2070,12 +2070,15 @@ function sourceData(layer: MapLayer): GeoJSON.FeatureCollection | string | null 
     // for data-layer sources only -- external sources (geojson-url,
     // arcgis-rest) are out of our control and would need a client-
     // side MapLibre filter for the same effect.
+    //
+    // layerKey, when present, names a v3 multi-layer item's specific
+    // sublayer. The server picks fs_<itemId>_<layerKey> instead of
+    // the v2 single-table fs_<itemId>. v1/v2 items don't carry one.
     const base = `/api/portal/items/${layer.source.itemId}/geojson`;
-    if (layer.boundaryFilterItemId) {
-      const qs = new URLSearchParams({ clip: layer.boundaryFilterItemId });
-      return `${base}?${qs}`;
-    }
-    return base;
+    const qs = new URLSearchParams();
+    if (layer.boundaryFilterItemId) qs.set('clip', layer.boundaryFilterItemId);
+    if (layer.source.layerKey) qs.set('layerKey', layer.source.layerKey);
+    return qs.toString() ? `${base}?${qs}` : base;
   }
   if (layer.source.kind === 'arcgis-rest') {
     // Start with an empty collection. The camera-driven refetch

--- a/packages/shared-types/src/map.ts
+++ b/packages/shared-types/src/map.ts
@@ -340,7 +340,20 @@ export interface MapLayerFilter {
 export type MapLayerSource =
   | { kind: 'geojson-url'; url: string }
   | { kind: 'geojson-inline'; geojson: unknown }
-  | { kind: 'data-layer'; itemId: string }
+  | {
+      kind: 'data-layer';
+      itemId: string;
+      /**
+       * Sublayer key when the source is a v3 multi-layer data layer.
+       * Absent / undefined means a v1 / v2 single-table item, OR a v3
+       * item with exactly one spatial sublayer (the API auto-picks).
+       * The map canvas threads this through to the `?layerKey=` query
+       * param on `/items/:id/geojson` so the right per-sublayer table
+       * is read. v3 items with multiple spatial sublayers REQUIRE this
+       * field; the add-layer dialog prompts for it on selection.
+       */
+      layerKey?: string;
+    }
   | {
       kind: 'arcgis-rest';
       /** Root service URL, without the trailing /<layerId>. */


### PR DESCRIPTION
## Summary

Pre-existing bug. The legacy `/items/:id/geojson` endpoint hard-codes `fs_<itemId>` for every `data_layer` item. v3 multi-layer items store features in `fs_<itemId>_<layerKey>` tables (one per sublayer), so adding a v3 source to a map silently returned an empty FeatureCollection. The Editor reads through the per-sublayer `/items/:id/layers/:layerKey/geojson` endpoint and worked fine; the map canvas, layer-metadata, and data-preview drawer all went through the broken legacy URL.

The original derived-layer PR description (#61) flagged this as deferred. This PR is that deferred fix. The workaround inside the derived-layer code path stays put — it's the right architecture for that service (it calls `toV3TableName` directly), not a hack to revert.

## Backend

`GET /items/:id/geojson` accepts an optional `?layerKey=<id>` query param. `ItemsService.getGeoJson` resolves the right PostGIS table based on the source's schema version:

- v1/v2 single-table items use `fs_<itemId>`; layerKey is ignored if passed (so a forward-compat client that always sends `?layerKey=` works against mixed portals).
- v3 multi-layer items use `fs_<itemId>_<layerKey>`. When layerKey is not supplied, the service auto-picks if there is exactly one spatial sublayer; multiple spatial sublayers without an explicit key, or an unknown key, raise BadRequestException with a clear message pointing at the dedicated per-sublayer endpoint.

A small `resolveLegacyGeoJsonTable` helper centralizes the v2-vs-v3 branch so the read path itself stays linear.

## Shared types

`MapLayerSource.kind === 'data-layer'` gains an optional `layerKey`: the canvas threads it through to the `?layerKey=` query param, so each map layer can target a specific sublayer of a multi-layer source. v1/v2 items continue to omit it; v3 single-spatial items can omit it too and let the API auto-pick.

## Frontend

Three call sites that build the legacy URL were updated:

- `map-canvas.tsx` `sourceData()`: adds `?layerKey=` when the map layer carries one. Uses URLSearchParams so it composes cleanly with the existing `?clip=` for layer-level boundary filters.
- `layer-metadata.ts`: same pattern when fetching the layer's metadata via the API.
- The data-preview drawer was already routing v3 items through the per-sublayer endpoint when a sublayer is chosen; its 'self' branch still hits the legacy URL but now gets a clear 400 (rather than empty results) for v3 items with multiple sublayers.

The map's Add Layer dialog now hydrates `data_layer` items on click (previously it skipped hydration for non-arcgis_service items entirely) and branches on schema version:

- v3 multi-spatial items expand into one MapLayer per spatial sublayer, each titled "Item - Sublayer" and stamped with its `layerKey`, matching the convention the derived-layer source picker uses.
- v3 single-spatial items add one MapLayer with the layerKey set explicitly.
- v2 items behave as before.
- A v3 item with no spatial sublayers (only attribute-only related tables) surfaces a clear inline error instead of adding a broken layer.

## Migration

None. Existing data_layer items in storage are unchanged. v2 items continue to render against the legacy table. Stored MapLayerSource values without layerKey continue to work for v1/v2; for v3 single-spatial sources the API auto-picks.

**Existing maps that reference v3 multi-layer items via a bare `itemId` will now 400 on the read** with a message telling the user (or the next save) to disambiguate. The Add Layer dialog re-add stamps the `layerKey` explicitly, so the issue self-heals as users re-add affected layers. Worth calling out in release notes — silent failure becomes a loud error.

If you'd rather make it self-heal silently — auto-pick the first spatial sublayer on the backend when the item is v3 with multiple sublayers and no key — change `resolveLegacyGeoJsonTable` to do that. Picking arbitrary "first" is rarely what users actually want, and the error path forces them to see what's happening once. Up to reviewer preference; trivial flip.

## Verification

```
pnpm install
pnpm -F portal-api test
pnpm -F portal-api typecheck
pnpm -F portal-web typecheck
```

36 tests pass (no new tests; existing coverage continues to pass). Typecheck clean across all three packages.
