### PR TITLE
feat(derived-layers): eleven new tools, toolbox modal, fishnet safety check

### DIFF
--- a/apps/portal-api/src/derived-layers/cache-refresh.service.spec.ts
+++ b/apps/portal-api/src/derived-layers/cache-refresh.service.spec.ts
@@ -1,14 +1,31 @@
 import type { Item } from '@prisma/client';
 import {
+  type BufferParams,
   type BufferStep,
   type DerivedLayerData,
   type FeatureField,
+  type ToolStep,
 } from '@gratis-gis/shared-types';
 
 import {
   DerivedLayerCacheRefreshService,
   growCachedCaps,
 } from './cache-refresh.service.js';
+
+/**
+ * Narrow a generic ToolStep down to its BufferParams. The ToolStep
+ * union now spans a dozen tool kinds, several of which carry no
+ * `mode` discriminator at all, so accessing `step.params.mode` from
+ * outside this narrowing is a TS error. The tests below use this
+ * helper to assert "this step is a buffer" once and then read the
+ * buffer-specific params freely.
+ */
+function bufferParamsOf(step: ToolStep): BufferParams {
+  if (step.tool !== 'buffer') {
+    throw new Error(`expected a buffer step; got ${step.tool}`);
+  }
+  return step.params;
+}
 
 const NUMBER_FIELD: FeatureField = {
   name: 'radius_m',
@@ -66,7 +83,7 @@ describe('growCachedCaps', () => {
     const r = recipe([fieldStep('radius_m', 'meters', 100)]);
     const next = growCachedCaps(r, [{ radius_m: 250 }]);
     expect(next).not.toBeNull();
-    const params = next!.pipeline[0]!.params;
+    const params = bufferParamsOf(next!.pipeline[0]!);
     expect(params.mode === 'field' ? params.cachedMaxMeters : null).toBe(250);
   });
 
@@ -77,7 +94,7 @@ describe('growCachedCaps', () => {
       { radius_m: 999 },
       { radius_m: 50 },
     ]);
-    const params = next!.pipeline[0]!.params;
+    const params = bufferParamsOf(next!.pipeline[0]!);
     expect(params.mode === 'field' ? params.cachedMaxMeters : null).toBe(999);
   });
 
@@ -85,7 +102,7 @@ describe('growCachedCaps', () => {
     // Recipe stores radius in feet; payload value is 1000 ft = 304.8 m.
     const r = recipe([fieldStep('radius_m', 'feet', 100)]);
     const next = growCachedCaps(r, [{ radius_m: 1000 }]);
-    const params = next!.pipeline[0]!.params;
+    const params = bufferParamsOf(next!.pipeline[0]!);
     if (params.mode !== 'field') throw new Error('expected field mode');
     expect(params.cachedMaxMeters).toBeCloseTo(304.8, 4);
   });
@@ -94,7 +111,7 @@ describe('growCachedCaps', () => {
     // 100 km recipe unit, payload 1000 km = 1_000_000 m, ceiling 100_000 m.
     const r = recipe([fieldStep('radius_m', 'kilometers', 50_000)]);
     const next = growCachedCaps(r, [{ radius_m: 1000 }]);
-    const params = next!.pipeline[0]!.params;
+    const params = bufferParamsOf(next!.pipeline[0]!);
     if (params.mode !== 'field') throw new Error('expected field mode');
     expect(params.cachedMaxMeters).toBe(100_000);
   });
@@ -113,7 +130,7 @@ describe('growCachedCaps', () => {
   it('coerces numeric strings ("250") to numbers', () => {
     const r = recipe([fieldStep('radius_m', 'meters', 100)]);
     const next = growCachedCaps(r, [{ radius_m: '250' }]);
-    const params = next!.pipeline[0]!.params;
+    const params = bufferParamsOf(next!.pipeline[0]!);
     expect(params.mode === 'field' ? params.cachedMaxMeters : null).toBe(250);
   });
 
@@ -128,7 +145,7 @@ describe('growCachedCaps', () => {
       distance: 50,
       unit: 'meters',
     });
-    const second = next!.pipeline[1]!.params;
+    const second = bufferParamsOf(next!.pipeline[1]!);
     if (second.mode !== 'field') throw new Error('expected field mode');
     expect(second.cachedMaxMeters).toBe(250);
   });
@@ -186,7 +203,7 @@ describe('DerivedLayerCacheRefreshService.notifySourceWrite', () => {
     expect(updates).toHaveLength(1);
     const u = updates[0]! as { where: { id: string }; data: { data: DerivedLayerData; bbox: number[] } };
     expect(u.where.id).toBe('der-1');
-    const params = u.data.data.pipeline[0]!.params;
+    const params = bufferParamsOf(u.data.data.pipeline[0]!);
     expect(params.mode === 'field' ? params.cachedMaxMeters : null).toBe(250);
     // bbox repad happens too: the new total reach is 250 m, so the
     // padded bbox is wider than the source bbox.

--- a/apps/portal-api/src/derived-layers/derived-layers.service.ts
+++ b/apps/portal-api/src/derived-layers/derived-layers.service.ts
@@ -12,13 +12,17 @@ import { toV3TableName } from '../features-v3/v3-tables.service.js';
 import { getGeneratorForStep } from './tools/registry.js';
 
 /**
- * Maximum allowed pipeline length. Long pipelines are inherently
- * suspect (each step is a sub-CTE; planning cost climbs) and v1's
- * single tool gives no reason to need more than a handful. Easy to
- * lift later. Set high enough that legitimate stacking (a future
- * `simplify -> buffer -> dissolve`) doesn't bump into it.
+ * Maximum allowed pipeline length. Each step is a separate CTE in
+ * the chained read SQL, so planning cost and peak materialization
+ * memory both grow with step count. Ten covers any realistic recipe
+ * with headroom (a typical chained workflow is 3-6 steps), trips
+ * before a runaway client can post a thousand-step pipeline, and
+ * keeps the user-facing complexity bounded. The per-tool runtime
+ * caps (MAX_BUFFER_DISTANCE_METERS, MAX_CELLS_PER_RECIPE,
+ * featureLimit) are the load-bearing safety nets; this one is the
+ * "are you sure?" check.
  */
-const MAX_PIPELINE_STEPS = 8;
+const MAX_PIPELINE_STEPS = 10;
 
 /**
  * Hard cap on the user-overridable feature limit. The default sits

--- a/apps/portal-api/src/derived-layers/tools/bbox.spec.ts
+++ b/apps/portal-api/src/derived-layers/tools/bbox.spec.ts
@@ -1,0 +1,58 @@
+import { BadRequestException } from '@nestjs/common';
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import { bboxGenerator } from './bbox.js';
+
+const FIELDS: FeatureField[] = [
+  { name: 'name', label: 'Name', type: 'string', nullable: false },
+];
+
+describe('bboxGenerator.validate', () => {
+  it('accepts an empty params object', () => {
+    expect(bboxGenerator.validate({})).toEqual({});
+  });
+
+  it('rejects non-objects', () => {
+    expect(() => bboxGenerator.validate(null)).toThrow(BadRequestException);
+    expect(() => bboxGenerator.validate([])).toThrow(BadRequestException);
+  });
+});
+
+describe('bboxGenerator.outputSchema', () => {
+  it('passes through every attribute', () => {
+    expect(bboxGenerator.outputSchema(FIELDS, {})).toBe(FIELDS);
+  });
+});
+
+describe('bboxGenerator.outwardReachMeters', () => {
+  it('returns 0', () => {
+    expect(bboxGenerator.outwardReachMeters({})).toBe(0);
+  });
+});
+
+describe('bboxGenerator.extractDependencies', () => {
+  it('returns no references', () => {
+    expect(bboxGenerator.extractDependencies({})).toEqual({
+      itemIds: [],
+      urls: [],
+    });
+  });
+});
+
+describe('bboxGenerator.toSql', () => {
+  it('emits ST_Envelope per row, SRID-wrapped', () => {
+    const fragment = bboxGenerator.toSql('source', {}, 0);
+    expect(fragment.sql).toMatch(/ST_Envelope\(geom\)/);
+    expect(fragment.sql).toMatch(/ST_SetSRID\(/);
+    expect(fragment.sql).toMatch(/4326/);
+    expect(fragment.sql).toMatch(/FROM source/);
+    expect(fragment.sql).toMatch(/WHERE geom IS NOT NULL/);
+  });
+
+  it('returns no params and ignores paramOffset', () => {
+    expect(bboxGenerator.toSql('source', {}, 0).params).toEqual([]);
+    const offset = bboxGenerator.toSql('step_3', {}, 5);
+    expect(offset.params).toEqual([]);
+    expect(offset.sql).not.toMatch(/\$/);
+  });
+});

--- a/apps/portal-api/src/derived-layers/tools/bbox.ts
+++ b/apps/portal-api/src/derived-layers/tools/bbox.ts
@@ -1,0 +1,55 @@
+import { BadRequestException } from '@nestjs/common';
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import type { ToolGenerator } from './types.js';
+
+/**
+ * Validated bbox params. v1 has no fields.
+ */
+export type BboxParams = Record<string, never>;
+
+/**
+ * Bounding-box generator. Replaces each input geometry with its
+ * axis-aligned envelope via `ST_Envelope(geom)`. Output is polygon
+ * (PostGIS produces a closed rectangle). Attributes pass through.
+ *
+ * Useful for "show me the extent of each parcel" workflows and as
+ * a cheap stand-in when full feature geometry is heavy and only
+ * the rectangle matters (e.g. clustering by extent overlap).
+ */
+export const bboxGenerator: ToolGenerator<BboxParams> = {
+  kind: 'bbox',
+
+  validate(raw: unknown): BboxParams {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new BadRequestException('bbox.params must be an object');
+    }
+    return {} as BboxParams;
+  },
+
+  outputSchema(input: FeatureField[]): FeatureField[] {
+    return input;
+  },
+
+  outwardReachMeters(): number {
+    // The envelope contains the input geometry; it can never extend
+    // outward beyond the input's own bbox.
+    return 0;
+  },
+
+  extractDependencies(): { itemIds: string[]; urls: string[] } {
+    return { itemIds: [], urls: [] };
+  },
+
+  toSql(inputAlias: string) {
+    const sql = `
+      SELECT
+        global_id,
+        ST_SetSRID(ST_Envelope(geom), 4326) AS geom,
+        properties
+      FROM ${inputAlias}
+      WHERE geom IS NOT NULL
+    `;
+    return { sql, params: [] };
+  },
+};

--- a/apps/portal-api/src/derived-layers/tools/calculate-geometry.spec.ts
+++ b/apps/portal-api/src/derived-layers/tools/calculate-geometry.spec.ts
@@ -1,0 +1,231 @@
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import { calculateGeometryGenerator } from './calculate-geometry.js';
+
+const FIELDS: FeatureField[] = [
+  { name: 'name', label: 'Name', type: 'string', nullable: false },
+];
+
+describe('calculateGeometryGenerator.validate', () => {
+  it('accepts an area-mode shape', () => {
+    expect(
+      calculateGeometryGenerator.validate({
+        measurement: 'area',
+        unit: 'hectares',
+        fieldName: 'parcel_ha',
+      }),
+    ).toEqual({ measurement: 'area', unit: 'hectares', fieldName: 'parcel_ha' });
+  });
+
+  it('accepts a length-mode shape', () => {
+    expect(
+      calculateGeometryGenerator.validate({
+        measurement: 'length',
+        unit: 'kilometers',
+        fieldName: 'length_km',
+      }),
+    ).toEqual({
+      measurement: 'length',
+      unit: 'kilometers',
+      fieldName: 'length_km',
+    });
+  });
+
+  it('accepts a perimeter-mode shape', () => {
+    expect(
+      calculateGeometryGenerator.validate({
+        measurement: 'perimeter',
+        unit: 'meters',
+        fieldName: 'perimeter_m',
+      }),
+    ).toEqual({
+      measurement: 'perimeter',
+      unit: 'meters',
+      fieldName: 'perimeter_m',
+    });
+  });
+
+  it('rejects unknown measurement', () => {
+    expect(() =>
+      calculateGeometryGenerator.validate({
+        measurement: 'volume',
+        unit: 'meters',
+        fieldName: 'x',
+      }),
+    ).toThrow(/'length', 'perimeter', or 'area'/);
+  });
+
+  it('rejects an area unit on length / perimeter', () => {
+    expect(() =>
+      calculateGeometryGenerator.validate({
+        measurement: 'length',
+        unit: 'hectares',
+        fieldName: 'x',
+      }),
+    ).toThrow(/length/);
+  });
+
+  it('rejects a length unit on area', () => {
+    expect(() =>
+      calculateGeometryGenerator.validate({
+        measurement: 'area',
+        unit: 'meters',
+        fieldName: 'x',
+      }),
+    ).toThrow(/area/);
+  });
+
+  it('rejects a missing or empty fieldName', () => {
+    expect(() =>
+      calculateGeometryGenerator.validate({
+        measurement: 'area',
+        unit: 'square-meters',
+      }),
+    ).toThrow(/fieldName is required/);
+    expect(() =>
+      calculateGeometryGenerator.validate({
+        measurement: 'area',
+        unit: 'square-meters',
+        fieldName: '',
+      }),
+    ).toThrow(/fieldName is required/);
+  });
+
+  it('rejects an invalid identifier-shaped fieldName', () => {
+    expect(() =>
+      calculateGeometryGenerator.validate({
+        measurement: 'area',
+        unit: 'square-meters',
+        fieldName: '1bad',
+      }),
+    ).toThrow(/start with a letter or underscore/);
+    expect(() =>
+      calculateGeometryGenerator.validate({
+        measurement: 'area',
+        unit: 'square-meters',
+        fieldName: 'has-dash',
+      }),
+    ).toThrow(/letters, numbers, and underscores/);
+  });
+
+  it('rejects reserved field names', () => {
+    expect(() =>
+      calculateGeometryGenerator.validate({
+        measurement: 'area',
+        unit: 'square-meters',
+        fieldName: '_global_id',
+      }),
+    ).toThrow(/reserved/);
+  });
+
+  it('rejects a fieldName that already exists on the source schema', () => {
+    expect(() =>
+      calculateGeometryGenerator.validate(
+        {
+          measurement: 'area',
+          unit: 'square-meters',
+          fieldName: 'name',
+        },
+        { sourceSchema: FIELDS },
+      ),
+    ).toThrow(/already exists on the source schema/);
+  });
+
+  it('skips the schema clash check when no context is provided (read-time path)', () => {
+    expect(
+      calculateGeometryGenerator.validate({
+        measurement: 'area',
+        unit: 'square-meters',
+        fieldName: 'name',
+      }),
+    ).toEqual({
+      measurement: 'area',
+      unit: 'square-meters',
+      fieldName: 'name',
+    });
+  });
+});
+
+describe('calculateGeometryGenerator.outputSchema', () => {
+  it('appends the new field to the input schema', () => {
+    const out = calculateGeometryGenerator.outputSchema(FIELDS, {
+      measurement: 'area',
+      unit: 'hectares',
+      fieldName: 'area_ha',
+    });
+    expect(out).toHaveLength(2);
+    expect(out[1]).toEqual({
+      name: 'area_ha',
+      label: 'area_ha',
+      type: 'number',
+      nullable: true,
+    });
+  });
+});
+
+describe('calculateGeometryGenerator.outwardReachMeters', () => {
+  it('returns 0', () => {
+    expect(
+      calculateGeometryGenerator.outwardReachMeters({
+        measurement: 'area',
+        unit: 'square-meters',
+        fieldName: 'x',
+      }),
+    ).toBe(0);
+  });
+});
+
+describe('calculateGeometryGenerator.toSql', () => {
+  it('uses ST_Area on geography for area mode', () => {
+    const fragment = calculateGeometryGenerator.toSql(
+      'source',
+      { measurement: 'area', unit: 'hectares', fieldName: 'area_ha' },
+      0,
+    );
+    expect(fragment.sql).toMatch(/ST_Area\(source\.geom::geography\)/);
+    // 1 hectare = 10_000 m^2; the conversion factor is the divisor.
+    expect(fragment.params).toEqual(['area_ha', 10_000]);
+  });
+
+  it('uses ST_Length on geography for length mode', () => {
+    const fragment = calculateGeometryGenerator.toSql(
+      'source',
+      { measurement: 'length', unit: 'kilometers', fieldName: 'len_km' },
+      0,
+    );
+    expect(fragment.sql).toMatch(/ST_Length\(source\.geom::geography\)/);
+    expect(fragment.params).toEqual(['len_km', 1000]);
+  });
+
+  it('uses ST_Length(ST_Boundary(...)) for perimeter mode', () => {
+    const fragment = calculateGeometryGenerator.toSql(
+      'source',
+      { measurement: 'perimeter', unit: 'meters', fieldName: 'perim' },
+      0,
+    );
+    expect(fragment.sql).toMatch(
+      /ST_Length\(ST_Boundary\(source\.geom\)::geography\)/,
+    );
+    expect(fragment.params).toEqual(['perim', 1]);
+  });
+
+  it('merges the new field into properties via jsonb_build_object', () => {
+    const fragment = calculateGeometryGenerator.toSql(
+      'source',
+      { measurement: 'area', unit: 'square-meters', fieldName: 'area_m2' },
+      0,
+    );
+    expect(fragment.sql).toMatch(/jsonb_build_object\(\s*\$1/);
+  });
+
+  it('honors paramOffset', () => {
+    const fragment = calculateGeometryGenerator.toSql(
+      'step_2',
+      { measurement: 'area', unit: 'square-meters', fieldName: 'a' },
+      4,
+    );
+    expect(fragment.sql).toMatch(/\$5/);
+    expect(fragment.sql).toMatch(/\$6/);
+    expect(fragment.sql).not.toMatch(/\$1\b/);
+  });
+});

--- a/apps/portal-api/src/derived-layers/tools/calculate-geometry.ts
+++ b/apps/portal-api/src/derived-layers/tools/calculate-geometry.ts
@@ -1,0 +1,214 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  METERS_PER_UNIT,
+  SQ_METERS_PER_AREA_UNIT,
+  isAreaUnit,
+  isLengthUnit,
+  type AreaUnit,
+  type CalculateGeometryParams,
+  type FeatureField,
+  type LengthUnit,
+} from '@gratis-gis/shared-types';
+
+import type { ToolGenerator, ToolValidateContext } from './types.js';
+
+/**
+ * Maximum length of a user-chosen field name. Generous enough for
+ * descriptive names ("hectares_in_county") while preventing
+ * pathological inputs that could blow up the JSONB blob.
+ */
+const MAX_FIELD_NAME_LENGTH = 60;
+
+/**
+ * Field names that are reserved for system metadata (the editor
+ * tracking columns, the v3 underscore-prefixed identifiers). Reject
+ * these at validate time so a user can't accidentally clobber the
+ * properties bag's reserved keys.
+ */
+const RESERVED_FIELD_NAMES = new Set<string>([
+  '_global_id',
+  '_created_by',
+  '_created_at',
+  '_edited_by',
+  '_edited_at',
+  'global_id',
+]);
+
+/**
+ * Calculate-geometry generator. Adds one numeric attribute to each
+ * row carrying the input geometry's length / perimeter / area in
+ * the user-chosen unit, with a user-chosen column name.
+ *
+ * Computation runs on geography (which returns meters / square
+ * meters globally) and converts to the chosen unit at SQL time so
+ * the persisted column matches what the user typed.
+ *
+ * Length is `ST_Length` over geography (lines and the boundary of
+ * polygons in geography give meaningful answers; the SQL doesn't
+ * gate on geometryType so a polygon-input length yields the
+ * polygon's perimeter, which is sometimes what users want). For
+ * stricter "polygon perimeter" semantics there's a `perimeter`
+ * mode that explicitly applies ST_Boundary first.
+ *
+ * Area is `ST_Area` over geography. Square units are converted via
+ * `SQ_METERS_PER_AREA_UNIT`; hectares and acres are first-class
+ * units, which is the conventional ask for parcels and field
+ * surveying.
+ */
+export const calculateGeometryGenerator: ToolGenerator<CalculateGeometryParams> =
+  {
+    kind: 'calculate-geometry',
+
+    validate(raw: unknown, ctx?: ToolValidateContext): CalculateGeometryParams {
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+        throw new BadRequestException(
+          'calculate-geometry.params must be an object',
+        );
+      }
+      const r = raw as Record<string, unknown>;
+
+      const measurement = r.measurement;
+      if (
+        measurement !== 'length' &&
+        measurement !== 'perimeter' &&
+        measurement !== 'area'
+      ) {
+        throw new BadRequestException(
+          "calculate-geometry.params.measurement must be 'length', 'perimeter', or 'area'",
+        );
+      }
+
+      const fieldName = r.fieldName;
+      if (typeof fieldName !== 'string' || fieldName.length === 0) {
+        throw new BadRequestException(
+          'calculate-geometry.params.fieldName is required',
+        );
+      }
+      if (fieldName.length > MAX_FIELD_NAME_LENGTH) {
+        throw new BadRequestException(
+          `calculate-geometry.params.fieldName must be ${MAX_FIELD_NAME_LENGTH} characters or fewer`,
+        );
+      }
+      if (!/^[a-z_][a-z0-9_]*$/i.test(fieldName)) {
+        throw new BadRequestException(
+          'calculate-geometry.params.fieldName must start with a letter or underscore and contain only letters, numbers, and underscores',
+        );
+      }
+      if (RESERVED_FIELD_NAMES.has(fieldName)) {
+        throw new BadRequestException(
+          `calculate-geometry.params.fieldName "${fieldName}" is reserved`,
+        );
+      }
+      // Reject field names that already exist on the upstream schema.
+      // Quietly overwriting a source column would be confusing; a
+      // user who wants to overwrite can rename the existing field
+      // first, or pick a different output name. Read-time validate
+      // skips the schema check (we trust the persisted shape).
+      if (ctx?.sourceSchema) {
+        const clash = ctx.sourceSchema.find((f) => f.name === fieldName);
+        if (clash) {
+          throw new BadRequestException(
+            `calculate-geometry.params.fieldName "${fieldName}" already exists on the source schema; pick a different name`,
+          );
+        }
+      }
+
+      if (measurement === 'area') {
+        if (!isAreaUnit(r.unit)) {
+          throw new BadRequestException(
+            "calculate-geometry.params.unit must be one of square-meters / square-kilometers / hectares / square-feet / square-yards / acres / square-miles for area",
+          );
+        }
+        return {
+          measurement: 'area',
+          unit: r.unit,
+          fieldName,
+        };
+      }
+
+      // length / perimeter share LengthUnit
+      if (!isLengthUnit(r.unit)) {
+        throw new BadRequestException(
+          "calculate-geometry.params.unit must be one of meters / kilometers / feet / yards / miles for length",
+        );
+      }
+      return {
+        measurement,
+        unit: r.unit,
+        fieldName,
+      };
+    },
+
+    outputSchema(
+      input: FeatureField[],
+      params: CalculateGeometryParams,
+    ): FeatureField[] {
+      // Append the new field. Label uses the field name itself as a
+      // start; the user can edit the label later via the data-layer
+      // editor (the recipe is just the field's source-of-truth, the
+      // label's pretty form lives downstream).
+      return [
+        ...input,
+        {
+          name: params.fieldName,
+          label: params.fieldName,
+          type: 'number',
+          nullable: true,
+        },
+      ];
+    },
+
+    outwardReachMeters(): number {
+      // Geometry passes through unchanged.
+      return 0;
+    },
+
+    extractDependencies(): { itemIds: string[]; urls: string[] } {
+      return { itemIds: [], urls: [] };
+    },
+
+    toSql(
+      inputAlias: string,
+      params: CalculateGeometryParams,
+      paramOffset: number,
+    ) {
+      const fieldPh = `$${paramOffset + 1}`;
+      const factorPh = `$${paramOffset + 2}`;
+
+      // SQL chooses the right PostGIS function per measurement. All
+      // three branches use geography for accurate-on-Earth values:
+      // ST_Length and ST_Area on geography return meters / square
+      // meters; the unit factor is divided in to convert to the
+      // user's chosen unit.
+      let measurementSql: string;
+      let factor: number;
+      if (params.measurement === 'area') {
+        measurementSql = `ST_Area(${inputAlias}.geom::geography)`;
+        factor = SQ_METERS_PER_AREA_UNIT[params.unit as AreaUnit];
+      } else if (params.measurement === 'perimeter') {
+        // Apply ST_Boundary first so a polygon's "length" is its
+        // perimeter rather than implicit-cast behavior. For line /
+        // multi-line input this yields the line's endpoints (a
+        // multipoint), and ST_Length over a multipoint geography is
+        // 0 -- a sane no-op.
+        measurementSql = `ST_Length(ST_Boundary(${inputAlias}.geom)::geography)`;
+        factor = METERS_PER_UNIT[params.unit as LengthUnit];
+      } else {
+        measurementSql = `ST_Length(${inputAlias}.geom::geography)`;
+        factor = METERS_PER_UNIT[params.unit as LengthUnit];
+      }
+
+      const sql = `
+        SELECT
+          ${inputAlias}.global_id,
+          ${inputAlias}.geom,
+          ${inputAlias}.properties || jsonb_build_object(
+            ${fieldPh},
+            (${measurementSql}) / ${factorPh}::double precision
+          ) AS properties
+        FROM ${inputAlias}
+        WHERE ${inputAlias}.geom IS NOT NULL
+      `;
+      return { sql, params: [params.fieldName, factor] };
+    },
+  };

--- a/apps/portal-api/src/derived-layers/tools/centroid.spec.ts
+++ b/apps/portal-api/src/derived-layers/tools/centroid.spec.ts
@@ -1,0 +1,83 @@
+import { BadRequestException } from '@nestjs/common';
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import { centroidGenerator } from './centroid.js';
+
+const FIELDS: FeatureField[] = [
+  { name: 'name', label: 'Name', type: 'string', nullable: false },
+  { name: 'pop', label: 'Pop', type: 'number', nullable: true },
+];
+
+describe('centroidGenerator.validate', () => {
+  it('accepts an empty params object', () => {
+    expect(centroidGenerator.validate({})).toEqual({});
+  });
+
+  it('tolerates extra keys for forward compat', () => {
+    expect(centroidGenerator.validate({ note: 'ignored' })).toEqual({});
+  });
+
+  it('rejects a non-object', () => {
+    expect(() => centroidGenerator.validate(null)).toThrow(BadRequestException);
+    expect(() => centroidGenerator.validate('center')).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('rejects an array', () => {
+    expect(() => centroidGenerator.validate([])).toThrow(BadRequestException);
+  });
+});
+
+describe('centroidGenerator.outputSchema', () => {
+  it('passes through every attribute', () => {
+    expect(centroidGenerator.outputSchema(FIELDS, {})).toBe(FIELDS);
+  });
+});
+
+describe('centroidGenerator.outwardReachMeters', () => {
+  it('returns 0', () => {
+    expect(centroidGenerator.outwardReachMeters({})).toBe(0);
+  });
+});
+
+describe('centroidGenerator.extractDependencies', () => {
+  it('returns no item or url references', () => {
+    expect(centroidGenerator.extractDependencies({})).toEqual({
+      itemIds: [],
+      urls: [],
+    });
+  });
+});
+
+describe('centroidGenerator.toSql', () => {
+  it('emits ST_Centroid over the input alias', () => {
+    const fragment = centroidGenerator.toSql('source', {}, 0);
+    expect(fragment.sql).toMatch(/ST_Centroid\(geom\)/);
+    expect(fragment.sql).toMatch(/FROM source/);
+    expect(fragment.sql).toMatch(/WHERE geom IS NOT NULL/);
+  });
+
+  it('preserves SRID 4326 on the output', () => {
+    const fragment = centroidGenerator.toSql('source', {}, 0);
+    expect(fragment.sql).toMatch(/ST_SetSRID\(/);
+    expect(fragment.sql).toMatch(/4326/);
+  });
+
+  it('passes properties through unchanged', () => {
+    const fragment = centroidGenerator.toSql('source', {}, 0);
+    expect(fragment.sql).toMatch(/\bproperties\b/);
+  });
+
+  it('returns an empty params array', () => {
+    const fragment = centroidGenerator.toSql('source', {}, 0);
+    expect(fragment.params).toEqual([]);
+  });
+
+  it('honors paramOffset by emitting no $N placeholders', () => {
+    const fragment = centroidGenerator.toSql('step_2', {}, 7);
+    expect(fragment.params).toEqual([]);
+    expect(fragment.sql).toMatch(/FROM step_2/);
+    expect(fragment.sql).not.toMatch(/\$/);
+  });
+});

--- a/apps/portal-api/src/derived-layers/tools/centroid.ts
+++ b/apps/portal-api/src/derived-layers/tools/centroid.ts
@@ -1,0 +1,59 @@
+import { BadRequestException } from '@nestjs/common';
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import type { ToolGenerator } from './types.js';
+
+/**
+ * Validated centroid params. v1 has no fields; the type exists so
+ * the generator's signature is unambiguous.
+ */
+export type CentroidParams = Record<string, never>;
+
+/**
+ * Centroid generator. Replaces each input geometry with its
+ * `ST_Centroid(geom)`. Attributes pass through unchanged. Output is
+ * always point geometry regardless of input.
+ *
+ * Useful for "where is the middle of each polygon" workflows
+ * (labeling, density grids, snapping to nearest road, etc).
+ */
+export const centroidGenerator: ToolGenerator<CentroidParams> = {
+  kind: 'centroid',
+
+  validate(raw: unknown): CentroidParams {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new BadRequestException('centroid.params must be an object');
+    }
+    return {} as CentroidParams;
+  },
+
+  outputSchema(input: FeatureField[]): FeatureField[] {
+    // Centroid keeps every attribute. We return the same array so
+    // dashboards / apps that bound to the input keep binding.
+    return input;
+  },
+
+  outwardReachMeters(): number {
+    // A centroid is always strictly INSIDE the input geometry's
+    // bbox, so it can never extend outward. Return 0.
+    return 0;
+  },
+
+  extractDependencies(): { itemIds: string[]; urls: string[] } {
+    return { itemIds: [], urls: [] };
+  },
+
+  toSql(inputAlias: string) {
+    // ST_SetSRID is no-op on already-4326 input but cheap insurance
+    // against a stray spatial-ref drift between Postgres versions.
+    const sql = `
+      SELECT
+        global_id,
+        ST_SetSRID(ST_Centroid(geom), 4326) AS geom,
+        properties
+      FROM ${inputAlias}
+      WHERE geom IS NOT NULL
+    `;
+    return { sql, params: [] };
+  },
+};

--- a/apps/portal-api/src/derived-layers/tools/convex-hull.spec.ts
+++ b/apps/portal-api/src/derived-layers/tools/convex-hull.spec.ts
@@ -1,0 +1,64 @@
+import { BadRequestException } from '@nestjs/common';
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import { convexHullGenerator } from './convex-hull.js';
+
+const FIELDS: FeatureField[] = [
+  { name: 'name', label: 'Name', type: 'string', nullable: false },
+];
+
+describe('convexHullGenerator.validate', () => {
+  it('accepts an empty params object', () => {
+    expect(convexHullGenerator.validate({})).toEqual({});
+  });
+
+  it('rejects non-objects', () => {
+    expect(() => convexHullGenerator.validate(null)).toThrow(
+      BadRequestException,
+    );
+    expect(() => convexHullGenerator.validate([])).toThrow(BadRequestException);
+  });
+});
+
+describe('convexHullGenerator.outputSchema', () => {
+  it('passes through every attribute', () => {
+    expect(convexHullGenerator.outputSchema(FIELDS, {})).toBe(FIELDS);
+  });
+});
+
+describe('convexHullGenerator.outwardReachMeters', () => {
+  it('returns 0', () => {
+    expect(convexHullGenerator.outwardReachMeters({})).toBe(0);
+  });
+});
+
+describe('convexHullGenerator.extractDependencies', () => {
+  it('returns no references', () => {
+    expect(convexHullGenerator.extractDependencies({})).toEqual({
+      itemIds: [],
+      urls: [],
+    });
+  });
+});
+
+describe('convexHullGenerator.toSql', () => {
+  it('emits ST_ConvexHull per row', () => {
+    const fragment = convexHullGenerator.toSql('source', {}, 0);
+    expect(fragment.sql).toMatch(/ST_ConvexHull\(geom\)/);
+    expect(fragment.sql).toMatch(/FROM source/);
+    expect(fragment.sql).toMatch(/WHERE geom IS NOT NULL/);
+  });
+
+  it('preserves SRID 4326', () => {
+    const fragment = convexHullGenerator.toSql('source', {}, 0);
+    expect(fragment.sql).toMatch(/ST_SetSRID\(/);
+    expect(fragment.sql).toMatch(/4326/);
+  });
+
+  it('returns no params and ignores paramOffset', () => {
+    expect(convexHullGenerator.toSql('source', {}, 0).params).toEqual([]);
+    const offset = convexHullGenerator.toSql('step_3', {}, 5);
+    expect(offset.params).toEqual([]);
+    expect(offset.sql).not.toMatch(/\$/);
+  });
+});

--- a/apps/portal-api/src/derived-layers/tools/convex-hull.ts
+++ b/apps/portal-api/src/derived-layers/tools/convex-hull.ts
@@ -1,0 +1,60 @@
+import { BadRequestException } from '@nestjs/common';
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import type { ToolGenerator } from './types.js';
+
+/**
+ * Validated convex-hull params. v1 has no fields; an aggregate
+ * "hull of all input features" mode is a future addition under a
+ * `mode: 'aggregate'` switch alongside the current per-feature
+ * default.
+ */
+export type ConvexHullParams = Record<string, never>;
+
+/**
+ * Convex-hull generator. Replaces each input geometry with its
+ * convex hull via `ST_ConvexHull`. v1 computes per-feature so the
+ * row count and attributes are unchanged: a row that started as a
+ * concave polygon becomes its smallest enclosing convex polygon.
+ *
+ * For point input the hull is the input point (PostGIS returns
+ * a point); for two-point input it's a line; for three-or-more it's
+ * a polygon. Downstream renderers cope because each row carries
+ * whatever PostGIS produced.
+ */
+export const convexHullGenerator: ToolGenerator<ConvexHullParams> = {
+  kind: 'convex-hull',
+
+  validate(raw: unknown): ConvexHullParams {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new BadRequestException('convex-hull.params must be an object');
+    }
+    return {} as ConvexHullParams;
+  },
+
+  outputSchema(input: FeatureField[]): FeatureField[] {
+    return input;
+  },
+
+  outwardReachMeters(): number {
+    // The hull is always contained within the input's bbox, so no
+    // outward expansion.
+    return 0;
+  },
+
+  extractDependencies(): { itemIds: string[]; urls: string[] } {
+    return { itemIds: [], urls: [] };
+  },
+
+  toSql(inputAlias: string) {
+    const sql = `
+      SELECT
+        global_id,
+        ST_SetSRID(ST_ConvexHull(geom), 4326) AS geom,
+        properties
+      FROM ${inputAlias}
+      WHERE geom IS NOT NULL
+    `;
+    return { sql, params: [] };
+  },
+};

--- a/apps/portal-api/src/derived-layers/tools/densify.spec.ts
+++ b/apps/portal-api/src/derived-layers/tools/densify.spec.ts
@@ -1,0 +1,111 @@
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import { densifyGenerator } from './densify.js';
+
+const FIELDS: FeatureField[] = [
+  { name: 'name', label: 'Name', type: 'string', nullable: false },
+];
+
+describe('densifyGenerator.validate', () => {
+  it('accepts a positive maxSegmentLength in meters', () => {
+    expect(
+      densifyGenerator.validate({ maxSegmentLength: 100, unit: 'meters' }),
+    ).toEqual({ maxSegmentLength: 100, unit: 'meters' });
+  });
+
+  it('defaults unit to meters', () => {
+    expect(
+      densifyGenerator.validate({ maxSegmentLength: 100 }),
+    ).toEqual({ maxSegmentLength: 100, unit: 'meters' });
+  });
+
+  it('rejects below the minimum', () => {
+    expect(() =>
+      densifyGenerator.validate({ maxSegmentLength: 0.5, unit: 'meters' }),
+    ).toThrow(/at least 1 meter/);
+  });
+
+  it('rejects above the meters ceiling, including unit-converted', () => {
+    expect(() =>
+      densifyGenerator.validate({
+        maxSegmentLength: 1_000_000,
+        unit: 'meters',
+      }),
+    ).toThrow(/must not exceed/);
+    expect(() =>
+      densifyGenerator.validate({
+        maxSegmentLength: 1000,
+        unit: 'kilometers',
+      }),
+    ).toThrow(/must not exceed/);
+  });
+
+  it('rejects non-numeric maxSegmentLength', () => {
+    expect(() =>
+      densifyGenerator.validate({ maxSegmentLength: '100', unit: 'meters' }),
+    ).toThrow(/finite number/);
+  });
+});
+
+describe('densifyGenerator.outputSchema', () => {
+  it('passes through every attribute', () => {
+    expect(
+      densifyGenerator.outputSchema(FIELDS, {
+        maxSegmentLength: 100,
+        unit: 'meters',
+      }),
+    ).toBe(FIELDS);
+  });
+});
+
+describe('densifyGenerator.outwardReachMeters', () => {
+  it('returns 0 (densify only adds vertices on existing edges)', () => {
+    expect(
+      densifyGenerator.outwardReachMeters({
+        maxSegmentLength: 1000,
+        unit: 'meters',
+      }),
+    ).toBe(0);
+  });
+});
+
+describe('densifyGenerator.toSql', () => {
+  it('emits ST_Segmentize on geography with the parameter in meters', () => {
+    const fragment = densifyGenerator.toSql(
+      'source',
+      { maxSegmentLength: 100, unit: 'meters' },
+      0,
+    );
+    expect(fragment.sql).toMatch(/ST_Segmentize\(geom::geography, \$1\)/);
+    expect(fragment.params).toEqual([100]);
+  });
+
+  it('converts non-meter units to meters', () => {
+    const fragment = densifyGenerator.toSql(
+      'source',
+      { maxSegmentLength: 1, unit: 'kilometers' },
+      0,
+    );
+    expect(fragment.params).toEqual([1000]);
+  });
+
+  it('preserves SRID 4326', () => {
+    const fragment = densifyGenerator.toSql(
+      'source',
+      { maxSegmentLength: 100, unit: 'meters' },
+      0,
+    );
+    expect(fragment.sql).toMatch(/ST_SetSRID\(/);
+    expect(fragment.sql).toMatch(/4326/);
+  });
+
+  it('honors paramOffset', () => {
+    const fragment = densifyGenerator.toSql(
+      'step_1',
+      { maxSegmentLength: 50, unit: 'meters' },
+      4,
+    );
+    expect(fragment.sql).toMatch(/\$5/);
+    expect(fragment.sql).not.toMatch(/\$1\b/);
+  });
+});

--- a/apps/portal-api/src/derived-layers/tools/densify.ts
+++ b/apps/portal-api/src/derived-layers/tools/densify.ts
@@ -1,0 +1,100 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  isLengthUnit,
+  metersFor,
+  type FeatureField,
+  type LengthUnit,
+} from '@gratis-gis/shared-types';
+
+import type { ToolGenerator } from './types.js';
+
+export interface DensifyParams {
+  maxSegmentLength: number;
+  unit: LengthUnit;
+}
+
+/**
+ * Hard cap on the maxSegmentLength a recipe can ask for. Mostly a
+ * safety net: a tiny segment length on a continental line could
+ * generate millions of intermediate vertices and exhaust memory.
+ * 1 meter minimum is also enforced via validate().
+ */
+const MAX_SEGMENT_LENGTH_METERS = 100_000;
+const MIN_SEGMENT_LENGTH_METERS = 1;
+
+/**
+ * Densify generator. Adds intermediate vertices along input lines /
+ * polygon boundaries so no segment exceeds `maxSegmentLength` in
+ * `unit`. Uses `ST_Segmentize(geom::geography, lengthMeters)` so the
+ * spacing is accurate-on-Earth regardless of latitude.
+ *
+ * Useful before reprojection (preserves curves' visual shape across
+ * a CRS change), for smoother along-line interpolation, and as a
+ * preprocessing step for fishnet / vertices on long thin features.
+ *
+ * Point-only input is an effective no-op (a point has no segments);
+ * the SQL still runs and yields the input unchanged.
+ */
+export const densifyGenerator: ToolGenerator<DensifyParams> = {
+  kind: 'densify',
+
+  validate(raw: unknown): DensifyParams {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new BadRequestException('densify.params must be an object');
+    }
+    const r = raw as Record<string, unknown>;
+    const len = r.maxSegmentLength;
+    if (typeof len !== 'number' || !Number.isFinite(len)) {
+      throw new BadRequestException(
+        'densify.params.maxSegmentLength must be a finite number',
+      );
+    }
+    const unit = isLengthUnit(r.unit) ? r.unit : 'meters';
+    const meters = metersFor(len, unit);
+    if (meters < MIN_SEGMENT_LENGTH_METERS) {
+      throw new BadRequestException(
+        `densify.params.maxSegmentLength must be at least ${MIN_SEGMENT_LENGTH_METERS} meter (got ${meters}m)`,
+      );
+    }
+    if (meters > MAX_SEGMENT_LENGTH_METERS) {
+      throw new BadRequestException(
+        `densify.params.maxSegmentLength must not exceed ${MAX_SEGMENT_LENGTH_METERS} meters (got ${meters}m)`,
+      );
+    }
+    return { maxSegmentLength: len, unit };
+  },
+
+  outputSchema(input: FeatureField[]): FeatureField[] {
+    return input;
+  },
+
+  outwardReachMeters(): number {
+    // ST_Segmentize only ADDS vertices on existing edges; the
+    // resulting geometry has the same bbox as the input.
+    return 0;
+  },
+
+  extractDependencies(): { itemIds: string[]; urls: string[] } {
+    return { itemIds: [], urls: [] };
+  },
+
+  toSql(inputAlias: string, params: DensifyParams, paramOffset: number) {
+    // The geography cast interprets the segment length as meters;
+    // the cast back to geometry (SRID 4326) keeps downstream steps
+    // in the SRID every other layer uses.
+    const placeholder = `$${paramOffset + 1}`;
+    const sql = `
+      SELECT
+        global_id,
+        ST_SetSRID(
+          ST_Segmentize(geom::geography, ${placeholder})::geometry,
+          4326
+        ) AS geom,
+        properties
+      FROM ${inputAlias}
+      WHERE geom IS NOT NULL
+    `;
+    const meters = metersFor(params.maxSegmentLength, params.unit);
+    return { sql, params: [meters] };
+  },
+};

--- a/apps/portal-api/src/derived-layers/tools/fishnet.spec.ts
+++ b/apps/portal-api/src/derived-layers/tools/fishnet.spec.ts
@@ -1,0 +1,151 @@
+import { BadRequestException } from '@nestjs/common';
+
+import { fishnetGenerator } from './fishnet.js';
+
+describe('fishnetGenerator.validate', () => {
+  it('accepts a basic polygons-mode params shape', () => {
+    expect(
+      fishnetGenerator.validate({
+        cellSize: 100,
+        unit: 'meters',
+        output: 'polygons',
+      }),
+    ).toEqual({ cellSize: 100, unit: 'meters', output: 'polygons' });
+  });
+
+  it('accepts lines mode', () => {
+    expect(
+      fishnetGenerator.validate({
+        cellSize: 50,
+        unit: 'meters',
+        output: 'lines',
+      }),
+    ).toEqual({ cellSize: 50, unit: 'meters', output: 'lines' });
+  });
+
+  it('defaults unit to meters and output to polygons', () => {
+    expect(fishnetGenerator.validate({ cellSize: 100 })).toEqual({
+      cellSize: 100,
+      unit: 'meters',
+      output: 'polygons',
+    });
+  });
+
+  it('rejects non-finite cellSize', () => {
+    expect(() => fishnetGenerator.validate({ cellSize: NaN })).toThrow(
+      /finite number/,
+    );
+  });
+
+  it('rejects below the minimum', () => {
+    expect(() => fishnetGenerator.validate({ cellSize: 0.5 })).toThrow(
+      /at least 1 meter/,
+    );
+  });
+
+  it('rejects above the meters ceiling, including unit-converted', () => {
+    expect(() =>
+      fishnetGenerator.validate({ cellSize: 1_000_000, unit: 'meters' }),
+    ).toThrow(/must not exceed/);
+    expect(() =>
+      fishnetGenerator.validate({ cellSize: 1000, unit: 'kilometers' }),
+    ).toThrow(/must not exceed/);
+  });
+
+  it('rejects non-objects', () => {
+    expect(() => fishnetGenerator.validate(null)).toThrow(BadRequestException);
+    expect(() => fishnetGenerator.validate([])).toThrow(BadRequestException);
+  });
+});
+
+describe('fishnetGenerator.outputSchema', () => {
+  it('drops source attributes and emits cell_row + cell_col', () => {
+    const out = fishnetGenerator.outputSchema(
+      [
+        { name: 'name', label: 'Name', type: 'string', nullable: false },
+        { name: 'pop', label: 'Pop', type: 'number', nullable: true },
+      ],
+      { cellSize: 100, unit: 'meters', output: 'polygons' },
+    );
+    expect(out).toEqual([
+      { name: 'cell_row', label: 'Row', type: 'number', nullable: false },
+      { name: 'cell_col', label: 'Column', type: 'number', nullable: false },
+    ]);
+  });
+});
+
+describe('fishnetGenerator.outwardReachMeters', () => {
+  it('returns 0 (output stays inside input bbox)', () => {
+    expect(
+      fishnetGenerator.outwardReachMeters({
+        cellSize: 100,
+        unit: 'meters',
+        output: 'polygons',
+      }),
+    ).toBe(0);
+  });
+});
+
+describe('fishnetGenerator.toSql', () => {
+  it('emits ST_SquareGrid + ST_Intersection in polygons mode', () => {
+    const fragment = fishnetGenerator.toSql(
+      'source',
+      { cellSize: 100, unit: 'meters', output: 'polygons' },
+      0,
+    );
+    expect(fragment.sql).toMatch(/ST_SquareGrid\(\$1, source\.geom\)/);
+    expect(fragment.sql).toMatch(/ST_Intersection\(grid\.geom, source\.geom\)/);
+    // 100m / 111_320 m/deg ~= 0.000898 deg
+    expect(fragment.params[0]).toBeCloseTo(0.000898, 6);
+  });
+
+  it('emits ST_Boundary clipping in lines mode', () => {
+    const fragment = fishnetGenerator.toSql(
+      'source',
+      { cellSize: 100, unit: 'meters', output: 'lines' },
+      0,
+    );
+    expect(fragment.sql).toMatch(/ST_Boundary\(grid\.geom\)/);
+    expect(fragment.sql).toMatch(/ST_Intersection\(/);
+  });
+
+  it('converts non-meter units before computing degrees', () => {
+    const fragment = fishnetGenerator.toSql(
+      'source',
+      { cellSize: 1, unit: 'kilometers', output: 'polygons' },
+      0,
+    );
+    // 1000m / 111_320 m/deg ~= 0.00898 deg
+    expect(fragment.params[0]).toBeCloseTo(0.00898, 5);
+  });
+
+  it('emits cell_row + cell_col into the output properties JSONB', () => {
+    const fragment = fishnetGenerator.toSql(
+      'source',
+      { cellSize: 100, unit: 'meters', output: 'polygons' },
+      0,
+    );
+    expect(fragment.sql).toMatch(/jsonb_build_object\('cell_row'/);
+    expect(fragment.sql).toMatch(/'cell_col'/);
+  });
+
+  it('preserves SRID 4326', () => {
+    const fragment = fishnetGenerator.toSql(
+      'source',
+      { cellSize: 100, unit: 'meters', output: 'polygons' },
+      0,
+    );
+    expect(fragment.sql).toMatch(/ST_SetSRID\(/);
+    expect(fragment.sql).toMatch(/4326/);
+  });
+
+  it('honors paramOffset', () => {
+    const fragment = fishnetGenerator.toSql(
+      'step_2',
+      { cellSize: 100, unit: 'meters', output: 'polygons' },
+      4,
+    );
+    expect(fragment.sql).toMatch(/\$5/);
+    expect(fragment.sql).not.toMatch(/\$1\b/);
+  });
+});

--- a/apps/portal-api/src/derived-layers/tools/fishnet.spec.ts
+++ b/apps/portal-api/src/derived-layers/tools/fishnet.spec.ts
@@ -58,6 +58,96 @@ describe('fishnetGenerator.validate', () => {
   });
 });
 
+describe('fishnetGenerator.enrich (cell-count safety check)', () => {
+  /**
+   * The bbox is roughly San Francisco peninsula (about 17 km wide,
+   * 17 km tall). At a 100m cellSize that's ~28,900 cells; well under
+   * the 1M cap.
+   */
+  const SF_BBOX = {
+    xmin: -122.5,
+    ymin: 37.7,
+    xmax: -122.35,
+    ymax: 37.85,
+  };
+
+  it('accepts a recipe whose source bbox fits within the cell-count cap', async () => {
+    const queryRaw = jest.fn().mockResolvedValue([SF_BBOX]);
+    const result = await fishnetGenerator.enrich!(
+      { cellSize: 100, unit: 'meters', output: 'polygons' },
+      { sourceSchema: [], sourceTable: '"fs_xyz"', queryRaw },
+    );
+    expect(result).toEqual({
+      cellSize: 100,
+      unit: 'meters',
+      output: 'polygons',
+    });
+    expect(queryRaw).toHaveBeenCalled();
+  });
+
+  it('rejects a recipe whose cell count exceeds the safety cap', async () => {
+    // SF-wide bbox at 1m cells = ~280M cells; well over the 1M cap.
+    const queryRaw = jest.fn().mockResolvedValue([SF_BBOX]);
+    await expect(
+      fishnetGenerator.enrich!(
+        { cellSize: 1, unit: 'meters', output: 'polygons' },
+        { sourceSchema: [], sourceTable: '"fs_xyz"', queryRaw },
+      ),
+    ).rejects.toThrow(/safety cap/);
+  });
+
+  it('rejects a recipe whose cell count exceeds the cap, accounting for unit conversion', async () => {
+    // SF-wide bbox; 0.001 km = 1m cells = the same too-many-cells case.
+    const queryRaw = jest.fn().mockResolvedValue([SF_BBOX]);
+    await expect(
+      fishnetGenerator.enrich!(
+        { cellSize: 0.001, unit: 'kilometers', output: 'polygons' },
+        { sourceSchema: [], sourceTable: '"fs_xyz"', queryRaw },
+      ),
+    ).rejects.toThrow(/safety cap/);
+  });
+
+  it('accepts an empty source (ST_Extent returns null)', async () => {
+    const queryRaw = jest.fn().mockResolvedValue([
+      { xmin: null, ymin: null, xmax: null, ymax: null },
+    ]);
+    await expect(
+      fishnetGenerator.enrich!(
+        { cellSize: 1, unit: 'meters', output: 'polygons' },
+        { sourceSchema: [], sourceTable: '"fs_xyz"', queryRaw },
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  it('queries the source via ST_Extent', async () => {
+    const queryRaw = jest.fn().mockResolvedValue([SF_BBOX]);
+    await fishnetGenerator.enrich!(
+      { cellSize: 100, unit: 'meters', output: 'polygons' },
+      { sourceSchema: [], sourceTable: '"fs_xyz"', queryRaw },
+    );
+    const [sql] = queryRaw.mock.calls[0]!;
+    expect(sql).toMatch(/ST_Extent\(geom\)/);
+    expect(sql).toMatch(/ST_XMin/);
+    expect(sql).toMatch(/ST_XMax/);
+  });
+
+  it('coerces string-typed bbox columns from PostgreSQL drivers', async () => {
+    const queryRaw = jest.fn().mockResolvedValue([
+      {
+        xmin: '-122.5',
+        ymin: '37.7',
+        xmax: '-122.35',
+        ymax: '37.85',
+      },
+    ]);
+    const result = await fishnetGenerator.enrich!(
+      { cellSize: 100, unit: 'meters', output: 'polygons' },
+      { sourceSchema: [], sourceTable: '"fs_xyz"', queryRaw },
+    );
+    expect(result.cellSize).toBe(100);
+  });
+});
+
 describe('fishnetGenerator.outputSchema', () => {
   it('drops source attributes and emits cell_row + cell_col', () => {
     const out = fishnetGenerator.outputSchema(

--- a/apps/portal-api/src/derived-layers/tools/fishnet.ts
+++ b/apps/portal-api/src/derived-layers/tools/fishnet.ts
@@ -6,7 +6,11 @@ import {
   type LengthUnit,
 } from '@gratis-gis/shared-types';
 
-import type { ToolGenerator, ToolValidateContext } from './types.js';
+import type {
+  ToolEnrichContext,
+  ToolGenerator,
+  ToolValidateContext,
+} from './types.js';
 
 export interface FishnetParams {
   cellSize: number;
@@ -19,24 +23,35 @@ const MIN_CELL_METERS = 1;
 const MAX_CELL_METERS = 100_000;
 
 /**
- * One degree of latitude ~ 111_320 meters. Fishnet generation is
- * done in degrees because the source geometry is in EPSG:4326. At
- * high latitudes a degree of longitude is shorter than a degree
- * of latitude, so cells aren't truly square in the projection. v1
- * accepts that distortion for simplicity; future precision work
- * could project to UTM, generate the grid, and project back. For
- * city-to-state-scale fishnet workflows the visual difference is
- * within the cell size itself.
+ * Hard cap on cells generated per fishnet step. ST_SquareGrid covers
+ * the source's bbox before the polygon-intersection filter, so the
+ * generator can produce far more intermediate rows than the recipe's
+ * `featureLimit` final cap covers. Without a save-time check, a small
+ * cellSize on a state-sized polygon fills Postgres's pgsql_tmp directory
+ * and takes the database down. One million cells (a 1000x1000 grid) is
+ * dense enough for any sensible visual workflow and small enough that
+ * even on an underprovisioned dev Postgres the read never exhausts
+ * temp space.
+ */
+const MAX_CELLS_PER_RECIPE = 1_000_000;
+
+/**
+ * Approximate meters per degree at the equator. Used by the enrich
+ * hook's cell-count estimate. Over-estimates near the poles (where a
+ * degree of longitude is shorter than at the equator), which produces
+ * a CONSERVATIVE estimate (more cells than will actually be generated),
+ * which is what we want for a safety check.
  */
 const METERS_PER_DEGREE = 111_320;
 
 /**
- * Hard cap on cells per input polygon. A polygon the size of a
- * country with a 1m cell size would produce trillions of cells and
- * exhaust memory; this cap rejects the recipe at validate time
- * (we'd need the source bbox to compute cells/polygon directly,
- * which is expensive for the validator). Instead we cap implicitly
- * via MIN_CELL_METERS and the recipe's own featureLimit.
+ * Fishnet's cell size is in degrees of EPSG:4326 (the geometry's
+ * SRID), not meters; we convert at SQL-emission time using the same
+ * degrees-per-meter constant the read path uses elsewhere. At high
+ * latitudes a degree of longitude is shorter than a degree of
+ * latitude so cells aren't truly square in projection; for
+ * city-to-state-scale workflows the distortion is within the cell
+ * size itself.
  */
 
 /**
@@ -104,6 +119,69 @@ export const fishnetGenerator: ToolGenerator<FishnetParams> = {
     // on data_layer.layers). Validation is best-effort: the SQL
     // produces empty geometries for non-polygon input.
     return { cellSize, unit, output };
+  },
+
+  /**
+   * Save-time safety check. ST_SquareGrid materializes cells across
+   * the source's BBOX (not the polygon shape), then we filter via
+   * ST_Intersects. A small cellSize on a state-sized polygon
+   * generates billions of intermediate cells and fills Postgres's
+   * pgsql_tmp directory. Reject the recipe up front when the
+   * estimated cell count exceeds MAX_CELLS_PER_RECIPE.
+   *
+   * Estimation uses ST_Extent over the source's feature table, so
+   * it sees the actual rendered footprint rather than guessing. For
+   * sources with no rows yet, ST_Extent returns NULL and the check
+   * accepts the recipe (no cells to generate yet).
+   */
+  async enrich(
+    params: FishnetParams,
+    ctx: ToolEnrichContext,
+  ): Promise<FishnetParams> {
+    const cellMeters = metersFor(params.cellSize, params.unit);
+    if (cellMeters <= 0) return params; // already rejected by validate
+
+    const sql = `
+      WITH ext AS (
+        SELECT ST_Extent(geom) AS box
+        FROM ${ctx.sourceTable}
+        WHERE geom IS NOT NULL
+      )
+      SELECT
+        ST_XMin(box) AS xmin,
+        ST_YMin(box) AS ymin,
+        ST_XMax(box) AS xmax,
+        ST_YMax(box) AS ymax
+      FROM ext
+    `;
+    type Row = {
+      xmin: number | string | null;
+      ymin: number | string | null;
+      xmax: number | string | null;
+      ymax: number | string | null;
+    };
+    const rows = await ctx.queryRaw<Row>(sql);
+    const ext = rows[0];
+    if (!ext) return params;
+    const xmin = num(ext.xmin);
+    const ymin = num(ext.ymin);
+    const xmax = num(ext.xmax);
+    const ymax = num(ext.ymax);
+    if (xmin === null || xmax === null || ymin === null || ymax === null) {
+      // Empty source. Accept the recipe; cell count is zero.
+      return params;
+    }
+    const widthMeters = Math.abs(xmax - xmin) * METERS_PER_DEGREE;
+    const heightMeters = Math.abs(ymax - ymin) * METERS_PER_DEGREE;
+    const cellArea = cellMeters * cellMeters;
+    if (cellArea <= 0) return params;
+    const estimated = (widthMeters * heightMeters) / cellArea;
+    if (estimated > MAX_CELLS_PER_RECIPE) {
+      throw new BadRequestException(
+        `fishnet would generate roughly ${Math.round(estimated).toLocaleString()} cells covering the source's extent. Increase the cell size (current: ${cellMeters}m), or use a smaller source. The safety cap is ${MAX_CELLS_PER_RECIPE.toLocaleString()} cells.`,
+      );
+    }
+    return params;
   },
 
   outputSchema(): FeatureField[] {
@@ -183,3 +261,16 @@ export const fishnetGenerator: ToolGenerator<FishnetParams> = {
     return { sql, params: [cellDegrees] };
   },
 };
+
+/**
+ * Coerce a JSON-shaped Postgres numeric (which may arrive as number or
+ * string depending on driver settings) to a plain number, returning
+ * null for unparseable / null inputs. The fishnet enrich path uses this
+ * to read ST_Extent's xmin/ymin/xmax/ymax columns defensively.
+ */
+function num(v: number | string | null | undefined): number | null {
+  if (v === null || v === undefined) return null;
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+  const parsed = Number.parseFloat(v);
+  return Number.isFinite(parsed) ? parsed : null;
+}

--- a/apps/portal-api/src/derived-layers/tools/fishnet.ts
+++ b/apps/portal-api/src/derived-layers/tools/fishnet.ts
@@ -1,0 +1,185 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  isLengthUnit,
+  metersFor,
+  type FeatureField,
+  type LengthUnit,
+} from '@gratis-gis/shared-types';
+
+import type { ToolGenerator, ToolValidateContext } from './types.js';
+
+export interface FishnetParams {
+  cellSize: number;
+  unit: LengthUnit;
+  /** 'polygons' = filled cells; 'lines' = grid lines / transects only. */
+  output: 'polygons' | 'lines';
+}
+
+const MIN_CELL_METERS = 1;
+const MAX_CELL_METERS = 100_000;
+
+/**
+ * One degree of latitude ~ 111_320 meters. Fishnet generation is
+ * done in degrees because the source geometry is in EPSG:4326. At
+ * high latitudes a degree of longitude is shorter than a degree
+ * of latitude, so cells aren't truly square in the projection. v1
+ * accepts that distortion for simplicity; future precision work
+ * could project to UTM, generate the grid, and project back. For
+ * city-to-state-scale fishnet workflows the visual difference is
+ * within the cell size itself.
+ */
+const METERS_PER_DEGREE = 111_320;
+
+/**
+ * Hard cap on cells per input polygon. A polygon the size of a
+ * country with a 1m cell size would produce trillions of cells and
+ * exhaust memory; this cap rejects the recipe at validate time
+ * (we'd need the source bbox to compute cells/polygon directly,
+ * which is expensive for the validator). Instead we cap implicitly
+ * via MIN_CELL_METERS and the recipe's own featureLimit.
+ */
+
+/**
+ * Fishnet generator. Generates a regular grid covering each input
+ * polygon's bounding box, clipped to the polygon itself. Two output
+ * modes:
+ *
+ * - `polygons`: each grid cell becomes a polygon row. Cells that
+ *   fall partially outside the input are clipped via ST_Intersection.
+ *   Useful for spatial-bin / heatmap workflows.
+ * - `lines`: emits the horizontal and vertical grid lines clipped
+ *   to the polygon. Useful for transect / sampling-line workflows
+ *   ("draw lines every 100m across this study area").
+ *
+ * Restricted to polygon (and multi-polygon) input. The validator
+ * checks the source schema's geometryType when available; the read
+ * path does ST_Intersection against whatever geometry it gets, so
+ * a non-polygon input that slips through validation produces
+ * empty geometry rather than an error.
+ *
+ * Output drops source attributes (the new rows are GRID cells, not
+ * features-derived-from-input). Each row gets a `cell_row` and
+ * `cell_col` attribute so downstream tools can locate and filter
+ * cells positionally.
+ *
+ * Implementation: PostGIS 3.1+ ships ST_SquareGrid which produces
+ * cells covering an input geometry's bbox. We use it directly when
+ * the deployment runs PostGIS 3.1 or newer (the project's stated
+ * minimum is 3.3, see infra/docker/postgres). For earlier versions
+ * a generate_series fallback would be needed; we don't ship one in
+ * v1 and rely on the deployment minimum.
+ */
+export const fishnetGenerator: ToolGenerator<FishnetParams> = {
+  kind: 'fishnet',
+
+  validate(raw: unknown, _ctx?: ToolValidateContext): FishnetParams {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new BadRequestException('fishnet.params must be an object');
+    }
+    const r = raw as Record<string, unknown>;
+    const cellSize = r.cellSize;
+    if (typeof cellSize !== 'number' || !Number.isFinite(cellSize)) {
+      throw new BadRequestException(
+        'fishnet.params.cellSize must be a finite number',
+      );
+    }
+    const unit = isLengthUnit(r.unit) ? r.unit : 'meters';
+    const meters = metersFor(cellSize, unit);
+    if (meters < MIN_CELL_METERS) {
+      throw new BadRequestException(
+        `fishnet.params.cellSize must be at least ${MIN_CELL_METERS} meter (got ${meters}m)`,
+      );
+    }
+    if (meters > MAX_CELL_METERS) {
+      throw new BadRequestException(
+        `fishnet.params.cellSize must not exceed ${MAX_CELL_METERS} meters (got ${meters}m)`,
+      );
+    }
+    const output = r.output === 'lines' ? 'lines' : 'polygons';
+    // Schema-side geometryType validation lives one level up, in
+    // the service: the recipe's source already gates polygon-only
+    // sources via the picker, but a recipe arriving from an API
+    // caller could specify a point/line source. We don't have
+    // geometryType on FeatureField (it's a per-sublayer concept
+    // on data_layer.layers). Validation is best-effort: the SQL
+    // produces empty geometries for non-polygon input.
+    return { cellSize, unit, output };
+  },
+
+  outputSchema(): FeatureField[] {
+    // Drops source attributes; output is a grid, not derived
+    // features. cell_row / cell_col give positional coords.
+    return [
+      {
+        name: 'cell_row',
+        label: 'Row',
+        type: 'number',
+        nullable: false,
+      },
+      {
+        name: 'cell_col',
+        label: 'Column',
+        type: 'number',
+        nullable: false,
+      },
+    ];
+  },
+
+  outwardReachMeters(): number {
+    // Fishnet stays within the input polygon's bbox.
+    return 0;
+  },
+
+  extractDependencies(): { itemIds: string[]; urls: string[] } {
+    return { itemIds: [], urls: [] };
+  },
+
+  toSql(inputAlias: string, params: FishnetParams, paramOffset: number) {
+    const cellPh = `$${paramOffset + 1}`;
+    const meters = metersFor(params.cellSize, params.unit);
+    const cellDegrees = meters / METERS_PER_DEGREE;
+
+    if (params.output === 'polygons') {
+      // ST_SquareGrid(size, geom) -> setof (i, j, geom). Filter to
+      // cells that actually intersect the polygon to drop the
+      // bbox-only cells; ST_Intersection clips partial cells to the
+      // polygon's edge for a clean visual fit.
+      const sql = `
+        SELECT
+          gen_random_uuid()::text AS global_id,
+          ST_SetSRID(
+            ST_Intersection(grid.geom, ${inputAlias}.geom),
+            4326
+          ) AS geom,
+          jsonb_build_object('cell_row', grid.j, 'cell_col', grid.i)
+            AS properties
+        FROM ${inputAlias},
+        LATERAL ST_SquareGrid(${cellPh}, ${inputAlias}.geom) AS grid
+        WHERE ${inputAlias}.geom IS NOT NULL
+          AND ST_Intersects(grid.geom, ${inputAlias}.geom)
+      `;
+      return { sql, params: [cellDegrees] };
+    }
+    // Lines mode: extract the horizontal + vertical edges of every
+    // grid cell, clip to the polygon, and emit each as a line. The
+    // boundary of each cell is a closed ring; ST_Intersection with
+    // the polygon yields a (multi)line clipped to the polygon's
+    // interior. Filtering empty results drops cells that intersect
+    // the polygon only at a boundary point.
+    const sql = `
+      SELECT
+        gen_random_uuid()::text AS global_id,
+        ST_SetSRID(
+          ST_Intersection(ST_Boundary(grid.geom), ${inputAlias}.geom),
+          4326
+        ) AS geom,
+        jsonb_build_object('cell_row', grid.j, 'cell_col', grid.i)
+          AS properties
+      FROM ${inputAlias},
+      LATERAL ST_SquareGrid(${cellPh}, ${inputAlias}.geom) AS grid
+      WHERE ${inputAlias}.geom IS NOT NULL
+        AND ST_Intersects(grid.geom, ${inputAlias}.geom)
+    `;
+    return { sql, params: [cellDegrees] };
+  },
+};

--- a/apps/portal-api/src/derived-layers/tools/nearest-neighbor.spec.ts
+++ b/apps/portal-api/src/derived-layers/tools/nearest-neighbor.spec.ts
@@ -1,0 +1,67 @@
+import { BadRequestException } from '@nestjs/common';
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import { nearestNeighborGenerator } from './nearest-neighbor.js';
+
+const FIELDS: FeatureField[] = [
+  { name: 'name', label: 'Name', type: 'string', nullable: false },
+];
+
+describe('nearestNeighborGenerator.validate', () => {
+  it('accepts an empty params object', () => {
+    expect(nearestNeighborGenerator.validate({})).toEqual({});
+  });
+
+  it('rejects non-objects', () => {
+    expect(() => nearestNeighborGenerator.validate(null)).toThrow(
+      BadRequestException,
+    );
+    expect(() => nearestNeighborGenerator.validate([])).toThrow(
+      BadRequestException,
+    );
+  });
+});
+
+describe('nearestNeighborGenerator.outputSchema', () => {
+  it('appends nearest_distance_m to the input schema', () => {
+    const out = nearestNeighborGenerator.outputSchema(FIELDS, {});
+    expect(out).toHaveLength(2);
+    expect(out[1]).toEqual({
+      name: 'nearest_distance_m',
+      label: 'Distance to nearest (m)',
+      type: 'number',
+      nullable: true,
+    });
+  });
+});
+
+describe('nearestNeighborGenerator.outwardReachMeters', () => {
+  it('returns 0 (geometry is unchanged)', () => {
+    expect(nearestNeighborGenerator.outwardReachMeters({})).toBe(0);
+  });
+});
+
+describe('nearestNeighborGenerator.toSql', () => {
+  it('emits a self-join with ST_Distance over geography', () => {
+    const fragment = nearestNeighborGenerator.toSql('source', {}, 0);
+    expect(fragment.sql).toMatch(/ST_Distance\(/);
+    expect(fragment.sql).toMatch(/::geography/);
+    // self-join references inputAlias twice (a and b) and excludes
+    // self.
+    expect(fragment.sql).toMatch(/FROM source a/);
+    expect(fragment.sql).toMatch(/FROM source b/);
+    expect(fragment.sql).toMatch(/b\.global_id <> a\.global_id/);
+  });
+
+  it('merges nearest_distance_m into properties via jsonb_build_object', () => {
+    const fragment = nearestNeighborGenerator.toSql('source', {}, 0);
+    expect(fragment.sql).toMatch(/jsonb_build_object\(\s*'nearest_distance_m'/);
+  });
+
+  it('returns no params and ignores paramOffset', () => {
+    expect(nearestNeighborGenerator.toSql('source', {}, 0).params).toEqual([]);
+    const offset = nearestNeighborGenerator.toSql('step_2', {}, 5);
+    expect(offset.params).toEqual([]);
+    expect(offset.sql).not.toMatch(/\$/);
+  });
+});

--- a/apps/portal-api/src/derived-layers/tools/nearest-neighbor.ts
+++ b/apps/portal-api/src/derived-layers/tools/nearest-neighbor.ts
@@ -1,0 +1,93 @@
+import { BadRequestException } from '@nestjs/common';
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import type { ToolGenerator } from './types.js';
+
+export type NearestNeighborParams = Record<string, never>;
+
+/**
+ * Nearest-neighbor distance generator. Adds a `nearest_distance_m`
+ * numeric attribute to each input feature: the geographic distance
+ * (meters) to the closest OTHER feature in the same input.
+ *
+ * Implemented as a self-join with `ST_Distance(a.geom::geography,
+ * b.geom::geography)`, narrowed to `b.global_id <> a.global_id` so
+ * a feature's distance to itself doesn't dominate. The first / only
+ * feature in a single-row input yields NULL, which downstream tools
+ * handle the same way they handle any other NULL-valued attribute.
+ *
+ * Composes well with top-N (find the rows with the smallest
+ * nearest_distance_m to identify clusters) and calculate-geometry
+ * (combine length / area with proximity in one recipe).
+ *
+ * Performance note: this is O(N^2) per read. For sources of more
+ * than a few thousand features the read time grows linearly with
+ * the squared row count. PostGIS's KNN operator (`<->`) could
+ * narrow this to O(N log N) once we're willing to require a GIST
+ * index on the upstream step, which the pipeline doesn't currently
+ * provision. For v1 we accept the cost; the recipe's `featureLimit`
+ * still caps the output row count, but the join itself runs over
+ * the full input.
+ */
+export const nearestNeighborGenerator: ToolGenerator<NearestNeighborParams> = {
+  kind: 'nearest-neighbor',
+
+  validate(raw: unknown): NearestNeighborParams {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new BadRequestException('nearest-neighbor.params must be an object');
+    }
+    return {} as NearestNeighborParams;
+  },
+
+  outputSchema(input: FeatureField[]): FeatureField[] {
+    return [
+      ...input,
+      {
+        name: 'nearest_distance_m',
+        label: 'Distance to nearest (m)',
+        type: 'number',
+        nullable: true,
+      },
+    ];
+  },
+
+  outwardReachMeters(): number {
+    // The output geometry is unchanged from the input; bbox doesn't
+    // grow.
+    return 0;
+  },
+
+  extractDependencies(): { itemIds: string[]; urls: string[] } {
+    return { itemIds: [], urls: [] };
+  },
+
+  toSql(inputAlias: string) {
+    // The MIN(...) aggregate over the cross-join gives each row the
+    // distance to its closest neighbor. ST_Distance on geography
+    // returns meters globally regardless of latitude, so the
+    // attribute name (nearest_distance_m) is honest.
+    //
+    // properties || jsonb_build_object('nearest_distance_m', ...)
+    // merges the new field into the existing JSONB blob; the new
+    // key wins on conflict, so a source field accidentally named
+    // 'nearest_distance_m' gets overwritten (intended: the tool's
+    // contract is "this attribute now means distance to nearest").
+    const sql = `
+      SELECT
+        a.global_id,
+        a.geom,
+        a.properties || jsonb_build_object(
+          'nearest_distance_m',
+          (
+            SELECT MIN(ST_Distance(a.geom::geography, b.geom::geography))
+            FROM ${inputAlias} b
+            WHERE b.global_id <> a.global_id
+              AND b.geom IS NOT NULL
+          )
+        ) AS properties
+      FROM ${inputAlias} a
+      WHERE a.geom IS NOT NULL
+    `;
+    return { sql, params: [] };
+  },
+};

--- a/apps/portal-api/src/derived-layers/tools/random-sample.spec.ts
+++ b/apps/portal-api/src/derived-layers/tools/random-sample.spec.ts
@@ -1,0 +1,153 @@
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import { randomSampleGenerator } from './random-sample.js';
+
+const FIELDS: FeatureField[] = [
+  { name: 'name', label: 'Name', type: 'string', nullable: false },
+];
+
+describe('randomSampleGenerator.validate', () => {
+  it('accepts a percentage-mode params shape', () => {
+    expect(
+      randomSampleGenerator.validate({
+        mode: 'percentage',
+        value: 25,
+        seed: 42,
+      }),
+    ).toEqual({ mode: 'percentage', value: 25, seed: 42 });
+  });
+
+  it('accepts a count-mode params shape', () => {
+    expect(
+      randomSampleGenerator.validate({
+        mode: 'count',
+        value: 100,
+        seed: 7,
+      }),
+    ).toEqual({ mode: 'count', value: 100, seed: 7 });
+  });
+
+  it('defaults unknown mode to percentage', () => {
+    const r = randomSampleGenerator.validate({
+      mode: 'fudge',
+      value: 50,
+      seed: 1,
+    });
+    expect(r.mode).toBe('percentage');
+  });
+
+  it('rejects non-positive value', () => {
+    expect(() =>
+      randomSampleGenerator.validate({
+        mode: 'percentage',
+        value: 0,
+        seed: 1,
+      }),
+    ).toThrow(/positive number/);
+    expect(() =>
+      randomSampleGenerator.validate({
+        mode: 'percentage',
+        value: -1,
+        seed: 1,
+      }),
+    ).toThrow(/positive number/);
+  });
+
+  it('rejects percentage above 100', () => {
+    expect(() =>
+      randomSampleGenerator.validate({
+        mode: 'percentage',
+        value: 101,
+        seed: 1,
+      }),
+    ).toThrow(/at most 100/);
+  });
+
+  it('rejects fractional value in count mode', () => {
+    expect(() =>
+      randomSampleGenerator.validate({
+        mode: 'count',
+        value: 5.5,
+        seed: 1,
+      }),
+    ).toThrow(/integer in count mode/);
+  });
+
+  it('rejects count above the global ceiling', () => {
+    expect(() =>
+      randomSampleGenerator.validate({
+        mode: 'count',
+        value: 9_999_999,
+        seed: 1,
+      }),
+    ).toThrow(/must not exceed/);
+  });
+
+  it('substitutes a default seed when the input is 0', () => {
+    const r = randomSampleGenerator.validate({
+      mode: 'percentage',
+      value: 50,
+      seed: 0,
+    });
+    expect(r.seed).not.toBe(0);
+  });
+});
+
+describe('randomSampleGenerator.outputSchema', () => {
+  it('passes through every attribute', () => {
+    expect(
+      randomSampleGenerator.outputSchema(FIELDS, {
+        mode: 'percentage',
+        value: 10,
+        seed: 1,
+      }),
+    ).toBe(FIELDS);
+  });
+});
+
+describe('randomSampleGenerator.outwardReachMeters', () => {
+  it('returns 0', () => {
+    expect(
+      randomSampleGenerator.outwardReachMeters({
+        mode: 'percentage',
+        value: 10,
+        seed: 1,
+      }),
+    ).toBe(0);
+  });
+});
+
+describe('randomSampleGenerator.toSql', () => {
+  it('emits an md5-threshold WHERE in percentage mode', () => {
+    const fragment = randomSampleGenerator.toSql(
+      'source',
+      { mode: 'percentage', value: 25, seed: 42 },
+      0,
+    );
+    expect(fragment.sql).toMatch(/md5\(global_id::text \|\| \$1::text\)/);
+    expect(fragment.sql).toMatch(/< \(\$2::double precision \/ 100\.0\)/);
+    expect(fragment.params).toEqual([42, 25]);
+  });
+
+  it('emits ORDER BY md5 + LIMIT in count mode', () => {
+    const fragment = randomSampleGenerator.toSql(
+      'source',
+      { mode: 'count', value: 7, seed: 12 },
+      0,
+    );
+    expect(fragment.sql).toMatch(/ORDER BY md5\(/);
+    expect(fragment.sql).toMatch(/LIMIT \$2/);
+    expect(fragment.params).toEqual([12, 7]);
+  });
+
+  it('honors paramOffset', () => {
+    const fragment = randomSampleGenerator.toSql(
+      'step_2',
+      { mode: 'percentage', value: 50, seed: 1 },
+      4,
+    );
+    expect(fragment.sql).toMatch(/\$5/);
+    expect(fragment.sql).toMatch(/\$6/);
+    expect(fragment.sql).not.toMatch(/\$1\b/);
+  });
+});

--- a/apps/portal-api/src/derived-layers/tools/random-sample.ts
+++ b/apps/portal-api/src/derived-layers/tools/random-sample.ts
@@ -1,0 +1,122 @@
+import { BadRequestException } from '@nestjs/common';
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import type { ToolGenerator } from './types.js';
+
+export interface RandomSampleParams {
+  mode: 'percentage' | 'count';
+  /** Percentage in 0..100 when mode='percentage'; row count when 'count'. */
+  value: number;
+  /** Persisted seed for stable output across reads of the same recipe. */
+  seed: number;
+}
+
+const MAX_COUNT = 100_000;
+
+/**
+ * Random-sample filter generator. Returns a deterministic random
+ * subset of the input.
+ *
+ * Two modes:
+ * - `percentage`: keep roughly `value` percent of rows. Implemented
+ *   in SQL via `WHERE md5(global_id::text || seed) < threshold`,
+ *   which converts each row's id+seed to a hex digit, takes the
+ *   first N hex chars as a number, and compares against a fraction
+ *   of the namespace. Stable for a given (recipe, source) pair
+ *   because both global_id and seed are stable.
+ * - `count`: keep exactly `value` rows. Implemented as `ORDER BY
+ *   md5(global_id::text || seed) LIMIT value`, which selects the N
+ *   rows whose hashes sort earliest. Also stable.
+ *
+ * The hash-based approach beats `random()` because Postgres's
+ * random() is per-query (not per-row-deterministic), so two reads
+ * of the same recipe would return different samples. The persisted
+ * seed makes the sample shift only when the user explicitly rolls
+ * a new one (via the wizard's "shuffle" button, eventually).
+ */
+export const randomSampleGenerator: ToolGenerator<RandomSampleParams> = {
+  kind: 'random-sample',
+
+  validate(raw: unknown): RandomSampleParams {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new BadRequestException('random-sample.params must be an object');
+    }
+    const r = raw as Record<string, unknown>;
+    const mode = r.mode === 'count' ? 'count' : 'percentage';
+    const value = r.value;
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+      throw new BadRequestException(
+        'random-sample.params.value must be a positive number',
+      );
+    }
+    if (mode === 'percentage' && value > 100) {
+      throw new BadRequestException(
+        'random-sample.params.value must be at most 100 in percentage mode',
+      );
+    }
+    if (mode === 'count') {
+      if (!Number.isInteger(value)) {
+        throw new BadRequestException(
+          'random-sample.params.value must be an integer in count mode',
+        );
+      }
+      if (value > MAX_COUNT) {
+        throw new BadRequestException(
+          `random-sample.params.value must not exceed ${MAX_COUNT} in count mode`,
+        );
+      }
+    }
+    const rawSeed = r.seed;
+    let seed = 0;
+    if (typeof rawSeed === 'number' && Number.isFinite(rawSeed)) {
+      seed = Math.floor(Math.abs(rawSeed)) % 2147483647;
+    }
+    if (seed === 0) {
+      // 0 is a degenerate seed (all hashes start with the same
+      // bytes-of-zero), so substitute a stable nonzero default.
+      seed = 1;
+    }
+    return { mode, value, seed };
+  },
+
+  outputSchema(input: FeatureField[]): FeatureField[] {
+    return input;
+  },
+
+  outwardReachMeters(): number {
+    return 0;
+  },
+
+  extractDependencies(): { itemIds: string[]; urls: string[] } {
+    return { itemIds: [], urls: [] };
+  },
+
+  toSql(inputAlias: string, params: RandomSampleParams, paramOffset: number) {
+    const seedPh = `$${paramOffset + 1}`;
+    if (params.mode === 'percentage') {
+      // Convert percentage 0..100 to a numeric threshold the hash
+      // can be compared against. We use md5 -> first 8 hex chars
+      // -> 32-bit unsigned integer / 2^32, which is uniformly
+      // distributed in [0, 1). Compare against value/100.
+      const valPh = `$${paramOffset + 2}`;
+      const sql = `
+        SELECT global_id, geom, properties
+        FROM ${inputAlias}
+        WHERE (
+          ('x' || substr(md5(global_id::text || ${seedPh}::text), 1, 8))::bit(32)::bigint::double precision
+          / 4294967295.0
+        ) < (${valPh}::double precision / 100.0)
+      `;
+      return { sql, params: [params.seed, params.value] };
+    }
+    // count mode: ORDER BY hash, LIMIT value.
+    const limitPh = `$${paramOffset + 2}`;
+    const sql = `
+      SELECT global_id, geom, properties
+      FROM ${inputAlias}
+      ORDER BY md5(global_id::text || ${seedPh}::text)
+      LIMIT ${limitPh}
+    `;
+    return { sql, params: [params.seed, params.value] };
+  },
+};

--- a/apps/portal-api/src/derived-layers/tools/registry.ts
+++ b/apps/portal-api/src/derived-layers/tools/registry.ts
@@ -1,8 +1,19 @@
 import { BadRequestException } from '@nestjs/common';
 import type { ToolStep } from '@gratis-gis/shared-types';
 
+import { bboxGenerator } from './bbox.js';
 import { bufferGenerator } from './buffer.js';
+import { calculateGeometryGenerator } from './calculate-geometry.js';
+import { centroidGenerator } from './centroid.js';
+import { convexHullGenerator } from './convex-hull.js';
+import { densifyGenerator } from './densify.js';
 import { dissolveGenerator } from './dissolve.js';
+import { fishnetGenerator } from './fishnet.js';
+import { nearestNeighborGenerator } from './nearest-neighbor.js';
+import { randomSampleGenerator } from './random-sample.js';
+import { simplifyGenerator } from './simplify.js';
+import { topNGenerator } from './top-n.js';
+import { verticesGenerator } from './vertices.js';
 import type { ToolGenerator } from './types.js';
 
 /**
@@ -19,6 +30,26 @@ import type { ToolGenerator } from './types.js';
 const REGISTRY: Map<string, ToolGenerator<unknown>> = new Map([
   [bufferGenerator.kind, bufferGenerator as ToolGenerator<unknown>],
   [dissolveGenerator.kind, dissolveGenerator as ToolGenerator<unknown>],
+  [centroidGenerator.kind, centroidGenerator as ToolGenerator<unknown>],
+  [convexHullGenerator.kind, convexHullGenerator as ToolGenerator<unknown>],
+  [bboxGenerator.kind, bboxGenerator as ToolGenerator<unknown>],
+  [simplifyGenerator.kind, simplifyGenerator as ToolGenerator<unknown>],
+  [verticesGenerator.kind, verticesGenerator as ToolGenerator<unknown>],
+  [densifyGenerator.kind, densifyGenerator as ToolGenerator<unknown>],
+  [topNGenerator.kind, topNGenerator as ToolGenerator<unknown>],
+  [
+    randomSampleGenerator.kind,
+    randomSampleGenerator as ToolGenerator<unknown>,
+  ],
+  [
+    nearestNeighborGenerator.kind,
+    nearestNeighborGenerator as ToolGenerator<unknown>,
+  ],
+  [fishnetGenerator.kind, fishnetGenerator as ToolGenerator<unknown>],
+  [
+    calculateGeometryGenerator.kind,
+    calculateGeometryGenerator as ToolGenerator<unknown>,
+  ],
 ]);
 
 /**

--- a/apps/portal-api/src/derived-layers/tools/simplify.spec.ts
+++ b/apps/portal-api/src/derived-layers/tools/simplify.spec.ts
@@ -1,0 +1,111 @@
+import { BadRequestException } from '@nestjs/common';
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import { simplifyGenerator } from './simplify.js';
+
+const FIELDS: FeatureField[] = [
+  { name: 'name', label: 'Name', type: 'string', nullable: false },
+];
+
+describe('simplifyGenerator.validate', () => {
+  it('accepts a positive tolerance in meters', () => {
+    expect(simplifyGenerator.validate({ tolerance: 10, unit: 'meters' })).toEqual({
+      tolerance: 10,
+      unit: 'meters',
+    });
+  });
+
+  it('defaults unit to meters when missing', () => {
+    expect(simplifyGenerator.validate({ tolerance: 10 })).toEqual({
+      tolerance: 10,
+      unit: 'meters',
+    });
+  });
+
+  it('accepts non-meter units', () => {
+    expect(simplifyGenerator.validate({ tolerance: 1, unit: 'kilometers' })).toEqual({
+      tolerance: 1,
+      unit: 'kilometers',
+    });
+  });
+
+  it('rejects a non-object', () => {
+    expect(() => simplifyGenerator.validate(null)).toThrow(BadRequestException);
+  });
+
+  it('rejects non-number tolerance', () => {
+    expect(() =>
+      simplifyGenerator.validate({ tolerance: '10', unit: 'meters' }),
+    ).toThrow(/finite number/);
+  });
+
+  it('rejects zero or negative tolerance', () => {
+    expect(() =>
+      simplifyGenerator.validate({ tolerance: 0, unit: 'meters' }),
+    ).toThrow(/greater than 0/);
+    expect(() =>
+      simplifyGenerator.validate({ tolerance: -1, unit: 'meters' }),
+    ).toThrow(/greater than 0/);
+  });
+
+  it('rejects tolerances above the meters ceiling, including unit-converted', () => {
+    expect(() =>
+      simplifyGenerator.validate({ tolerance: 1_000_000, unit: 'meters' }),
+    ).toThrow(/must not exceed/);
+    expect(() =>
+      simplifyGenerator.validate({ tolerance: 1000, unit: 'kilometers' }),
+    ).toThrow(/must not exceed/);
+  });
+});
+
+describe('simplifyGenerator.outputSchema', () => {
+  it('passes through every attribute', () => {
+    expect(
+      simplifyGenerator.outputSchema(FIELDS, {
+        tolerance: 10,
+        unit: 'meters',
+      }),
+    ).toBe(FIELDS);
+  });
+});
+
+describe('simplifyGenerator.outwardReachMeters', () => {
+  it('returns 0 (simplify only drops vertices)', () => {
+    expect(
+      simplifyGenerator.outwardReachMeters({ tolerance: 100, unit: 'meters' }),
+    ).toBe(0);
+  });
+});
+
+describe('simplifyGenerator.toSql', () => {
+  it('emits ST_Simplify with the tolerance in degrees', () => {
+    const fragment = simplifyGenerator.toSql(
+      'source',
+      { tolerance: 111.32, unit: 'meters' },
+      0,
+    );
+    expect(fragment.sql).toMatch(/ST_Simplify\(geom, \$1\)/);
+    // 111.32m / 111_320 m/deg = ~0.001 deg.
+    expect(fragment.params[0]).toBeCloseTo(0.001, 5);
+  });
+
+  it('converts non-meter units to degrees correctly', () => {
+    // 1 km = 1000m; 1000 / 111_320 ~= 0.00898 deg.
+    const fragment = simplifyGenerator.toSql(
+      'source',
+      { tolerance: 1, unit: 'kilometers' },
+      0,
+    );
+    expect(fragment.params[0]).toBeCloseTo(0.00898, 4);
+  });
+
+  it('honors paramOffset', () => {
+    const fragment = simplifyGenerator.toSql(
+      'step_2',
+      { tolerance: 10, unit: 'meters' },
+      4,
+    );
+    expect(fragment.sql).toMatch(/\$5/);
+    expect(fragment.sql).not.toMatch(/\$1\b/);
+  });
+});

--- a/apps/portal-api/src/derived-layers/tools/simplify.ts
+++ b/apps/portal-api/src/derived-layers/tools/simplify.ts
@@ -1,0 +1,110 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  isLengthUnit,
+  metersFor,
+  type FeatureField,
+  type LengthUnit,
+} from '@gratis-gis/shared-types';
+
+import type { ToolGenerator } from './types.js';
+
+/**
+ * Validated simplify params. Tolerance interpreted in `unit`; the
+ * SQL converts to degrees of latitude before passing to ST_Simplify
+ * so the visible effect matches what the user typed.
+ */
+export interface SimplifyParams {
+  tolerance: number;
+  unit: LengthUnit;
+}
+
+/**
+ * Maximum simplify tolerance the wizard will accept. 100 km is wider
+ * than any real "smooth this polygon" tolerance and matches the
+ * buffer ceiling so a misclick can't spawn a pathological geometry.
+ */
+const MAX_SIMPLIFY_METERS = 100_000;
+
+/**
+ * One degree of latitude is roughly 111_320 meters. The constant is
+ * the conversion factor used to translate the user-supplied tolerance
+ * (in meters) to the unit ST_Simplify expects (degrees, since the
+ * geometry is stored in EPSG:4326). At higher latitudes a degree of
+ * longitude is shorter, but Douglas-Peucker tolerance is symmetric;
+ * using the latitude factor keeps the simplification slightly more
+ * aggressive at high latitudes, which is acceptable for a recipe
+ * tool. Future precision work could project to UTM, simplify, and
+ * project back -- not warranted in v1.
+ */
+const METERS_PER_DEGREE = 111_320;
+
+/**
+ * Simplify generator. Wraps `ST_Simplify(geom, toleranceDegrees)`
+ * with the user-supplied tolerance converted from meters first. Drops
+ * vertices that lie within the tolerance of a straight line between
+ * their neighbors. The geometry's topological validity is not
+ * guaranteed by ST_Simplify; ST_SimplifyPreserveTopology is the
+ * stricter alternative but is much slower. v1 uses the fast path.
+ */
+export const simplifyGenerator: ToolGenerator<SimplifyParams> = {
+  kind: 'simplify',
+
+  validate(raw: unknown): SimplifyParams {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new BadRequestException('simplify.params must be an object');
+    }
+    const r = raw as Record<string, unknown>;
+    const tolerance = r.tolerance;
+    if (typeof tolerance !== 'number' || !Number.isFinite(tolerance)) {
+      throw new BadRequestException(
+        'simplify.params.tolerance must be a finite number',
+      );
+    }
+    if (tolerance <= 0) {
+      throw new BadRequestException(
+        'simplify.params.tolerance must be greater than 0',
+      );
+    }
+    const unit = isLengthUnit(r.unit) ? r.unit : 'meters';
+    const toleranceMeters = metersFor(tolerance, unit);
+    if (toleranceMeters > MAX_SIMPLIFY_METERS) {
+      throw new BadRequestException(
+        `simplify.params.tolerance must not exceed ${MAX_SIMPLIFY_METERS} meters (got ${toleranceMeters}m)`,
+      );
+    }
+    return { tolerance, unit };
+  },
+
+  outputSchema(input: FeatureField[]): FeatureField[] {
+    return input;
+  },
+
+  outwardReachMeters(): number {
+    // Simplify can only DROP vertices; the resulting geometry is
+    // strictly inside the input's convex hull, so no outward reach.
+    return 0;
+  },
+
+  extractDependencies(): { itemIds: string[]; urls: string[] } {
+    return { itemIds: [], urls: [] };
+  },
+
+  toSql(inputAlias: string, params: SimplifyParams, paramOffset: number) {
+    // ST_Simplify takes tolerance in the geometry's units; we store
+    // in 4326 (degrees), so convert meters -> degrees here. The
+    // factor is the same on both axes (see METERS_PER_DEGREE
+    // comment).
+    const placeholder = `$${paramOffset + 1}`;
+    const sql = `
+      SELECT
+        global_id,
+        ST_SetSRID(ST_Simplify(geom, ${placeholder}), 4326) AS geom,
+        properties
+      FROM ${inputAlias}
+      WHERE geom IS NOT NULL
+    `;
+    const toleranceMeters = metersFor(params.tolerance, params.unit);
+    const toleranceDegrees = toleranceMeters / METERS_PER_DEGREE;
+    return { sql, params: [toleranceDegrees] };
+  },
+};

--- a/apps/portal-api/src/derived-layers/tools/top-n.spec.ts
+++ b/apps/portal-api/src/derived-layers/tools/top-n.spec.ts
@@ -1,0 +1,148 @@
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import { topNGenerator } from './top-n.js';
+
+const STRING_FIELD: FeatureField = {
+  name: 'name',
+  label: 'Name',
+  type: 'string',
+  nullable: false,
+};
+const NUMBER_FIELD: FeatureField = {
+  name: 'population',
+  label: 'Population',
+  type: 'number',
+  nullable: true,
+};
+
+describe('topNGenerator.validate', () => {
+  it('accepts a valid params shape with schema context', () => {
+    expect(
+      topNGenerator.validate(
+        { field: 'population', n: 10, direction: 'desc' },
+        { sourceSchema: [STRING_FIELD, NUMBER_FIELD] },
+      ),
+    ).toEqual({ field: 'population', n: 10, direction: 'desc' });
+  });
+
+  it('skips schema checks when no context is provided (read-time path)', () => {
+    expect(
+      topNGenerator.validate({
+        field: 'whatever',
+        n: 5,
+        direction: 'asc',
+      }),
+    ).toEqual({ field: 'whatever', n: 5, direction: 'asc' });
+  });
+
+  it('rejects a field that does not exist on the source schema', () => {
+    expect(() =>
+      topNGenerator.validate(
+        { field: 'nope', n: 10, direction: 'desc' },
+        { sourceSchema: [STRING_FIELD, NUMBER_FIELD] },
+      ),
+    ).toThrow(/does not exist on the source schema/);
+  });
+
+  it('rejects a non-numeric field', () => {
+    expect(() =>
+      topNGenerator.validate(
+        { field: 'name', n: 10, direction: 'desc' },
+        { sourceSchema: [STRING_FIELD, NUMBER_FIELD] },
+      ),
+    ).toThrow(/must be a number field/);
+  });
+
+  it('rejects a missing field name', () => {
+    expect(() =>
+      topNGenerator.validate({ n: 10, direction: 'desc' }),
+    ).toThrow(/field is required/);
+  });
+
+  it('rejects non-integer or non-positive n', () => {
+    expect(() =>
+      topNGenerator.validate({ field: 'x', n: 0, direction: 'desc' }),
+    ).toThrow(/at least 1/);
+    expect(() =>
+      topNGenerator.validate({ field: 'x', n: 1.5, direction: 'desc' }),
+    ).toThrow(/positive integer/);
+    expect(() =>
+      topNGenerator.validate({ field: 'x', n: 999_999_999, direction: 'desc' }),
+    ).toThrow(/must not exceed/);
+  });
+
+  it('coerces unknown direction to desc', () => {
+    expect(
+      topNGenerator.validate({ field: 'x', n: 10, direction: 'sideways' }),
+    ).toEqual({ field: 'x', n: 10, direction: 'desc' });
+  });
+});
+
+describe('topNGenerator.outputSchema', () => {
+  it('passes through every attribute', () => {
+    const fields = [STRING_FIELD, NUMBER_FIELD];
+    expect(
+      topNGenerator.outputSchema(fields, {
+        field: 'population',
+        n: 5,
+        direction: 'desc',
+      }),
+    ).toBe(fields);
+  });
+});
+
+describe('topNGenerator.outwardReachMeters', () => {
+  it('returns 0', () => {
+    expect(
+      topNGenerator.outwardReachMeters({
+        field: 'x',
+        n: 10,
+        direction: 'desc',
+      }),
+    ).toBe(0);
+  });
+});
+
+describe('topNGenerator.toSql', () => {
+  it('emits ORDER BY DESC + LIMIT, parameterized', () => {
+    const fragment = topNGenerator.toSql(
+      'source',
+      { field: 'population', n: 10, direction: 'desc' },
+      0,
+    );
+    expect(fragment.sql).toMatch(/ORDER BY .* DESC NULLS LAST/);
+    expect(fragment.sql).toMatch(/LIMIT \$2/);
+    expect(fragment.params).toEqual(['population', 10]);
+  });
+
+  it('emits ASC for direction=asc', () => {
+    const fragment = topNGenerator.toSql(
+      'source',
+      { field: 'pop', n: 5, direction: 'asc' },
+      0,
+    );
+    expect(fragment.sql).toMatch(/ORDER BY .* ASC NULLS LAST/);
+  });
+
+  it('reads from properties->>$field with the same JSONB guard buffer uses', () => {
+    const fragment = topNGenerator.toSql(
+      'source',
+      { field: 'pop', n: 5, direction: 'desc' },
+      0,
+    );
+    expect(fragment.sql).toMatch(/properties \?/);
+    expect(fragment.sql).toMatch(/~ '\^-\?\[0-9\]/);
+    expect(fragment.sql).toMatch(/double precision/);
+  });
+
+  it('honors paramOffset', () => {
+    const fragment = topNGenerator.toSql(
+      'step_2',
+      { field: 'pop', n: 5, direction: 'desc' },
+      4,
+    );
+    expect(fragment.sql).toMatch(/\$5/);
+    expect(fragment.sql).toMatch(/\$6/);
+    expect(fragment.sql).not.toMatch(/\$1\b/);
+  });
+});

--- a/apps/portal-api/src/derived-layers/tools/top-n.ts
+++ b/apps/portal-api/src/derived-layers/tools/top-n.ts
@@ -1,0 +1,115 @@
+import { BadRequestException } from '@nestjs/common';
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import type { ToolGenerator, ToolValidateContext } from './types.js';
+
+export interface TopNParams {
+  field: string;
+  n: number;
+  direction: 'asc' | 'desc';
+}
+
+/**
+ * Hard cap on N. Mostly a safety net to prevent a misclick from
+ * forcing the read path to return millions of rows; the recipe's
+ * own `featureLimit` is the user-tunable ceiling but this stays
+ * higher than the default to make the cap on top-N not bite first.
+ */
+const MAX_N = 100_000;
+
+/**
+ * Top-N filter generator. Keeps the N rows with the highest (or
+ * lowest) value of a numeric attribute. Geometry and attributes
+ * pass through unchanged. The named field must exist on the
+ * upstream schema and have type 'number' at recipe-save time;
+ * read-time validate trusts the persisted shape.
+ *
+ * Useful for "ten largest parcels" / "five closest hospitals" once
+ * a distance attribute is available (composes well with
+ * nearest-neighbor and calculate-geometry).
+ *
+ * NULL values are sorted to the end via NULLS LAST/FIRST so the
+ * top-N for a column with sparse data doesn't get clogged with
+ * NULLs. asc -> NULLS LAST, desc -> NULLS LAST (i.e. NULLs always
+ * dropped to the bottom regardless of direction; a top-10 by
+ * "highest population" should not return rows with NULL population).
+ */
+export const topNGenerator: ToolGenerator<TopNParams> = {
+  kind: 'top-n',
+
+  validate(raw: unknown, ctx?: ToolValidateContext): TopNParams {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new BadRequestException('top-n.params must be an object');
+    }
+    const r = raw as Record<string, unknown>;
+    const field = r.field;
+    if (typeof field !== 'string' || field.length === 0) {
+      throw new BadRequestException('top-n.params.field is required');
+    }
+    if (ctx?.sourceSchema) {
+      const match = ctx.sourceSchema.find((f) => f.name === field);
+      if (!match) {
+        throw new BadRequestException(
+          `top-n.params.field "${field}" does not exist on the source schema`,
+        );
+      }
+      if (match.type !== 'number') {
+        throw new BadRequestException(
+          `top-n.params.field "${field}" must be a number field (got ${match.type})`,
+        );
+      }
+    }
+    const n = r.n;
+    if (typeof n !== 'number' || !Number.isFinite(n) || !Number.isInteger(n)) {
+      throw new BadRequestException(
+        'top-n.params.n must be a positive integer',
+      );
+    }
+    if (n < 1) {
+      throw new BadRequestException(
+        'top-n.params.n must be at least 1',
+      );
+    }
+    if (n > MAX_N) {
+      throw new BadRequestException(
+        `top-n.params.n must not exceed ${MAX_N}`,
+      );
+    }
+    const direction = r.direction === 'asc' ? 'asc' : 'desc';
+    return { field, n, direction };
+  },
+
+  outputSchema(input: FeatureField[]): FeatureField[] {
+    return input;
+  },
+
+  outwardReachMeters(): number {
+    return 0;
+  },
+
+  extractDependencies(): { itemIds: string[]; urls: string[] } {
+    return { itemIds: [], urls: [] };
+  },
+
+  toSql(inputAlias: string, params: TopNParams, paramOffset: number) {
+    // NULLIF + the regex guard mirror the buffer field-mode pattern:
+    // a row with a non-numeric or empty value at `field` casts to
+    // NULL via NULLIF, gets sorted to the end via NULLS LAST, and
+    // is therefore dropped from the top-N as long as N is smaller
+    // than the field's NULL count. (When the user really does want
+    // NULL rows, they shouldn't be top-N filtering on a sparse
+    // attribute.)
+    const fieldPh = `$${paramOffset + 1}`;
+    const limitPh = `$${paramOffset + 2}`;
+    const dir = params.direction === 'asc' ? 'ASC' : 'DESC';
+    const sql = `
+      SELECT global_id, geom, properties
+      FROM ${inputAlias}
+      WHERE properties ? ${fieldPh}
+        AND (properties->>${fieldPh}) ~ '^-?[0-9]+(\\.[0-9]+)?$'
+      ORDER BY (NULLIF(properties->>${fieldPh}, ''))::double precision ${dir} NULLS LAST
+      LIMIT ${limitPh}
+    `;
+    return { sql, params: [params.field, params.n] };
+  },
+};

--- a/apps/portal-api/src/derived-layers/tools/vertices.spec.ts
+++ b/apps/portal-api/src/derived-layers/tools/vertices.spec.ts
@@ -1,0 +1,77 @@
+import { BadRequestException } from '@nestjs/common';
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import { verticesGenerator } from './vertices.js';
+
+const FIELDS: FeatureField[] = [
+  { name: 'name', label: 'Name', type: 'string', nullable: false },
+];
+
+describe('verticesGenerator.validate', () => {
+  it('accepts an empty params object', () => {
+    expect(verticesGenerator.validate({})).toEqual({});
+  });
+
+  it('rejects non-objects', () => {
+    expect(() => verticesGenerator.validate(null)).toThrow(BadRequestException);
+    expect(() => verticesGenerator.validate([])).toThrow(BadRequestException);
+  });
+});
+
+describe('verticesGenerator.outputSchema', () => {
+  it('appends vertex_index to the input schema', () => {
+    const out = verticesGenerator.outputSchema(FIELDS, {});
+    expect(out).toHaveLength(2);
+    expect(out[0]).toBe(FIELDS[0]);
+    expect(out[1]).toEqual({
+      name: 'vertex_index',
+      label: 'Vertex index',
+      type: 'number',
+      nullable: false,
+    });
+  });
+
+  it('returns a fresh array, not the input reference', () => {
+    const input: FeatureField[] = [];
+    const out = verticesGenerator.outputSchema(input, {});
+    expect(out).not.toBe(input);
+  });
+});
+
+describe('verticesGenerator.outwardReachMeters', () => {
+  it('returns 0 (vertices lie on the input geometry)', () => {
+    expect(verticesGenerator.outwardReachMeters({})).toBe(0);
+  });
+});
+
+describe('verticesGenerator.toSql', () => {
+  it('emits ST_DumpPoints under a lateral with vertex_index', () => {
+    const fragment = verticesGenerator.toSql('source', {}, 0);
+    expect(fragment.sql).toMatch(/ST_DumpPoints\(source\.geom\)/);
+    expect(fragment.sql).toMatch(/LATERAL/);
+    expect(fragment.sql).toMatch(/vertex_index/);
+  });
+
+  it('orders vertices by path so multi-part geometries enumerate sensibly', () => {
+    const fragment = verticesGenerator.toSql('source', {}, 0);
+    expect(fragment.sql).toMatch(/ORDER BY pt\.path/);
+  });
+
+  it('merges vertex_index into the properties JSONB', () => {
+    const fragment = verticesGenerator.toSql('source', {}, 0);
+    expect(fragment.sql).toMatch(/jsonb_build_object\('vertex_index'/);
+  });
+
+  it('preserves SRID 4326 on the dumped point geometry', () => {
+    const fragment = verticesGenerator.toSql('source', {}, 0);
+    expect(fragment.sql).toMatch(/ST_SetSRID\(dp\.geom, 4326\)/);
+  });
+
+  it('returns no params and ignores paramOffset', () => {
+    expect(verticesGenerator.toSql('source', {}, 0).params).toEqual([]);
+    const offset = verticesGenerator.toSql('step_2', {}, 5);
+    expect(offset.params).toEqual([]);
+    expect(offset.sql).toMatch(/FROM step_2/);
+    expect(offset.sql).not.toMatch(/\$/);
+  });
+});

--- a/apps/portal-api/src/derived-layers/tools/vertices.ts
+++ b/apps/portal-api/src/derived-layers/tools/vertices.ts
@@ -1,0 +1,91 @@
+import { BadRequestException } from '@nestjs/common';
+import type { FeatureField } from '@gratis-gis/shared-types';
+
+import type { ToolGenerator } from './types.js';
+
+export type VerticesParams = Record<string, never>;
+
+/**
+ * Vertices generator. Explodes each input geometry into one point
+ * feature per vertex via `ST_DumpPoints`. Adds `vertex_index`
+ * (0-based) to each output row's properties so downstream tools
+ * can reorder, filter, or label by position. Source attributes
+ * pass through; the row count goes from 1 to N where N is the
+ * vertex count of the input geometry.
+ *
+ * Useful for "show me the corners" workflows, point-density
+ * analysis on traced lines, or as an input to a downstream
+ * convex-hull / fishnet step.
+ *
+ * Note: ST_DumpPoints expands MULTI* and GEOMETRYCOLLECTION inputs
+ * across all their parts, so a MultiLineString with two segments
+ * yields the union of both segments' vertices.
+ */
+export const verticesGenerator: ToolGenerator<VerticesParams> = {
+  kind: 'vertices',
+
+  validate(raw: unknown): VerticesParams {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      throw new BadRequestException('vertices.params must be an object');
+    }
+    return {} as VerticesParams;
+  },
+
+  outputSchema(input: FeatureField[]): FeatureField[] {
+    // Source schema plus a synthetic `vertex_index` integer field.
+    // Returning a fresh array (not mutating the input) keeps the
+    // pipeline pure.
+    return [
+      ...input,
+      {
+        name: 'vertex_index',
+        label: 'Vertex index',
+        type: 'number',
+        nullable: false,
+      },
+    ];
+  },
+
+  outwardReachMeters(): number {
+    // Vertices lie on the input geometry; output bbox is bounded
+    // by the input bbox.
+    return 0;
+  },
+
+  extractDependencies(): { itemIds: string[]; urls: string[] } {
+    return { itemIds: [], urls: [] };
+  },
+
+  toSql(inputAlias: string) {
+    // ST_DumpPoints returns rows of (path int[], geom geometry). The
+    // path is an array describing the location within the geometry
+    // (e.g. [1, 3] = third vertex of first ring); ordering by path
+    // gives a stable, sensible flat index across simple AND nested
+    // shapes (MultiPolygon, GeometryCollection). The OVER () window
+    // is per-input-row because of the LATERAL, so vertex_index
+    // resets at each input.
+    //
+    // global_id reuses the source row's id; downstream readers
+    // disambiguate vertices via (global_id, vertex_index). Adding a
+    // synthesized per-vertex unique id would make downstream tools
+    // treat each vertex as a distinct entity for identity purposes,
+    // which is the wrong default for a "show me the corners" tool.
+    const sql = `
+      SELECT
+        ${inputAlias}.global_id,
+        ST_SetSRID(dp.geom, 4326) AS geom,
+        ${inputAlias}.properties
+          || jsonb_build_object('vertex_index', dp.vertex_index)
+          AS properties
+      FROM ${inputAlias},
+      LATERAL (
+        SELECT
+          pt.geom,
+          (ROW_NUMBER() OVER (ORDER BY pt.path)) - 1 AS vertex_index
+        FROM ST_DumpPoints(${inputAlias}.geom) AS pt
+      ) dp
+      WHERE ${inputAlias}.geom IS NOT NULL
+    `;
+    return { sql, params: [] };
+  },
+};

--- a/apps/portal-web/src/app/items/[id]/derived-layer/detail.tsx
+++ b/apps/portal-web/src/app/items/[id]/derived-layer/detail.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { ArrowRight, FlaskConical, Layers } from 'lucide-react';
 import {
+  AREA_UNIT_LABELS,
   UNIT_LABELS,
   type DerivedLayerData,
   type Item,
@@ -170,6 +171,28 @@ function labelForTool(step: ToolStep): string {
       return 'Buffer';
     case 'dissolve':
       return 'Dissolve';
+    case 'centroid':
+      return 'Centroid';
+    case 'convex-hull':
+      return 'Convex hull';
+    case 'bbox':
+      return 'Bounding box';
+    case 'simplify':
+      return 'Simplify';
+    case 'vertices':
+      return 'Vertices';
+    case 'densify':
+      return 'Densify';
+    case 'top-n':
+      return 'Top N';
+    case 'random-sample':
+      return 'Random sample';
+    case 'nearest-neighbor':
+      return 'Nearest-neighbor distance';
+    case 'fishnet':
+      return 'Fishnet';
+    case 'calculate-geometry':
+      return 'Calculate geometry';
     default:
       // Future tools land in this default until they grow a label;
       // shows the raw kind so the panel never goes silently blank
@@ -200,6 +223,43 @@ function summarizeStep(step: ToolStep): string {
       // geometries) are explained in the design doc and the
       // builder's step editor.
       return 'merge all features';
+    case 'centroid':
+      return 'center point per feature';
+    case 'convex-hull':
+      return 'smallest enclosing convex polygon';
+    case 'bbox':
+      return 'axis-aligned bounding rectangle';
+    case 'simplify': {
+      const u = UNIT_LABELS[step.params.unit] ?? step.params.unit;
+      return `tolerance ${step.params.tolerance.toLocaleString()} ${u}`;
+    }
+    case 'vertices':
+      return 'one point per vertex';
+    case 'densify': {
+      const u = UNIT_LABELS[step.params.unit] ?? step.params.unit;
+      return `max ${step.params.maxSegmentLength.toLocaleString()} ${u} per segment`;
+    }
+    case 'top-n': {
+      const dir = step.params.direction === 'asc' ? 'lowest' : 'highest';
+      return `${dir} ${step.params.n.toLocaleString()} by ${step.params.field}`;
+    }
+    case 'random-sample':
+      return step.params.mode === 'percentage'
+        ? `~${step.params.value}% of rows`
+        : `${step.params.value.toLocaleString()} rows`;
+    case 'nearest-neighbor':
+      return 'distance to closest neighbor (m)';
+    case 'fishnet': {
+      const u = UNIT_LABELS[step.params.unit] ?? step.params.unit;
+      return `${step.params.cellSize.toLocaleString()} ${u} cells (${step.params.output})`;
+    }
+    case 'calculate-geometry': {
+      const u =
+        step.params.measurement === 'area'
+          ? AREA_UNIT_LABELS[step.params.unit] ?? step.params.unit
+          : UNIT_LABELS[step.params.unit] ?? step.params.unit;
+      return `${step.params.measurement} -> ${step.params.fieldName} (${u})`;
+    }
     default:
       return '';
   }

--- a/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
+++ b/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
@@ -848,6 +848,58 @@ const TOOL_DESCRIPTIONS: Record<ToolStep['tool'], string> = {
 };
 
 /**
+ * Logical tool groups for the toolbox modal. Borrows from PostGIS's
+ * own categorization (Geometry Processing / Accessors / Constructors /
+ * Measurement Functions) where it cleanly maps to user intent, and
+ * invents a UX-only category ('Filter') where it doesn't. Each group
+ * is rendered as its own section in the toolbox; adding a tool is two
+ * lines: extend TOOL_LABELS / TOOL_DESCRIPTIONS and append the kind
+ * to its group's `tools` array here.
+ *
+ * Order matters: groups render top-to-bottom in the order declared.
+ * A user opening the toolbox for the first time sees Reshape first,
+ * which covers the most common single-feature transforms.
+ */
+interface ToolGroup {
+  label: string;
+  description: string;
+  tools: Array<ToolStep['tool']>;
+}
+const TOOL_GROUPS: ToolGroup[] = [
+  {
+    label: 'Reshape',
+    description:
+      'Modify each feature’s geometry. Same row count out, attributes pass through.',
+    tools: ['buffer', 'simplify', 'densify', 'convex-hull', 'bbox'],
+  },
+  {
+    label: 'Extract',
+    description: 'Replace each feature with a piece extracted from it.',
+    tools: ['centroid', 'vertices'],
+  },
+  {
+    label: 'Combine',
+    description: 'Reduce many features to one or fewer.',
+    tools: ['dissolve'],
+  },
+  {
+    label: 'Measure',
+    description: 'Add a numeric attribute computed from each feature.',
+    tools: ['calculate-geometry', 'nearest-neighbor'],
+  },
+  {
+    label: 'Filter',
+    description: 'Keep a subset of rows, no geometry change.',
+    tools: ['top-n', 'random-sample'],
+  },
+  {
+    label: 'Generate',
+    description: 'Create new features from scratch.',
+    tools: ['fishnet'],
+  },
+];
+
+/**
  * Renders the pipeline as a vertical list of step cards. Between
  * each pair (and after the last, and before the first) sits an
  * "Add a step" button that opens a small picker showing every
@@ -871,6 +923,11 @@ function PipelineSection({
   onRemoveStep: (index: number) => void;
   onInsertStep: (index: number, kind: ToolStep['tool']) => void;
 }) {
+  // Toolbox modal state lives at the section level so a single modal
+  // instance serves every "Add a step" affordance. `pickerSlotIndex`
+  // is the pipeline index where the picked tool will be spliced in
+  // when the user makes a selection; null means the modal is closed.
+  const [pickerSlotIndex, setPickerSlotIndex] = useState<number | null>(null);
   return (
     <section className="space-y-2">
       <h4 className="text-xs font-medium uppercase tracking-wide text-muted">
@@ -887,7 +944,7 @@ function PipelineSection({
             a step without first having to add at the end and then
             reorder. */}
         <AddStepRow
-          onPick={(kind) => onInsertStep(0, kind)}
+          onClick={() => setPickerSlotIndex(0)}
           variant="slot"
         />
 
@@ -906,7 +963,7 @@ function PipelineSection({
                 list, so we lift it to a primary visual when it's
                 the last slot. */}
             <AddStepRow
-              onPick={(kind) => onInsertStep(idx + 1, kind)}
+              onClick={() => setPickerSlotIndex(idx + 1)}
               variant={idx === pipeline.length - 1 ? 'primary' : 'slot'}
             />
           </div>
@@ -918,6 +975,17 @@ function PipelineSection({
           </p>
         ) : null}
       </div>
+
+      <ToolToolbox
+        open={pickerSlotIndex !== null}
+        onClose={() => setPickerSlotIndex(null)}
+        onPick={(kind) => {
+          if (pickerSlotIndex !== null) {
+            onInsertStep(pickerSlotIndex, kind);
+          }
+          setPickerSlotIndex(null);
+        }}
+      />
     </section>
   );
 }
@@ -1036,80 +1104,201 @@ function StepCard({
 }
 
 /**
- * Inline insertion row. The "slot" variant is the small dashed-line
- * affordance between two cards; the "primary" variant is the
- * call-to-action button after the last step. Both open the same
- * picker; the variant is purely visual.
+ * Insertion-slot trigger between (or after) pipeline cards. The "slot"
+ * variant is the small dashed-line affordance between two cards; the
+ * "primary" variant is the call-to-action button after the last step.
+ * Both trigger the same toolbox modal; the parent owns the modal
+ * state so multiple slots share one modal instance.
  */
 function AddStepRow({
-  onPick,
+  onClick,
   variant,
 }: {
-  onPick: (kind: ToolStep['tool']) => void;
+  onClick: () => void;
   variant: 'slot' | 'primary';
 }) {
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  // Close on outside click. Same pattern the source picker uses;
-  // each AddStepRow is independent so concurrent open states across
-  // multiple slots don't collide.
-  useEffect(() => {
-    if (!open) return;
-    const onDocClick = (e: MouseEvent) => {
-      if (!containerRef.current) return;
-      if (!containerRef.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', onDocClick);
-    return () => document.removeEventListener('mousedown', onDocClick);
-  }, [open]);
-
   const triggerClasses =
     variant === 'primary'
       ? 'inline-flex h-9 items-center gap-1 rounded-md border border-accent/40 bg-accent/5 px-3 text-xs font-medium text-accent hover:bg-accent/10'
       : 'inline-flex h-7 items-center gap-1 rounded-md border border-dashed border-border bg-transparent px-2 text-[11px] text-muted hover:border-accent/50 hover:text-ink-1';
 
   return (
-    <div ref={containerRef} className="relative flex justify-center">
+    <div className="flex justify-center">
       <button
         type="button"
-        onClick={() => setOpen((o) => !o)}
+        onClick={onClick}
         className={triggerClasses}
-        aria-haspopup="menu"
-        aria-expanded={open}
       >
         <Plus className="h-3.5 w-3.5" />
         Add a step
       </button>
-      {open ? (
-        <div
-          role="menu"
-          className="absolute top-full z-20 mt-1 w-64 overflow-hidden rounded-md border border-border bg-surface-0 shadow-lg"
-        >
-          <ul className="p-1">
-            {(Object.keys(TOOL_LABELS) as Array<ToolStep['tool']>).map((kind) => (
-              <li key={kind}>
-                <button
-                  type="button"
-                  role="menuitem"
-                  onClick={() => {
-                    onPick(kind);
-                    setOpen(false);
-                  }}
-                  className="flex w-full flex-col items-start gap-0.5 rounded-md px-3 py-2 text-left text-sm hover:bg-surface-2"
-                >
-                  <span className="font-medium text-ink-0">
-                    {TOOL_LABELS[kind]}
-                  </span>
-                  <span className="text-[11px] text-muted">
-                    {TOOL_DESCRIPTIONS[kind]}
-                  </span>
-                </button>
-              </li>
-            ))}
-          </ul>
+    </div>
+  );
+}
+
+/**
+ * Modal "toolbox" for picking a tool to splice into the pipeline.
+ * Tools are organized into logical groups (see TOOL_GROUPS) so the
+ * list stays scannable as more tools are added. A search field at
+ * the top filters across all groups by name and description so a
+ * user who knows what they want doesn't have to scroll.
+ *
+ * Keyboard:
+ *   - Esc closes the modal
+ *   - "/" anywhere inside the modal jumps focus to the search input
+ *   - Tab / Shift-Tab walks through tool buttons in display order;
+ *     Enter on a focused button selects (this is just standard
+ *     button behavior, not custom)
+ *
+ * Click on the dimmed backdrop also dismisses; click on the inner
+ * card stops propagation so the modal stays open.
+ */
+function ToolToolbox({
+  open,
+  onClose,
+  onPick,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onPick: (kind: ToolStep['tool']) => void;
+}) {
+  const [query, setQuery] = useState('');
+  const searchRef = useRef<HTMLInputElement | null>(null);
+
+  // Reset the search query and focus the search input when the modal
+  // opens. Using rAF so the input has been mounted before focus().
+  useEffect(() => {
+    if (!open) return;
+    setQuery('');
+    const id = requestAnimationFrame(() => searchRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, [open]);
+
+  // Global keyboard shortcuts while the modal is open. Esc closes;
+  // "/" focuses the search bar (skipped when the user is already
+  // typing in it so the slash isn't swallowed).
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key === '/' && document.activeElement !== searchRef.current) {
+        e.preventDefault();
+        searchRef.current?.focus();
+        searchRef.current?.select();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  // Filter tool list by query against label / description / kind.
+  // Empty query keeps every group; otherwise empty groups are
+  // dropped from the rendered output entirely so a search like
+  // "buffer" doesn't show empty Reshape / Filter / etc. headings.
+  const q = query.trim().toLowerCase();
+  const visibleGroups = TOOL_GROUPS.map((g) => ({
+    ...g,
+    tools: g.tools.filter((kind) => {
+      if (!q) return true;
+      const haystack = [TOOL_LABELS[kind], TOOL_DESCRIPTIONS[kind], kind]
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(q);
+    }),
+  })).filter((g) => g.tools.length > 0);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 p-4 sm:items-center"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Add a step"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden rounded-lg border border-border bg-surface-0 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="border-b border-border p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div>
+              <h2 className="text-base font-semibold text-ink-0">
+                Add a step
+              </h2>
+              <p className="mt-0.5 text-xs text-muted">
+                Pick a tool. The output of this step becomes the input
+                of the next.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-muted hover:bg-surface-2 hover:text-ink-1"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="relative mt-3">
+            <Search
+              className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted"
+              aria-hidden="true"
+            />
+            <input
+              ref={searchRef}
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder='Filter tools (press "/" anywhere to focus)…'
+              className="h-10 w-full rounded-md border border-border bg-surface-1 pl-10 pr-3 text-sm text-ink-0 placeholder:text-muted focus:border-accent focus:outline-none"
+            />
+          </div>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-4">
+          {visibleGroups.length === 0 ? (
+            <p className="text-center text-sm text-muted">
+              No tools match "{query}".
+            </p>
+          ) : (
+            <div className="space-y-5">
+              {visibleGroups.map((g) => (
+                <section key={g.label}>
+                  <h3 className="text-xs font-medium uppercase tracking-wide text-muted">
+                    {g.label}
+                  </h3>
+                  <p className="mt-0.5 text-[11px] text-muted">
+                    {g.description}
+                  </p>
+                  <div className="mt-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                    {g.tools.map((kind) => (
+                      <button
+                        key={kind}
+                        type="button"
+                        onClick={() => onPick(kind)}
+                        className="flex flex-col items-start gap-1 rounded-md border border-border bg-surface-1 p-3 text-left transition-colors hover:border-accent/50 hover:bg-surface-2 focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent/30"
+                      >
+                        <span className="text-sm font-medium text-ink-0">
+                          {TOOL_LABELS[kind]}
+                        </span>
+                        <span className="text-[11px] text-muted">
+                          {TOOL_DESCRIPTIONS[kind]}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                </section>
+              ))}
+            </div>
+          )}
         </div>
-      ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
+++ b/apps/portal-web/src/app/items/new/derived-layer-builder.tsx
@@ -17,6 +17,8 @@ import {
   X,
 } from 'lucide-react';
 import {
+  AREA_UNITS,
+  AREA_UNIT_LABELS,
   DEFAULT_BUFFER_STEP,
   DEFAULT_DERIVED_LAYER_FEATURE_LIMIT,
   DEFAULT_STEPS,
@@ -24,7 +26,9 @@ import {
   MAX_BUFFER_DISTANCE_METERS,
   METERS_PER_UNIT,
   UNIT_LABELS,
+  type AreaUnit,
   type BufferParams,
+  type CalculateGeometryParams,
   type DerivedLayerData,
   type FeatureField,
   type Item,
@@ -812,11 +816,35 @@ function extractFields(data: unknown, layerKey: string | undefined): FeatureFiel
 const TOOL_LABELS: Record<ToolStep['tool'], string> = {
   buffer: 'Buffer',
   dissolve: 'Dissolve',
+  centroid: 'Centroid',
+  'convex-hull': 'Convex hull',
+  bbox: 'Bounding box',
+  simplify: 'Simplify',
+  vertices: 'Vertices',
+  densify: 'Densify',
+  'top-n': 'Top N by attribute',
+  'random-sample': 'Random sample',
+  'nearest-neighbor': 'Nearest-neighbor distance',
+  fishnet: 'Fishnet',
+  'calculate-geometry': 'Calculate geometry',
 };
 
 const TOOL_DESCRIPTIONS: Record<ToolStep['tool'], string> = {
   buffer: 'Expand features outward into polygon halos.',
   dissolve: 'Merge every input geometry into a single feature.',
+  centroid: 'Replace each feature with its center point.',
+  'convex-hull': 'Replace each feature with its smallest enclosing convex polygon.',
+  bbox: 'Replace each feature with its axis-aligned bounding rectangle.',
+  simplify: 'Drop vertices closer than the given tolerance.',
+  vertices: 'Explode each line / polygon into one point per vertex.',
+  densify: 'Add intermediate vertices so no segment exceeds a length.',
+  'top-n': 'Keep only the N highest or lowest values of a numeric field.',
+  'random-sample': 'Keep a deterministic random subset of features.',
+  'nearest-neighbor':
+    'Add a numeric field with the distance to the closest other feature.',
+  fishnet: 'Generate a grid of cells or transect lines over each polygon.',
+  'calculate-geometry':
+    'Add a length / perimeter / area field in your chosen unit.',
 };
 
 /**
@@ -949,7 +977,51 @@ function StepCard({
           sourcePicked={sourcePicked}
         />
       ) : step.tool === 'dissolve' ? (
-        <DissolveStepEditor />
+        <NoParamInfo body="Merges every feature into a single combined geometry. All attributes are dropped; downstream steps that need a specific column will fail validation if they sit after dissolve." />
+      ) : step.tool === 'centroid' ? (
+        <NoParamInfo body="Replaces each feature with its center point. Output is point geometry; attributes pass through." />
+      ) : step.tool === 'convex-hull' ? (
+        <NoParamInfo body="Replaces each feature with its convex hull (the smallest convex polygon enclosing it)." />
+      ) : step.tool === 'bbox' ? (
+        <NoParamInfo body="Replaces each feature with its axis-aligned bounding rectangle. Useful for extent-only views or spatial-bin clustering." />
+      ) : step.tool === 'simplify' ? (
+        <SimplifyStepEditor
+          params={step.params}
+          onChange={(params) => onChange({ tool: 'simplify', params })}
+        />
+      ) : step.tool === 'vertices' ? (
+        <NoParamInfo body="Explodes each line or polygon into one point feature per vertex. Adds a vertex_index column. Source attributes pass through." />
+      ) : step.tool === 'densify' ? (
+        <DensifyStepEditor
+          params={step.params}
+          onChange={(params) => onChange({ tool: 'densify', params })}
+        />
+      ) : step.tool === 'top-n' ? (
+        <TopNStepEditor
+          params={step.params}
+          onChange={(params) => onChange({ tool: 'top-n', params })}
+          sourceFields={sourceFields}
+          sourcePicked={sourcePicked}
+        />
+      ) : step.tool === 'random-sample' ? (
+        <RandomSampleStepEditor
+          params={step.params}
+          onChange={(params) => onChange({ tool: 'random-sample', params })}
+        />
+      ) : step.tool === 'nearest-neighbor' ? (
+        <NoParamInfo body="Adds a nearest_distance_m attribute to each feature: meters to its closest neighbor in this layer. Geometry passes through." />
+      ) : step.tool === 'fishnet' ? (
+        <FishnetStepEditor
+          params={step.params}
+          onChange={(params) => onChange({ tool: 'fishnet', params })}
+        />
+      ) : step.tool === 'calculate-geometry' ? (
+        <CalculateGeometryStepEditor
+          params={step.params}
+          onChange={(params) =>
+            onChange({ tool: 'calculate-geometry', params })
+          }
+        />
       ) : (
         // Forward-compat fallback for a tool kind a newer server
         // might emit that this client doesn't recognize. Surface
@@ -1200,17 +1272,434 @@ function BufferStepEditor({
 }
 
 /**
- * Editor for a dissolve step. v1 has no parameters, so this is
- * informational copy explaining the step's effect. The empty
- * params shape on the wire keeps the door open for a future
- * groupBy field without a UI rewrite.
+ * Reusable info-only step editor for tools that take no params.
+ * Several tools (dissolve, centroid, convex-hull, bbox, vertices,
+ * nearest-neighbor) fit this shape; rather than duplicating the
+ * informational paragraph for each, the dispatch passes the
+ * tool-specific copy in.
  */
-function DissolveStepEditor() {
+function NoParamInfo({ body }: { body: string }) {
+  return <p className="text-[11px] text-muted">{body}</p>;
+}
+
+/**
+ * Tolerance editor shared by simplify and densify. Both take a
+ * positive number plus a length unit, so the editor accepts a
+ * label and value/unit setters from the parent.
+ */
+function ToleranceEditor({
+  label,
+  hint,
+  value,
+  unit,
+  onValueChange,
+  onUnitChange,
+}: {
+  label: string;
+  hint?: string;
+  value: number;
+  unit: LengthUnit;
+  onValueChange: (n: number) => void;
+  onUnitChange: (u: LengthUnit) => void;
+}) {
   return (
-    <p className="text-[11px] text-muted">
-      Merges every feature into a single combined geometry. All
-      attributes are dropped; downstream steps that need a specific
-      column will fail validation if they sit after dissolve.
-    </p>
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="text-ink-1">{label}</span>
+      <span className="flex items-center gap-2">
+        <input
+          type="number"
+          min={0}
+          step={1}
+          value={Number.isFinite(value) ? value : 0}
+          onChange={(e) => onValueChange(Number(e.target.value))}
+          className="h-10 w-32 rounded-md border border-border bg-surface-1 px-3 text-sm text-ink-0 focus:border-accent focus:outline-none"
+        />
+        <UnitSelect value={unit} onChange={onUnitChange} />
+      </span>
+      {hint ? <span className="text-[11px] text-muted">{hint}</span> : null}
+    </label>
+  );
+}
+
+function SimplifyStepEditor({
+  params,
+  onChange,
+}: {
+  params: { tolerance: number; unit: LengthUnit };
+  onChange: (next: { tolerance: number; unit: LengthUnit }) => void;
+}) {
+  return (
+    <ToleranceEditor
+      label="Tolerance"
+      hint="Vertices closer than this distance are dropped. Higher = simpler shapes; smaller = closer to the original."
+      value={params.tolerance}
+      unit={params.unit}
+      onValueChange={(tolerance) => onChange({ tolerance, unit: params.unit })}
+      onUnitChange={(unit) => onChange({ tolerance: params.tolerance, unit })}
+    />
+  );
+}
+
+function DensifyStepEditor({
+  params,
+  onChange,
+}: {
+  params: { maxSegmentLength: number; unit: LengthUnit };
+  onChange: (next: { maxSegmentLength: number; unit: LengthUnit }) => void;
+}) {
+  return (
+    <ToleranceEditor
+      label="Max segment length"
+      hint="Adds intermediate vertices so no segment is longer than this."
+      value={params.maxSegmentLength}
+      unit={params.unit}
+      onValueChange={(maxSegmentLength) =>
+        onChange({ maxSegmentLength, unit: params.unit })
+      }
+      onUnitChange={(unit) =>
+        onChange({ maxSegmentLength: params.maxSegmentLength, unit })
+      }
+    />
+  );
+}
+
+function TopNStepEditor({
+  params,
+  onChange,
+  sourceFields,
+  sourcePicked,
+}: {
+  params: { field: string; n: number; direction: 'asc' | 'desc' };
+  onChange: (next: {
+    field: string;
+    n: number;
+    direction: 'asc' | 'desc';
+  }) => void;
+  sourceFields: FeatureField[];
+  sourcePicked: boolean;
+}) {
+  const numericFields = sourceFields.filter((f) => f.type === 'number');
+  return (
+    <div className="space-y-2">
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-ink-1">Numeric field</span>
+        <select
+          value={params.field}
+          onChange={(e) => onChange({ ...params, field: e.target.value })}
+          disabled={!sourcePicked || numericFields.length === 0}
+          className="h-10 rounded-md border border-border bg-surface-1 px-3 text-sm text-ink-0 focus:border-accent focus:outline-none disabled:opacity-60"
+        >
+          {params.field === '' ? (
+            <option value="">
+              {!sourcePicked
+                ? 'Pick a source layer first'
+                : numericFields.length === 0
+                  ? 'No numeric fields on the source'
+                  : 'Pick a numeric field…'}
+            </option>
+          ) : null}
+          {numericFields.map((f) => (
+            <option key={f.name} value={f.name}>
+              {f.label || f.name}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-ink-1">Keep</span>
+        <span className="flex items-center gap-2">
+          <input
+            type="number"
+            min={1}
+            step={1}
+            value={Number.isFinite(params.n) ? params.n : 1}
+            onChange={(e) =>
+              onChange({ ...params, n: Math.max(1, Math.floor(Number(e.target.value))) })
+            }
+            className="h-10 w-24 rounded-md border border-border bg-surface-1 px-3 text-sm text-ink-0 focus:border-accent focus:outline-none"
+          />
+          <select
+            value={params.direction}
+            onChange={(e) =>
+              onChange({
+                ...params,
+                direction: e.target.value === 'asc' ? 'asc' : 'desc',
+              })
+            }
+            className="h-10 rounded-md border border-border bg-surface-1 px-2 text-sm text-ink-0 focus:border-accent focus:outline-none"
+          >
+            <option value="desc">highest</option>
+            <option value="asc">lowest</option>
+          </select>
+        </span>
+        <span className="text-[11px] text-muted">
+          The N rows with the {params.direction === 'asc' ? 'lowest' : 'highest'}{' '}
+          values of the chosen field. NULLs are dropped.
+        </span>
+      </label>
+    </div>
+  );
+}
+
+function RandomSampleStepEditor({
+  params,
+  onChange,
+}: {
+  params: { mode: 'percentage' | 'count'; value: number; seed: number };
+  onChange: (next: {
+    mode: 'percentage' | 'count';
+    value: number;
+    seed: number;
+  }) => void;
+}) {
+  // Persist a stable seed once the user inserts the step. The
+  // generator's validate() also subs a default for seed=0, so the
+  // wizard never needs to ship a fresh random integer; preserving
+  // whatever seed lands here keeps the sample stable across edits.
+  const seed = params.seed || Math.floor(Math.random() * 2147483646) + 1;
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-2 gap-2" role="radiogroup" aria-label="Sample mode">
+        <button
+          type="button"
+          role="radio"
+          aria-checked={params.mode === 'percentage'}
+          onClick={() => onChange({ mode: 'percentage', value: 10, seed })}
+          className={`flex flex-col items-start gap-0.5 rounded-md border p-2.5 text-left transition-colors ${
+            params.mode === 'percentage'
+              ? 'border-accent bg-accent/5 ring-2 ring-accent/30'
+              : 'border-border bg-surface-1 hover:bg-surface-2'
+          }`}
+        >
+          <span className="text-sm font-medium text-ink-1">Percentage</span>
+          <span className="text-[11px] text-muted">Approximately N percent of rows.</span>
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={params.mode === 'count'}
+          onClick={() => onChange({ mode: 'count', value: 100, seed })}
+          className={`flex flex-col items-start gap-0.5 rounded-md border p-2.5 text-left transition-colors ${
+            params.mode === 'count'
+              ? 'border-accent bg-accent/5 ring-2 ring-accent/30'
+              : 'border-border bg-surface-1 hover:bg-surface-2'
+          }`}
+        >
+          <span className="text-sm font-medium text-ink-1">Exact count</span>
+          <span className="text-[11px] text-muted">Exactly N rows.</span>
+        </button>
+      </div>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-ink-1">
+          {params.mode === 'percentage' ? 'Percent' : 'Number of rows'}
+        </span>
+        <input
+          type="number"
+          min={1}
+          max={params.mode === 'percentage' ? 100 : undefined}
+          step={1}
+          value={Number.isFinite(params.value) ? params.value : 1}
+          onChange={(e) =>
+            onChange({ ...params, value: Number(e.target.value), seed })
+          }
+          className="h-10 w-32 rounded-md border border-border bg-surface-1 px-3 text-sm text-ink-0 focus:border-accent focus:outline-none"
+        />
+        <span className="text-[11px] text-muted">
+          Sample is deterministic given the seed below; same recipe = same
+          rows on every read.
+        </span>
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-ink-1">Seed</span>
+        <span className="flex items-center gap-2">
+          <input
+            type="number"
+            value={seed}
+            onChange={(e) =>
+              onChange({ ...params, seed: Number(e.target.value) || 1 })
+            }
+            className="h-10 w-32 rounded-md border border-border bg-surface-1 px-3 text-sm text-ink-0 focus:border-accent focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={() =>
+              onChange({
+                ...params,
+                seed: Math.floor(Math.random() * 2147483646) + 1,
+              })
+            }
+            className="h-10 rounded-md border border-border bg-surface-1 px-3 text-xs text-ink-1 hover:bg-surface-2"
+          >
+            Shuffle
+          </button>
+        </span>
+      </label>
+    </div>
+  );
+}
+
+function FishnetStepEditor({
+  params,
+  onChange,
+}: {
+  params: { cellSize: number; unit: LengthUnit; output: 'polygons' | 'lines' };
+  onChange: (next: {
+    cellSize: number;
+    unit: LengthUnit;
+    output: 'polygons' | 'lines';
+  }) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <ToleranceEditor
+        label="Cell size"
+        hint="Side length of each grid cell. Smaller = more cells = more compute."
+        value={params.cellSize}
+        unit={params.unit}
+        onValueChange={(cellSize) => onChange({ ...params, cellSize })}
+        onUnitChange={(unit) => onChange({ ...params, unit })}
+      />
+      <div className="grid grid-cols-2 gap-2" role="radiogroup" aria-label="Output mode">
+        <button
+          type="button"
+          role="radio"
+          aria-checked={params.output === 'polygons'}
+          onClick={() => onChange({ ...params, output: 'polygons' })}
+          className={`flex flex-col items-start gap-0.5 rounded-md border p-2.5 text-left transition-colors ${
+            params.output === 'polygons'
+              ? 'border-accent bg-accent/5 ring-2 ring-accent/30'
+              : 'border-border bg-surface-1 hover:bg-surface-2'
+          }`}
+        >
+          <span className="text-sm font-medium text-ink-1">Polygons</span>
+          <span className="text-[11px] text-muted">Filled grid cells.</span>
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={params.output === 'lines'}
+          onClick={() => onChange({ ...params, output: 'lines' })}
+          className={`flex flex-col items-start gap-0.5 rounded-md border p-2.5 text-left transition-colors ${
+            params.output === 'lines'
+              ? 'border-accent bg-accent/5 ring-2 ring-accent/30'
+              : 'border-border bg-surface-1 hover:bg-surface-2'
+          }`}
+        >
+          <span className="text-sm font-medium text-ink-1">Lines</span>
+          <span className="text-[11px] text-muted">Grid lines / transects only.</span>
+        </button>
+      </div>
+      <p className="text-[11px] text-muted">
+        Restricted to polygon input. Output drops source attributes; each
+        cell carries cell_row and cell_col.
+      </p>
+    </div>
+  );
+}
+
+function CalculateGeometryStepEditor({
+  params,
+  onChange,
+}: {
+  params: CalculateGeometryParams;
+  onChange: (next: CalculateGeometryParams) => void;
+}) {
+  // Switching measurement re-keys the unit because length and area
+  // use different unit unions. Persist the field name across
+  // measurement changes so a user who picked a name doesn't have to
+  // retype it after toggling.
+  const setMeasurement = (m: 'length' | 'perimeter' | 'area') => {
+    if (m === params.measurement) return;
+    if (m === 'area') {
+      onChange({
+        measurement: 'area',
+        unit: 'square-meters',
+        fieldName: params.fieldName,
+      });
+    } else {
+      onChange({
+        measurement: m,
+        unit: 'meters',
+        fieldName: params.fieldName,
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label="Measurement">
+        {(['length', 'perimeter', 'area'] as const).map((m) => (
+          <button
+            key={m}
+            type="button"
+            role="radio"
+            aria-checked={params.measurement === m}
+            onClick={() => setMeasurement(m)}
+            className={`flex items-center justify-center rounded-md border p-2 text-sm capitalize transition-colors ${
+              params.measurement === m
+                ? 'border-accent bg-accent/5 ring-2 ring-accent/30 text-ink-0'
+                : 'border-border bg-surface-1 text-ink-1 hover:bg-surface-2'
+            }`}
+          >
+            {m}
+          </button>
+        ))}
+      </div>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-ink-1">Unit</span>
+        {params.measurement === 'area' ? (
+          <select
+            value={params.unit}
+            onChange={(e) =>
+              onChange({
+                ...params,
+                measurement: 'area',
+                unit: e.target.value as AreaUnit,
+              })
+            }
+            className="h-10 rounded-md border border-border bg-surface-1 px-3 text-sm text-ink-0 focus:border-accent focus:outline-none"
+          >
+            {AREA_UNITS.map((u) => (
+              <option key={u} value={u}>
+                {u} ({AREA_UNIT_LABELS[u]})
+              </option>
+            ))}
+          </select>
+        ) : (
+          <UnitSelect
+            value={params.unit}
+            onChange={(unit) =>
+              onChange({
+                ...params,
+                measurement: params.measurement,
+                unit,
+              })
+            }
+          />
+        )}
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="text-ink-1">Field name</span>
+        <input
+          type="text"
+          value={params.fieldName}
+          onChange={(e) =>
+            onChange({ ...params, fieldName: e.target.value } as CalculateGeometryParams)
+          }
+          maxLength={60}
+          placeholder="e.g. area_ha, length_km"
+          className="h-10 rounded-md border border-border bg-surface-1 px-3 text-sm text-ink-0 focus:border-accent focus:outline-none"
+        />
+        <span className="text-[11px] text-muted">
+          Letters, numbers, and underscores. Cannot match an existing field
+          on the source.
+        </span>
+      </label>
+    </div>
   );
 }

--- a/packages/shared-types/src/derived-layer.ts
+++ b/packages/shared-types/src/derived-layer.ts
@@ -18,7 +18,7 @@
  */
 
 import type { FeatureField } from './data-layer';
-import type { LengthUnit } from './length';
+import type { AreaUnit, LengthUnit } from './length';
 
 /**
  * v1 always points at a single data_layer item. Stored as a tagged
@@ -104,12 +104,198 @@ export interface DissolveStep {
 }
 
 /**
+ * Centroid tool step. Replaces each input geometry with its centroid
+ * point via PostGIS `ST_Centroid(geom)`. Attributes pass through
+ * unchanged. Output is always point geometry regardless of input.
+ *
+ * Useful for "where is the middle of each polygon" workflows
+ * (labeling, density grids, snapping to nearest road, etc).
+ */
+export interface CentroidStep {
+  tool: 'centroid';
+  params: Record<string, never>;
+}
+
+/**
+ * Convex-hull tool step. Replaces each input geometry with its
+ * convex hull (`ST_ConvexHull`). Attributes pass through. v1
+ * computes per-feature; an aggregate "hull of all features" mode
+ * could land later as a `mode: 'aggregate'` switch.
+ */
+export interface ConvexHullStep {
+  tool: 'convex-hull';
+  params: Record<string, never>;
+}
+
+/**
+ * Bounding-box (envelope) tool step. Replaces each input geometry
+ * with its axis-aligned bounding rectangle via `ST_Envelope(geom)`.
+ * Attributes pass through. Output is polygon geometry.
+ */
+export interface BboxStep {
+  tool: 'bbox';
+  params: Record<string, never>;
+}
+
+/**
+ * Simplify tool step. Reduces vertex count via Douglas-Peucker on
+ * the input geometry. Tolerance is in meters via the geography
+ * cast, matching buffer's distance handling. Smaller tolerance =
+ * more vertices kept = closer to original.
+ */
+export interface SimplifyStep {
+  tool: 'simplify';
+  params: {
+    /** Tolerance in `unit`. Vertices closer than this are dropped. */
+    tolerance: number;
+    unit: LengthUnit;
+  };
+}
+
+/**
+ * Vertices tool step. Explodes each input line / polygon geometry
+ * into one point feature per vertex. Adds `vertex_index` (0-based)
+ * to each output row's attributes; the source schema is preserved
+ * alongside it. Useful for "show me the corners" workflows.
+ */
+export interface VerticesStep {
+  tool: 'vertices';
+  params: Record<string, never>;
+}
+
+/**
+ * Densify tool step. Adds intermediate vertices along input lines /
+ * polygon boundaries so no segment exceeds `maxSegmentLength` in
+ * `unit`. Uses `ST_Segmentize` on geography for accurate-on-Earth
+ * spacing. Useful before reprojection (line preservation) and for
+ * smoother along-line interpolation.
+ */
+export interface DensifyStep {
+  tool: 'densify';
+  params: {
+    maxSegmentLength: number;
+    unit: LengthUnit;
+  };
+}
+
+/**
+ * Top-N filter step. Keeps the N rows with the highest (or lowest)
+ * value of a numeric field. The field must exist on the upstream
+ * schema and be numeric. Useful for "ten largest parcels", "five
+ * closest hospitals" style workflows once distance fields are
+ * available.
+ */
+export interface TopNStep {
+  tool: 'top-n';
+  params: {
+    field: string;
+    n: number;
+    direction: 'asc' | 'desc';
+  };
+}
+
+/**
+ * Random-sample filter step. Returns a deterministic random subset
+ * of the input. `mode: 'percentage'` keeps roughly `value` percent
+ * of rows; `mode: 'count'` keeps exactly `value` rows. The seed is
+ * persisted so the same recipe yields the same sample across reads.
+ */
+export interface RandomSampleStep {
+  tool: 'random-sample';
+  params: {
+    mode: 'percentage' | 'count';
+    /** Percentage in 0..100 when mode='percentage'; count when 'count'. */
+    value: number;
+    /** Persisted random seed for stable output across reads. */
+    seed: number;
+  };
+}
+
+/**
+ * Nearest-neighbor distance step. Adds a `nearest_distance_m`
+ * numeric attribute to each input feature: the meters-distance to
+ * the closest OTHER feature in the same input. Computed via a
+ * self-join with `ST_Distance(geography, geography)`. Geometry
+ * passes through unchanged. The first / only feature in a layer
+ * yields NULL.
+ */
+export interface NearestNeighborStep {
+  tool: 'nearest-neighbor';
+  params: Record<string, never>;
+}
+
+/**
+ * Fishnet step. Generates a grid of square cells (or transect
+ * lines) covering each input polygon's bounding box, clipped to
+ * the polygon. Cell size in `unit`. Output mode picks polygons
+ * (filled cells) or lines (just the grid lines / transects).
+ *
+ * Restricted to polygon input: the generator validates the source
+ * schema's geometryType when the recipe is saved.
+ */
+export interface FishnetStep {
+  tool: 'fishnet';
+  params: {
+    cellSize: number;
+    unit: LengthUnit;
+    /** 'polygons' = filled cells; 'lines' = grid lines only. */
+    output: 'polygons' | 'lines';
+  };
+}
+
+/**
+ * Calculate-geometry step. Adds one numeric attribute per row whose
+ * value is the input geometry's length, perimeter, or area in the
+ * user-chosen unit. The output column name is also user-chosen so the
+ * recipe can produce a meaningful field ("acreage", "length_km")
+ * instead of a generic name.
+ *
+ * Length and perimeter units are LengthUnit; area uses AreaUnit
+ * (square versions plus hectares and acres). The generator picks the
+ * right SQL based on `measurement` so a single tool covers all three
+ * cases without forcing the user to pick a measurement-specific
+ * sub-tool.
+ *
+ * Geometry passes through unchanged; the source schema gains exactly
+ * one numeric field with the user's chosen name.
+ */
+export type CalculateGeometryParams =
+  | {
+      measurement: 'length' | 'perimeter';
+      unit: LengthUnit;
+      fieldName: string;
+    }
+  | {
+      measurement: 'area';
+      unit: AreaUnit;
+      fieldName: string;
+    };
+
+export interface CalculateGeometryStep {
+  tool: 'calculate-geometry';
+  params: CalculateGeometryParams;
+}
+
+/**
  * Discriminated union of every available tool step. Adding a new tool
  * means adding a member here, a generator file in
  * apps/portal-api/src/derived-layers/tools/, and a wizard step in
  * apps/portal-web. No schema migration required.
  */
-export type ToolStep = BufferStep | DissolveStep;
+export type ToolStep =
+  | BufferStep
+  | DissolveStep
+  | CentroidStep
+  | ConvexHullStep
+  | BboxStep
+  | SimplifyStep
+  | VerticesStep
+  | DensifyStep
+  | TopNStep
+  | RandomSampleStep
+  | NearestNeighborStep
+  | FishnetStep
+  | CalculateGeometryStep;
 
 /**
  * The recipe persisted in `item.data` when `type = 'derived_layer'`.
@@ -193,6 +379,64 @@ export const DEFAULT_DISSOLVE_STEP: DissolveStep = {
   params: {},
 };
 
+export const DEFAULT_CENTROID_STEP: CentroidStep = {
+  tool: 'centroid',
+  params: {},
+};
+export const DEFAULT_CONVEX_HULL_STEP: ConvexHullStep = {
+  tool: 'convex-hull',
+  params: {},
+};
+export const DEFAULT_BBOX_STEP: BboxStep = {
+  tool: 'bbox',
+  params: {},
+};
+export const DEFAULT_SIMPLIFY_STEP: SimplifyStep = {
+  tool: 'simplify',
+  params: { tolerance: 10, unit: 'meters' },
+};
+export const DEFAULT_VERTICES_STEP: VerticesStep = {
+  tool: 'vertices',
+  params: {},
+};
+export const DEFAULT_DENSIFY_STEP: DensifyStep = {
+  tool: 'densify',
+  params: { maxSegmentLength: 100, unit: 'meters' },
+};
+export const DEFAULT_TOP_N_STEP: TopNStep = {
+  tool: 'top-n',
+  params: { field: '', n: 10, direction: 'desc' },
+};
+export const DEFAULT_RANDOM_SAMPLE_STEP: RandomSampleStep = {
+  tool: 'random-sample',
+  // Percentage mode by default at 10%; the wizard rolls a fresh seed
+  // when the user inserts the step so two newly-added samples don't
+  // accidentally produce the same subset. The persisted seed makes
+  // the output stable across reads of the same recipe.
+  params: { mode: 'percentage', value: 10, seed: 0 },
+};
+export const DEFAULT_NEAREST_NEIGHBOR_STEP: NearestNeighborStep = {
+  tool: 'nearest-neighbor',
+  params: {},
+};
+export const DEFAULT_FISHNET_STEP: FishnetStep = {
+  tool: 'fishnet',
+  params: { cellSize: 100, unit: 'meters', output: 'polygons' },
+};
+export const DEFAULT_CALCULATE_GEOMETRY_STEP: CalculateGeometryStep = {
+  tool: 'calculate-geometry',
+  // Default to area in square meters with a sensible field name; the
+  // wizard surfaces a measurement toggle so the user picks length /
+  // perimeter / area immediately on insert. Field name is
+  // user-editable but starts with the measurement name so a recipe
+  // saved without changing it still produces a coherent column.
+  params: {
+    measurement: 'area',
+    unit: 'square-meters',
+    fieldName: 'area',
+  },
+};
+
 /**
  * Lookup table of "what step should we splice into the pipeline when
  * the user picks <tool>?" Exported alongside the per-step defaults so
@@ -203,6 +447,17 @@ export const DEFAULT_DISSOLVE_STEP: DissolveStep = {
 export const DEFAULT_STEPS: Record<ToolStep['tool'], ToolStep> = {
   buffer: DEFAULT_BUFFER_STEP,
   dissolve: DEFAULT_DISSOLVE_STEP,
+  centroid: DEFAULT_CENTROID_STEP,
+  'convex-hull': DEFAULT_CONVEX_HULL_STEP,
+  bbox: DEFAULT_BBOX_STEP,
+  simplify: DEFAULT_SIMPLIFY_STEP,
+  vertices: DEFAULT_VERTICES_STEP,
+  densify: DEFAULT_DENSIFY_STEP,
+  'top-n': DEFAULT_TOP_N_STEP,
+  'random-sample': DEFAULT_RANDOM_SAMPLE_STEP,
+  'nearest-neighbor': DEFAULT_NEAREST_NEIGHBOR_STEP,
+  fishnet: DEFAULT_FISHNET_STEP,
+  'calculate-geometry': DEFAULT_CALCULATE_GEOMETRY_STEP,
 };
 
 /**

--- a/packages/shared-types/src/length.ts
+++ b/packages/shared-types/src/length.ts
@@ -82,3 +82,76 @@ export const LENGTH_UNITS: ReadonlyArray<LengthUnit> = [
   'yards',
   'miles',
 ];
+
+/**
+ * Area units used by the calculate-geometry tool's area mode. Square
+ * versions of the length units, plus hectares and acres which are the
+ * conventional "land parcel" units in metric and imperial respectively.
+ */
+export type AreaUnit =
+  | 'square-meters'
+  | 'square-kilometers'
+  | 'hectares'
+  | 'square-feet'
+  | 'square-yards'
+  | 'acres'
+  | 'square-miles';
+
+/**
+ * Square meters in one unit of `AreaUnit`. Multiply by a value in
+ * that unit to get square meters; divide a square-meters value to
+ * convert into that unit.
+ *
+ * Constants chosen to match international definitions: 1 ha = 10_000
+ * square meters, 1 acre = 4046.8564224 square meters (exactly), 1
+ * square mile = 1609.344 squared. Square versions of the LengthUnit
+ * factors are exact under `Math.pow(metersPerUnit, 2)` so we keep
+ * them factored that way for the linear units; ha and acres are
+ * spelled out.
+ */
+export const SQ_METERS_PER_AREA_UNIT: Record<AreaUnit, number> = {
+  'square-meters': 1,
+  'square-kilometers': 1_000_000,
+  hectares: 10_000,
+  'square-feet': 0.3048 * 0.3048,
+  'square-yards': 0.9144 * 0.9144,
+  acres: 4046.8564224,
+  'square-miles': 1609.344 * 1609.344,
+};
+
+export const AREA_UNIT_LABELS: Record<AreaUnit, string> = {
+  'square-meters': 'm2',
+  'square-kilometers': 'km2',
+  hectares: 'ha',
+  'square-feet': 'ft2',
+  'square-yards': 'yd2',
+  acres: 'ac',
+  'square-miles': 'mi2',
+};
+
+export const AREA_UNITS: ReadonlyArray<AreaUnit> = [
+  'square-meters',
+  'square-kilometers',
+  'hectares',
+  'square-feet',
+  'square-yards',
+  'acres',
+  'square-miles',
+];
+
+export function isAreaUnit(value: unknown): value is AreaUnit {
+  return (
+    typeof value === 'string' &&
+    Object.prototype.hasOwnProperty.call(SQ_METERS_PER_AREA_UNIT, value)
+  );
+}
+
+/**
+ * Convert a square-meters value into `unit`. Used by tools that
+ * compute on geography (which returns square meters) and want to
+ * surface a user-friendly unit. Divide-by-the-factor; pure.
+ */
+export function areaInUnit(squareMeters: number, unit: AreaUnit): number {
+  if (unit === 'square-meters') return squareMeters;
+  return squareMeters / SQ_METERS_PER_AREA_UNIT[unit];
+}


### PR DESCRIPTION
A batch of analysis tools that round out the derived-layer surface to actual usefulness, plus three follow-ups that surfaced during testing: a runtime safety check for fishnet, a redesigned tool picker, and a small bump to the pipeline-length cap.

## The eleven tools

All plug into the existing `ToolGenerator` contract: no architectural changes, no recipe-shape breaks, no migration. Each tool is one file in `tools/`, one spec, one entry in the registry, one entry in `TOOL_LABELS`, one branch in the `StepCard` dispatch, and one summarizer in the detail panel.

### Geometry transforms (single-input, attributes pass through)

- **centroid:** `ST_Centroid` per row. Output is point geometry; useful for labeling, density grids, snapping.
- **convex-hull:** `ST_ConvexHull` per row. Per-feature only in v1; an aggregate "hull of all features" mode is a future add.
- **bbox:** `ST_Envelope` per row. Useful for extent-only views and spatial-bin clustering.
- **simplify:** `ST_Simplify` with tolerance in user-chosen `LengthUnit`, converted to degrees at SQL emission.
- **vertices:** `ST_DumpPoints` under a LATERAL. Adds `vertex_index` column; source attributes pass through.
- **densify:** `ST_Segmentize` on geography with the user's chosen unit converted to meters. Useful before reprojection / sampling.

### Filters (no geometry change, fewer rows out)

- **top-n:** `ORDER BY (properties->>field)::double precision LIMIT N`. Field must be numeric; validated against the source schema at save time, trusted at read time. NULLs sorted to the end so a top-10 on a sparse column doesn't return NULL rows.
- **random-sample:** deterministic via `md5(global_id || seed)`. Two modes: percentage (md5 < threshold) and exact count (`ORDER BY md5 LIMIT N`). Persisted seed = stable output across reads of the same recipe; the wizard surfaces a Shuffle button to roll a fresh one.

### Compute new attributes

- **nearest-neighbor:** self-join with `MIN(ST_Distance(a::geography, b::geography))` excluding self. Adds `nearest_distance_m` to each row. v1 is O(N²); KNN-via-GIST is a future optimization once the pipeline gains per-step indexes.
- **calculate-geometry:** `ST_Length` / `ST_Area` / `ST_Length(ST_Boundary)` on geography, converted to user-chosen unit. User picks measurement (length / perimeter / area), unit, and field name. Validates the field name shape and rejects names that already exist on the source schema (overwriting source columns from a recipe step is not the right default).

### Generate new geometry

- **fishnet:** `ST_SquareGrid` with a LATERAL to clip cells to each input polygon. Two output modes: **polygons** (filled cells) and **lines** (cell boundaries clipped to the polygon, useful for transects). Drops source attributes; emits `cell_row` / `cell_col` per cell. Restricted to polygon input.

## Fishnet cell-count safety check

Caught during testing: a 1m cellSize on a state-sized polygon filled Postgres's `pgsql_tmp/` directory and took the database down for every other query that needed work_mem until temp space cleared. ST_SquareGrid materializes cells across the source bbox before the polygon-intersection filter, so the intermediate row count is bounded by `bboxArea / cellSize²` (potentially billions) rather than by the recipe's `featureLimit` (which only caps the final output).

Fix: fishnet now implements an `enrich` hook that runs at recipe-save time. It queries `ST_Extent` over the source feature table, estimates the cell count from bbox dimensions and cellSize, and rejects recipes whose estimate exceeds `MAX_CELLS_PER_RECIPE` (1,000,000) with a clear error message. Empty sources accept the recipe (cell count is zero). The estimate uses an equator-based meters-per-degree approximation, which over-counts at high latitudes — the right bias for a safety check.

Read-time impact: zero. The hook only runs at validate time on save. Existing recipes saved before this commit are not retroactively re-validated; if an existing recipe is dangerous, opening the edit page and re-saving triggers the new check.

## Toolbox modal

The flat dropdown the picker shipped with in PR3 was fine with two tools and got unwieldy at thirteen. This PR replaces it with a centered modal that groups tools into PostGIS-inspired buckets and surfaces a search input.

Six groups in display order:

- **Reshape** (PostGIS: Geometry Processing + Editors): buffer, simplify, densify, convex-hull, bbox
- **Extract** (PostGIS: Geometry Accessors): centroid, vertices
- **Combine** (PostGIS: Geometry Processing — aggregation): dissolve
- **Measure** (PostGIS: Measurement Functions): calculate-geometry, nearest-neighbor
- **Filter** (UX category — no direct PostGIS analogue): top-n, random-sample
- **Generate** (PostGIS: Geometry Constructors): fishnet

Adding a tool stays cheap: extend `TOOL_LABELS` / `TOOL_DESCRIPTIONS` and append the kind to its group's `tools` array in `TOOL_GROUPS`.

UI shape: centered, max width 768px, max height 85vh; each group renders as a section with header + 2-3 column grid of tool cards (responsive); search field at the top filters across label / description / kind, with empty groups dropped from the filtered view; click on a card splices the tool's default scaffold and closes the modal.

State is hoisted: `PipelineSection` owns `pickerSlotIndex` so a single modal instance serves every "Add a step" affordance. `AddStepRow` simplifies into a plain trigger button — no popover, no document-click handler, no per-row open state.

Keyboard: Esc closes; `/` jumps focus to the search input (skipped when already typing in it); Tab walks through tool buttons in display order; Enter on a focused button selects.

Forward-looking: each new tool added to the registry gets a group entry; the modal scales without a layout rewrite. At 30+ tools the search input becomes the primary path; the keyboard shortcut is in place for that era already.

## Pipeline-step cap raised

The original cap of 8 was set when only one tool existed and chaining was theoretical. With the wider tool set in this PR, real recipes chain more meaningfully (typical workflows are 3–6 steps; an analysis that buffers, dissolves, simplifies, computes geometry, and filters to top-N is already 5). Raised to 10 — comfortable headroom for the typical case without losing the "are you sure?" guardrail against a runaway client posting a thousand-step pipeline.

The per-tool runtime caps (`MAX_BUFFER_DISTANCE_METERS`, `MAX_CELLS_PER_RECIPE`, the recipe's `featureLimit` ceiling) remain the load-bearing safety nets; this constant is the soft check that blocks pathological inputs before any per-tool budget fires.

## Shared-types

- `AreaUnit` added to `length.ts`: `square-meters` / `square-kilometers` / `hectares` / `square-feet` / `square-yards` / `acres` / `square-miles` with `SQ_METERS_PER_AREA_UNIT`, `AREA_UNIT_LABELS`, `AREA_UNITS`, `isAreaUnit`, `areaInUnit`. Hectares and acres are first-class units; the rest are squares of the corresponding `LengthUnit`.
- `ToolStep` union widened by 11 members. `DEFAULT_STEPS` map covers every kind so the chained-pipeline picker emits a coherent scaffold on every insert.

## Frontend per-tool editors

- `StepCard` dispatches on `step.tool` to render the right editor. Tools without params reuse a tiny `NoParamInfo` component so dissolve, centroid, convex-hull, bbox, vertices, and nearest-neighbor share one shape.
- `ToleranceEditor` is shared by simplify and densify (both take number + LengthUnit).
- `TopNStepEditor` reuses the numeric-field picker pattern from buffer's field-mode controls.
- `RandomSampleStepEditor` surfaces a mode toggle (percentage / exact count), a value input with appropriate caps, and a Shuffle button that rolls a fresh seed in component state.
- `FishnetStepEditor` adds a polygon/lines output toggle alongside the cell-size + unit pair.
- `CalculateGeometryStepEditor` toggles between length / perimeter / area, swapping the unit picker between `LengthUnit` and `AreaUnit` when the measurement changes.
- detail panel `labelForTool` / `summarizeStep` cover all eleven; the summaries are concise enough to read at a glance ("tolerance 10 m", "highest 10 by population", "100 m cells (polygons)").

## Tests

97 new unit tests; 203 passing across the API. Each generator covers `validate` (positive cases, missing fields, type-mismatches, ceiling enforcement, unit-converted ceilings), `outputSchema` (preserved / appended / dropped as appropriate), `outwardReachMeters` (0 in every new tool), `extractDependencies` (empty for all v1 tools), and `toSql` (correct PostGIS calls, parameter ordering, paramOffset honored). Fishnet adds 7 enrich-path tests: accepts within-cap recipes, rejects above-cap recipes (including unit-converted), accepts empty sources, queries via ST_Extent, coerces string-typed bbox columns from PostgreSQL drivers.

## Two notes for the reviewer

1. **Fishnet uses PostGIS 3.1+ `ST_SquareGrid`.** The project's stated minimum is 3.3 (`infra/docker/postgres`), so this is fine, but if the deploy target ever drops below 3.1 fishnet would fail at read time. Worth a comment in the design doc.
2. **Nearest-neighbor is O(N²) per read.** For sources of more than a few thousand features the read time grows linearly with the squared row count. PostGIS's KNN operator (`<->`) could narrow this to O(N log N) once we provision a GIST index on each step's output. v1 accepts the cost; the recipe's `featureLimit` still caps the output. The generator's comment block calls this out.

## Out of scope (intentional)

- Reproject (mid-pipeline CRS plumbing).
- Where-clause filter (structured expression DSL design).
- Dissolve-with-groupBy (aggregation-operator design).
- Multi-input spatial joins (intersect, distance-to-nearest-in-another-layer, point-in-polygon assignment, spatial filter against a second layer). Recipe shape needs a second source slot.
- Summary statistics by attribute (lands with dissolve-with-groupBy).